### PR TITLE
Fix agent session updates and worktree launches

### DIFF
--- a/src/__tests__/integration/runtime-lifecycle.test.ts
+++ b/src/__tests__/integration/runtime-lifecycle.test.ts
@@ -20,8 +20,25 @@ import { tmpdir } from 'node:os'
 import { vi } from 'vitest'
 
 vi.mock('electron', () => ({
+  app: {
+    getPath: () => tmpdir(),
+    setBadgeCount: () => {}
+  },
   BrowserWindow: {
     getAllWindows: () => []
+  },
+  Notification: class {
+    show(): void {}
+    static isSupported(): boolean {
+      return false
+    }
+  }
+}))
+
+vi.mock('../../main/services/database', () => ({
+  database: {
+    getPreference: () => undefined,
+    setPreference: () => {}
   }
 }))
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -47,17 +47,6 @@ function mapToolState(toolState?: string): ToolCall['state'] {
   return 'running'
 }
 
-function buildToolCall(partId: string, toolName: string | undefined, toolState: string | undefined, text: string | undefined, timestamp: number): ToolCall {
-  return {
-    id: partId,
-    name: toolName ?? 'unknown',
-    state: mapToolState(toolState),
-    input: undefined,
-    output: text ?? undefined,
-    timestamp
-  }
-}
-
 export function App() {
   const [filter, setFilter] = useState<FilterValue>('all')
   const [searchQuery, setSearchQuery] = useState('')
@@ -101,7 +90,9 @@ export function App() {
       status: agent.status,
       model: agent.model,
       lastActivityAt: formatTimeAgo(agent.lastActivityAt),
-      blockedSince: agent.blockedSince ? formatTimeAgo(agent.blockedSince) : undefined
+      lastActivityAtMs: agent.lastActivityAt,
+      blockedSince: agent.blockedSince ? formatTimeAgo(agent.blockedSince) : undefined,
+      blockedSinceMs: agent.blockedSince
     }))
   }, [store.agents])
 
@@ -232,7 +223,14 @@ export function App() {
 
       const toolCalls = msg.parts
         .filter((part) => part.type === 'tool')
-        .map((part) => buildToolCall(part.id, part.toolName, part.toolState, part.text, msg.createdAt))
+        .map((part) => ({
+          id: part.id,
+          name: part.toolName ?? 'unknown',
+          state: mapToolState(part.toolState),
+          input: part.toolInput,
+          output: part.text ?? undefined,
+          timestamp: msg.createdAt
+        }))
 
       if (textContent.trim()) {
         flushPendingToolCalls(msg.id, msg.createdAt)
@@ -262,33 +260,13 @@ export function App() {
     return transcriptItems
   }, [freshSessionState, selectedAgent, store])
 
-  // ── Extract file changes from store messages ──
+  // ── File changes for selected agent ──
   const selectedFiles: FileChange[] = useMemo(() => {
     if (!selectedAgent) return []
     const liveAgent = store.agents.find((agent) => agent.id === selectedAgent.id)
     if (!liveAgent) return []
 
-    const liveMessages = store.getMessagesForSession(liveAgent.sessionId)
-    const files: FileChange[] = []
-    const seenPaths = new Set<string>()
-
-    for (const msg of liveMessages) {
-      for (const part of msg.parts) {
-        if (part.type === 'tool' && part.toolName === 'file.edited' && part.text) {
-          const filePath = part.text.trim()
-          if (filePath && !seenPaths.has(filePath)) {
-            seenPaths.add(filePath)
-            files.push({
-              path: filePath,
-              action: 'modified',
-              timestamp: msg.createdAt
-            })
-          }
-        }
-      }
-    }
-
-    return files
+    return store.getFileChangesForSession(liveAgent.sessionId)
   }, [selectedAgent, store])
 
   // ── Extract tool calls from store messages ──
@@ -303,38 +281,28 @@ export function App() {
     for (const msg of liveMessages) {
       for (const part of msg.parts) {
         if (part.type === 'tool') {
-          tools.push(buildToolCall(part.id, part.toolName, part.toolState, part.text, msg.createdAt))
+            tools.push({
+              id: part.id,
+              name: part.toolName ?? 'unknown',
+              state: mapToolState(part.toolState),
+              input: part.toolInput,
+              output: part.text ?? undefined,
+              timestamp: msg.createdAt
+            })
+          }
         }
       }
-    }
 
     return tools
   }, [selectedAgent, store])
 
