### PR TITLE
Manage idle runtimes and launch ports

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -61,6 +61,7 @@ app.whenReady().then(async () => {
 
   // Start runtime health checks after window creation
   runtimeManager.startHealthChecks()
+  agentController.startIdleRuntimeChecks()
   console.log('[Main] Health checks started')
 
   app.on('activate', () => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -125,7 +125,7 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle('runtime:stop', async (_event, runtimeId: string) => {
     try {
-      runtimeManager.stopRuntime(runtimeId)
+      await agentController.stopRuntime(runtimeId)
       return { ok: true }
     } catch (error) {
       return { ok: false, error: String(error) }

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -29,6 +29,8 @@ interface PersistedAgentHandle {
 }
 
 const ACTIVE_AGENTS_PREFERENCE_KEY = 'active_agents'
+const IDLE_RUNTIME_CHECK_INTERVAL_MS = 60_000
+const DEFAULT_RUNTIME_IDLE_TIMEOUT_MS = 15 * 60_000
 
 /**
  * High-level controller for managing individual agent instances.
@@ -38,6 +40,7 @@ class AgentController {
   private agents = new Map<string, AgentHandle>()
   private bridges = new Map<string, EventBridge>()
   private nextId = 1
+  private idleRuntimeTimer: ReturnType<typeof setInterval> | null = null
 
   async restorePersistedAgents(): Promise<void> {
     const persistedAgents = this.loadPersistedAgents()
@@ -87,6 +90,7 @@ class AgentController {
     const runtime = await this.ensureBridgeForDirectory(directory)
     const client = runtime.client
     const directoryContext = workspaceManager.getDirectoryContext(directory)
+    runtimeManager.touchRuntimeActivity(runtime.id)
 
     // Derive a session title
     const projectSlug = directory.split('/').pop() ?? 'project'
@@ -159,8 +163,8 @@ class AgentController {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
 
-    const runtime = runtimeManager.getRuntime(handle.runtimeId)
-    if (!runtime) throw new Error(`Runtime ${handle.runtimeId} not found`)
+    const runtime = await this.ensureRuntimeForAgent(handle)
+    runtimeManager.touchRuntimeActivity(runtime.id)
 
     await runtime.client.session.promptAsync({
       headers: { 'x-opencode-directory': handle.directory },
@@ -178,8 +182,8 @@ class AgentController {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
 
-    const runtime = runtimeManager.getRuntime(handle.runtimeId)
-    if (!runtime) throw new Error(`Runtime ${handle.runtimeId} not found`)
+    const runtime = await this.ensureRuntimeForAgent(handle)
+    runtimeManager.touchRuntimeActivity(runtime.id)
 
     await runtime.client.postSessionIdPermissionsPermissionId({
       headers: { 'x-opencode-directory': handle.directory },
@@ -198,8 +202,8 @@ class AgentController {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
 
-    const runtime = runtimeManager.getRuntime(handle.runtimeId)
-    if (!runtime) throw new Error(`Runtime ${handle.runtimeId} not found`)
+    const runtime = await this.ensureRuntimeForAgent(handle)
+    runtimeManager.touchRuntimeActivity(runtime.id)
 
     await runtime.client.session.abort({
       headers: { 'x-opencode-directory': handle.directory },
@@ -214,8 +218,8 @@ class AgentController {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
 
-    const runtime = runtimeManager.getRuntime(handle.runtimeId)
-    if (!runtime) throw new Error(`Runtime ${handle.runtimeId} not found`)
+    const runtime = await this.ensureRuntimeForAgent(handle)
+    runtimeManager.touchRuntimeActivity(runtime.id)
 
     const result = await runtime.client.session.messages({
       headers: { 'x-opencode-directory': handle.directory },
@@ -296,10 +300,23 @@ class AgentController {
     this.persistAgents()
   }
 
+  startIdleRuntimeChecks(): void {
+    if (this.idleRuntimeTimer) return
+
+    this.idleRuntimeTimer = setInterval(() => {
+      void this.stopIdleRuntimes()
+    }, IDLE_RUNTIME_CHECK_INTERVAL_MS)
+  }
+
   /**
    * Stop all agents and bridges.
    */
   stopAll(): void {
+    if (this.idleRuntimeTimer) {
+      clearInterval(this.idleRuntimeTimer)
+      this.idleRuntimeTimer = null
+    }
+
     for (const bridge of this.bridges.values()) {
       bridge.stop()
     }
@@ -346,6 +363,61 @@ class AgentController {
     }
 
     return runtime
+  }
+
+  private async ensureRuntimeForAgent(handle: AgentHandle): Promise<RuntimeInfo> {
+    const existingRuntime = runtimeManager.getRuntime(handle.runtimeId)
+    if (existingRuntime) return existingRuntime
+
+    const runtime = await this.ensureBridgeForDirectory(handle.directory)
+    handle.runtimeId = runtime.id
+    handle.bridge = this.bridges.get(runtime.id)!
+
+    this.broadcastToRenderer('agent:launched', {
+      id: handle.id,
+      runtimeId: handle.runtimeId,
+      sessionId: handle.sessionId,
+      directory: handle.directory,
+      projectName: handle.projectName,
+      branchName: handle.branchName,
+      isWorktree: handle.isWorktree,
+      workspaceName: handle.workspaceName,
+      prompt: handle.prompt,
+      title: handle.title
+    })
+
+    return runtime
+  }
+
+  private async stopIdleRuntimes(): Promise<void> {
+    const idleTimeoutMs = Number.parseInt(
+      process.env.OC_ORCHESTRATOR_RUNTIME_IDLE_TIMEOUT_MS ?? `${DEFAULT_RUNTIME_IDLE_TIMEOUT_MS}`,
+      10
+    )
+
+    if (!Number.isFinite(idleTimeoutMs) || idleTimeoutMs <= 0) return
+
+    const now = Date.now()
+
+    for (const runtime of runtimeManager.getAllRuntimes()) {
+      const idleForMs = now - runtime.lastActivityAt
+      if (idleForMs < idleTimeoutMs) continue
+
+      console.log(
+        `[AgentController] Stopping idle runtime ${runtime.id} after ${Math.round(idleForMs / 1000)}s of inactivity`
+      )
+      await this.stopRuntime(runtime.id)
+    }
+  }
+
+  async stopRuntime(runtimeId: string): Promise<void> {
+    const bridge = this.bridges.get(runtimeId)
+    if (bridge) {
+      bridge.stop()
+      this.bridges.delete(runtimeId)
+    }
+
+    await runtimeManager.stopRuntime(runtimeId)
   }
 
   private loadPersistedAgents(): PersistedAgentHandle[] {

--- a/src/main/services/event-bridge.ts
+++ b/src/main/services/event-bridge.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow } from 'electron'
 import type { OpencodeClient } from '@opencode-ai/sdk/client'
+import { runtimeManager } from './runtime-manager'
 
 const INITIAL_BACKOFF_MS = 1_000
 const MAX_BACKOFF_MS = 30_000
@@ -138,6 +139,10 @@ export class EventBridge {
   }
 
   private forwardEvent(event: { type: string; properties: unknown }): void {
+    if (event.type !== 'server.heartbeat') {
+      runtimeManager.touchRuntimeActivity(this.runtimeId)
+    }
+
     // Forward all events to the renderer, tagged with the runtime ID
     this.broadcastToRenderer('opencode:event', {
       runtimeId: this.runtimeId,

--- a/src/main/services/runtime-manager.ts
+++ b/src/main/services/runtime-manager.ts
@@ -1,6 +1,7 @@
 import { createOpencodeServer } from '@opencode-ai/sdk/server'
 import { createOpencodeClient, type OpencodeClient } from '@opencode-ai/sdk/client'
 import { BrowserWindow } from 'electron'
+import { createServer } from 'node:net'
 
 export interface RuntimeInfo {
   id: string
@@ -9,6 +10,7 @@ export interface RuntimeInfo {
   client: OpencodeClient
   close: () => void
   startedAt: number
+  lastActivityAt: number
   activeSessions: number
   healthy: boolean
 }
@@ -37,7 +39,10 @@ class RuntimeManager {
 
     console.log(`[RuntimeManager] Starting server for ${directory}`)
 
+    const port = await this.getAvailablePort()
+
     const server = await createOpencodeServer({
+      port,
       timeout: 15000
     })
 
@@ -54,6 +59,7 @@ class RuntimeManager {
       client,
       close: server.close,
       startedAt: Date.now(),
+      lastActivityAt: Date.now(),
       activeSessions: 0,
       healthy: true
     }
@@ -174,6 +180,13 @@ class RuntimeManager {
     const runtime = this.runtimes.get(runtimeId)
     if (!runtime) return
     runtime.activeSessions = Math.max(0, runtime.activeSessions + delta)
+    runtime.lastActivityAt = Date.now()
+  }
+
+  touchRuntimeActivity(runtimeId: string): void {
+    const runtime = this.runtimes.get(runtimeId)
+    if (!runtime) return
+    runtime.lastActivityAt = Date.now()
   }
 
   /**
@@ -256,6 +269,34 @@ class RuntimeManager {
 
   getAllRuntimes(): RuntimeInfo[] {
     return Array.from(this.runtimes.values())
+  }
+
+  private async getAvailablePort(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const probeServer = createServer()
+
+      probeServer.once('error', (error) => {
+        reject(error)
+      })
+
+      probeServer.listen(0, '127.0.0.1', () => {
+        const address = probeServer.address()
+        if (!address || typeof address === 'string') {
+          probeServer.close(() => reject(new Error('Failed to resolve an available port')))
+          return
+        }
+
+        const { port } = address
+        probeServer.close((error) => {
+          if (error) {
+            reject(error)
+            return
+          }
+
+          resolve(port)
+        })
+      })
+    })
   }
 
   private broadcastToRenderer(channel: string, data: unknown): void {


### PR DESCRIPTION
Assign a unique port to each OpenCode runtime, shut down idle runtimes after a configurable timeout, and recreate stopped runtimes on demand when an agent becomes active again.