-  // ── Events from store messages ──
+  // ── Events for selected agent ──
   const selectedEvents: EventEntry[] = useMemo(() => {
     if (!selectedAgent) return []
     const liveAgent = store.agents.find((agent) => agent.id === selectedAgent.id)
     if (!liveAgent) return []
 
-    const liveMessages = store.getMessagesForSession(liveAgent.sessionId)
-    const events: EventEntry[] = []
-
-    for (const msg of liveMessages) {
-      for (const part of msg.parts) {
-        if (part.type === 'step-start' || part.type === 'step-finish') {
-          events.push({
-            id: part.id,
-            type: part.type,
-            summary: part.text ?? part.type,
-            timestamp: msg.createdAt,
-            data: null
-          })
-        }
-      }
-    }
-
-    return events
+    return store.getEventsForSession(liveAgent.sessionId)
   }, [selectedAgent, store])
 
   // ── Permission for selected agent ──
@@ -521,9 +489,36 @@ export function App() {
     prompt?: string,
     title?: string,
     _model?: string,
-    _worktreeStrategy?: string
+    worktreeStrategy?: string
   ) => {
-    const result = await store.launchAgent(directory, prompt || undefined, title)
+    let launchDirectory = directory
+
+    if (worktreeStrategy === 'new-worktree') {
+      const repoRootResult = await window.api.getRepoRoot(directory)
+      if (!repoRootResult.ok || !repoRootResult.data) {
+        console.error('Failed to resolve repo root for launch:', repoRootResult.error)
+        return
+      }
+
+      const directoryParts = directory.replace(/\/$/, '').split('/').filter(Boolean)
+      const projectSlug = sanitizeSlugSegment(directoryParts[directoryParts.length - 1] ?? 'project', 'project')
+      const taskSource = title?.trim() || prompt?.trim() || 'agent'
+      const taskSlug = sanitizeSlugSegment(taskSource, 'agent')
+      const worktreeResult = await window.api.createWorktree({
+        repoRoot: repoRootResult.data,
+        projectSlug,
+        taskSlug
+      })
+
+      if (!worktreeResult.ok || !worktreeResult.data) {
+        console.error('Failed to create worktree for launch:', worktreeResult.error)
+        return
+      }
+
+      launchDirectory = worktreeResult.data.worktreePath
+    }
+
+    const result = await store.launchAgent(launchDirectory, prompt || undefined, title)
 
     // Auto-open the detail drawer for the newly launched agent
     // (especially useful when no prompt is given so the user can interact immediately)
@@ -782,6 +777,7 @@ export function App() {
 }
 
 function formatTimeAgo(timestamp: number): string {
+  if (!Number.isFinite(timestamp)) return 'just now'
   const seconds = Math.floor((Date.now() - timestamp) / 1000)
   if (seconds < 5) return 'just now'
   if (seconds < 60) return `${seconds}s ago`

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -70,8 +70,11 @@ export function DetailDrawer({
   const [inputText, setInputText] = useState('')
   const [activeTab, setActiveTab] = useState<TabKey>('transcript')
   const [isVisible, setIsVisible] = useState(false)
+  const [showJumpToLatest, setShowJumpToLatest] = useState(false)
+  const transcriptScrollRef = useRef<HTMLDivElement>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const overlayRef = useRef<HTMLDivElement>(null)
+  const shouldAutoScrollRef = useRef(true)
 
   const matchingCommands = inputText.startsWith('/')
     ? CHAT_COMMANDS.filter(({ command }) => command.startsWith(inputText.trim().toLowerCase()))
@@ -87,10 +90,30 @@ export function DetailDrawer({
 
   // Auto-scroll to bottom when new messages arrive
   useEffect(() => {
-    if (activeTab === 'transcript' && messagesEndRef.current) {
+    if (activeTab === 'transcript' && messagesEndRef.current && shouldAutoScrollRef.current) {
+      setShowJumpToLatest(false)
       messagesEndRef.current.scrollIntoView({ behavior: 'smooth' })
+    } else if (activeTab === 'transcript' && messages.length > 0) {
+      setShowJumpToLatest(true)
     }
   }, [messages, activeTab])
+
+  const handleTranscriptScroll = () => {
+    const container = transcriptScrollRef.current
+    if (!container) return
+
+    const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight
+    shouldAutoScrollRef.current = distanceFromBottom < 48
+    if (shouldAutoScrollRef.current) {
+      setShowJumpToLatest(false)
+    }
+  }
+
+  const handleJumpToLatest = () => {
+    shouldAutoScrollRef.current = true
+    setShowJumpToLatest(false)
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }
 
   const handleSend = () => {
     if (!inputText.trim() || !onSendMessage) return
@@ -164,9 +187,9 @@ export function DetailDrawer({
           <div className="flex items-center gap-2">
             <div className="text-right mr-2">
               <div className="text-[10px] text-kumo-subtle font-mono">{agent.model}</div>
-              {agent.lastActivityAt && (
+              {agent.lastActivityAtMs && (
                 <div className="text-[10px] text-kumo-subtle font-mono">
-                  {formatRelativeTime(new Date(agent.lastActivityAt).getTime())}
+                  {formatRelativeTime(agent.lastActivityAtMs)}
                 </div>
               )}
             </div>
@@ -188,7 +211,11 @@ export function DetailDrawer({
         </div>
 
         {/* Tab Content */}
-        <div className="flex-1 overflow-y-auto px-4 py-3 flex flex-col gap-2">
+        <div
+          ref={transcriptScrollRef}
+          onScroll={activeTab === 'transcript' ? handleTranscriptScroll : undefined}
+          className="flex-1 overflow-y-auto px-4 py-3 flex flex-col gap-2"
+        >
           {activeTab === 'transcript' && (
             <>
               {messages.length === 0 ? (
@@ -255,6 +282,19 @@ export function DetailDrawer({
                       </button>
                     )}
                   </div>
+                </div>
+              )}
+
+              {showJumpToLatest && activeTab === 'transcript' && (
+                <div className="sticky bottom-2 z-10 flex justify-center">
+                  <button
+                    type="button"
+                    onClick={handleJumpToLatest}
+                    className="inline-flex items-center gap-1.5 rounded-full border border-kumo-interact/30 bg-kumo-interact/12 px-3 py-1.5 text-[11px] font-medium text-kumo-link shadow-lg backdrop-blur hover:bg-kumo-interact/18 transition-colors"
+                  >
+                    <CaretDown size={12} />
+                    Jump to latest
+                  </button>
                 </div>
               )}
 
@@ -483,6 +523,7 @@ function ActionButton({
 }
 
 function formatRelativeTime(timestamp: number): string {
+  if (!Number.isFinite(timestamp)) return 'just now'
   const seconds = Math.floor((Date.now() - timestamp) / 1000)
   if (seconds < 60) return `${seconds}s ago`
   const minutes = Math.floor(seconds / 60)

--- a/src/renderer/src/components/FilesChanged.tsx
+++ b/src/renderer/src/components/FilesChanged.tsx
@@ -50,7 +50,17 @@ function extractFilename(filePath: string): string {
 }
 
 export function FilesChanged({ files }: FilesChangedProps) {
-  if (files.length === 0) {
+  const latestByPath = new Map<string, FileChange>()
+  for (const file of files) {
+    const existingFile = latestByPath.get(file.path)
+    if (!existingFile || existingFile.timestamp < file.timestamp) {
+      latestByPath.set(file.path, file)
+    }
+  }
+
+  const dedupedFiles = Array.from(latestByPath.values())
+
+  if (dedupedFiles.length === 0) {
     return (
       <div className="flex-1 flex flex-col items-center justify-center gap-2 text-kumo-subtle py-12">
         <File size={28} weight="duotone" />
@@ -59,12 +69,12 @@ export function FilesChanged({ files }: FilesChangedProps) {
     )
   }
 
-  const sorted = [...files].sort((fileA, fileB) => fileB.timestamp - fileA.timestamp)
+  const sorted = dedupedFiles.sort((fileA, fileB) => fileB.timestamp - fileA.timestamp)
 
   return (
     <div className="flex flex-col gap-1 py-2">
       <div className="text-[11px] text-kumo-subtle px-1 pb-1">
-        {files.length} file{files.length !== 1 ? 's' : ''} changed
+        {dedupedFiles.length} file{dedupedFiles.length !== 1 ? 's' : ''} changed
       </div>
       {sorted.map((file, index) => (
         <div

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -32,6 +32,7 @@ interface HistoricalMessagePart {
     error?: string
     title?: string
     raw?: string
+    input?: unknown
   }
   reason?: string
   snapshot?: string
@@ -89,6 +90,7 @@ export interface LiveMessagePart {
   text?: string
   toolName?: string
   toolState?: string
+  toolInput?: string
 }
 
 export interface FileChangeRecord {
@@ -245,6 +247,7 @@ function resolveSessionIdForEvent(
   // Try nested info object (message events)
   const info = props.info as Record<string, unknown> | undefined
   if (info?.sessionID) return info.sessionID as string
+  if (info?.id) return info.id as string
 
   // Try nested part object (message part events)
   const part = props.part as Record<string, unknown> | undefined
@@ -263,6 +266,50 @@ function trackFileChange(sessionId: string, filePath: string, action: FileChange
     timestamp: Date.now()
   })
   state.fileChanges.set(sessionId, changes)
+}
+
+function getMessageCreatedAt(info: Record<string, unknown> | HistoricalMessageInfo): number {
+  const time = info.time as { created?: number } | undefined
+  return typeof time?.created === 'number' ? time.created : Date.now()
+}
+
+function getToolState(partState: Record<string, unknown> | undefined): string | undefined {
+  const status = partState?.status
+  return typeof status === 'string' ? status : undefined
+}
+
+function stringifyToolInput(input: unknown): string | undefined {
+  if (input === undefined) return undefined
+  try {
+    return JSON.stringify(input, null, 2)
+  } catch {
+    return String(input)
+  }
+}
+
+function getToolOutput(part: Record<string, unknown>, partState: Record<string, unknown> | undefined): string | undefined {
+  const text = part.text
+  if (typeof text === 'string' && text.trim()) return text
+
+  const output = partState?.output
+  if (typeof output === 'string' && output.trim()) return output
+
+  const error = partState?.error
+  if (typeof error === 'string' && error.trim()) return error
+
+  const title = partState?.title
+  if (typeof title === 'string' && title.trim()) return title
+
+  const raw = partState?.raw
+  if (typeof raw === 'string' && raw.trim()) return raw
+
+  return undefined
+}
+
+function inferFileAction(before: string | undefined, after: string | undefined): FileChangeRecord['action'] {
+  if (!before && after) return 'created'
+  if (before && !after) return 'deleted'
+  return 'modified'
 }
 
 function upsertMessage(message: LiveMessage): LiveMessage {
@@ -304,6 +351,7 @@ function mapHistoricalPart(part: HistoricalMessagePart): LiveMessagePart {
   if (part.type === 'tool') {
     nextPart.toolName = part.tool
     nextPart.toolState = part.state?.status
+    nextPart.toolInput = stringifyToolInput(part.state?.input)
     nextPart.text = part.text ?? part.state?.output ?? part.state?.error ?? part.state?.title ?? part.state?.raw
   }
 
@@ -316,7 +364,7 @@ function hydrateHistoricalMessages(entries: unknown): void {
   for (const entry of entries as HistoricalSessionMessage[]) {
     if (!entry?.info?.id || !entry.info.sessionID || !Array.isArray(entry.parts)) continue
 
-    const createdAt = entry.info.time?.created ?? Date.now()
+    const createdAt = getMessageCreatedAt(entry.info)
     const message = upsertMessage({
       id: entry.info.id,
       role: entry.info.role,
@@ -424,18 +472,16 @@ function processEvent(payload: OpenCodeEventPayload): void {
     }
 
     case 'session.updated': {
-      const sessionId = props.sessionID as string
+      const info = props.info as Record<string, unknown> | undefined
+      const sessionId = info?.id as string | undefined
+      if (!sessionId) break
       const agent = findAgentBySession(sessionId)
       if (agent) {
-        agent.lastActivityAt = Date.now()
-        // Update any session metadata that may have changed
-        const title = props.title as string | undefined
+        const time = info?.time as { updated?: number } | undefined
+        agent.lastActivityAt = typeof time?.updated === 'number' ? time.updated : Date.now()
+        const title = info?.title as string | undefined
         if (title) {
           agent.taskSummary = title.slice(0, 120)
-        }
-        const branch = props.branch as string | undefined
-        if (branch) {
-          agent.branchName = branch
         }
         emit()
       }
@@ -447,6 +493,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
       const sessionId = info.sessionID as string
       const messageId = info.id as string
       const role = info.role as 'user' | 'assistant'
+      const createdAt = getMessageCreatedAt(info)
 
       const agent = findAgentBySession(sessionId)
       if (agent) {
@@ -475,10 +522,13 @@ function processEvent(payload: OpenCodeEventPayload): void {
           id: messageId,
           role,
           sessionId,
-          createdAt: Date.now(),
+          createdAt,
           parts: []
         })
         state.messages.set(sessionId, messages)
+      } else {
+        existing.createdAt = createdAt
+        existing.role = role
       }
 
       emit()
@@ -497,22 +547,23 @@ function processEvent(payload: OpenCodeEventPayload): void {
 
       if (message) {
         const existingPart = message.parts.find((partItem) => partItem.id === partId)
+        const toolState = part.state as Record<string, unknown> | undefined
         if (existingPart) {
-          existingPart.text = part.text as string | undefined
+          existingPart.text = getToolOutput(part, toolState) ?? part.text as string | undefined
           if (partType === 'tool') {
-            const toolState = part.state as Record<string, unknown> | undefined
-            existingPart.toolState = toolState?.type as string | undefined
+            existingPart.toolState = getToolState(toolState)
+            existingPart.toolInput = stringifyToolInput(toolState?.input)
           }
         } else {
           const newPart: LiveMessagePart = {
             id: partId,
             type: partType,
-            text: part.text as string | undefined
+            text: getToolOutput(part, toolState) ?? part.text as string | undefined
           }
           if (partType === 'tool') {
             newPart.toolName = part.tool as string | undefined
-            const toolState = part.state as Record<string, unknown> | undefined
-            newPart.toolState = toolState?.type as string | undefined
+            newPart.toolState = getToolState(toolState)
+            newPart.toolInput = stringifyToolInput(toolState?.input)
           }
           message.parts.push(newPart)
         }
@@ -588,6 +639,26 @@ function processEvent(payload: OpenCodeEventPayload): void {
       break
     }
 
+    case 'session.diff': {
+      const sessionId = props.sessionID as string
+      const diffs = props.diff as Array<Record<string, unknown>> | undefined
+      const agent = findAgentBySession(sessionId)
+      if (agent && Array.isArray(diffs)) {
+        agent.lastActivityAt = Date.now()
+        for (const diff of diffs) {
+          const filePath = diff.file as string | undefined
+          if (!filePath) continue
+          trackFileChange(
+            sessionId,
+            filePath,
+            inferFileAction(diff.before as string | undefined, diff.after as string | undefined)
+          )
+        }
+        emit()
+      }
+      break
+    }
+
     case 'file.edited': {
       // Track file activity and record the change
       const agent = findAgentByRuntime(runtimeId)
@@ -597,6 +668,38 @@ function processEvent(payload: OpenCodeEventPayload): void {
         trackFileChange(agent.sessionId, filePath, 'modified')
         emit()
       }
+      break
+    }
+
+    case 'file.watcher.updated': {
+      const agent = findAgentByRuntime(runtimeId)
+      if (agent) {
+        agent.lastActivityAt = Date.now()
+        const filePath = props.file as string | undefined
+        const eventName = props.event as string | undefined
+        if (filePath) {
+          const action = eventName === 'add'
+            ? 'created'
+            : eventName === 'unlink'
+              ? 'deleted'
+              : 'modified'
+          trackFileChange(agent.sessionId, filePath, action)
+        }
+        emit()
+      }
+      break
+    }
+
+    case 'vcs.branch.updated': {
+      const branch = props.branch as string | undefined
+      if (!branch) break
+      for (const agent of state.agents.values()) {
+        if (agent.runtimeId === runtimeId) {
+          agent.branchName = branch
+          agent.lastActivityAt = Date.now()
+        }
+      }
+      emit()
       break
     }
 

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -38,7 +38,9 @@ export interface AgentRuntime {
   status: AgentStatus
   model: string
   lastActivityAt: string
+  lastActivityAtMs: number
   blockedSince?: string
+  blockedSinceMs?: number
 }
 
 export interface Interrupt {


### PR DESCRIPTION
Make new-worktree launches start inside the created worktree, improve drawer session rendering for tools, files, timestamps, and scrolling, and stabilize the skipped integration test setup so local test runs pass.