### PR TITLE
Add agent removal and worktree cleanup

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -70,6 +70,16 @@ export function registerIpcHandlers(): void {
     }
   })
 
+  ipcMain.handle('agent:remove', async (_event, agentId: string) => {
+    try {
+      await agentController.removeAgent(agentId)
+      return { ok: true }
+    } catch (error) {
+      console.error('[IPC] agent:remove failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
   ipcMain.handle('agent:get-messages', async (_event, agentId: string) => {
     try {
       const messages = await agentController.getMessages(agentId)

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -293,9 +293,25 @@ class AgentController {
   }
 
   /**
-   * Remove an agent without aborting it.
+   * Remove an agent from orchestration and clean up its worktree when possible.
    */
-  removeAgent(agentId: string): void {
+  async removeAgent(agentId: string): Promise<void> {
+    const handle = this.agents.get(agentId)
+    if (!handle) throw new Error(`Agent ${agentId} not found`)
+
+    const otherAgents = Array.from(this.agents.values()).filter((agent) => agent.id !== agentId)
+    const hasRuntimePeers = otherAgents.some((agent) => agent.runtimeId === handle.runtimeId)
+    const hasDirectoryPeers = otherAgents.some((agent) => agent.directory === handle.directory)
+
+    if (!hasRuntimePeers) {
+      await this.stopRuntime(handle.runtimeId)
+    }
+
+    if (handle.isWorktree && !hasDirectoryPeers) {
+      const repoRoot = workspaceManager.getCommonRepoRoot(handle.directory)
+      workspaceManager.removeWorktree(repoRoot, handle.directory)
+    }
+
     this.agents.delete(agentId)
     this.persistAgents()
   }

--- a/src/main/services/workspace-manager.ts
+++ b/src/main/services/workspace-manager.ts
@@ -237,6 +237,22 @@ class WorkspaceManager {
     }
   }
 
+  getCommonRepoRoot(directory: string): string {
+    try {
+      const gitCommonDir = execSync('git rev-parse --path-format=absolute --git-common-dir', {
+        cwd: directory,
+        encoding: 'utf-8',
+        stdio: 'pipe'
+      }).trim()
+
+      return path.dirname(gitCommonDir)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      console.error(`[WorkspaceManager] Failed to get common repo root: ${message}`)
+      throw new Error(`Failed to get common repo root: ${message}`)
+    }
+  }
+
   /**
    * Gets the current branch name for a directory.
    */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -20,6 +20,9 @@ const api = {
   abortAgent: (agentId: string): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:abort', agentId),
 
+  removeAgent: (agentId: string): Promise<IpcResult> =>
+    ipcRenderer.invoke('agent:remove', agentId),
+
   getMessages: (agentId: string): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:get-messages', agentId),
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -374,6 +374,39 @@ export function App() {
     setSelectedAgentId(agentId)
   }, [])
 
+  const handleRemoveAgent = useCallback(async (agentId: string) => {
+    const liveAgent = findLiveAgent(agentId)
+    if (!liveAgent) return
+
+    const confirmMessage = liveAgent.isWorktree
+      ? `Remove ${liveAgent.name}? This will clean up the worktree and remove the agent from the UI.`
+      : `Remove ${liveAgent.name} from the UI?`
+
+    if (!window.confirm(confirmMessage)) return
+
+    const result = await store.removeAgent(agentId)
+    if (!result?.ok) return
+
+    setSelectedIds((previousIds) => {
+      if (!previousIds.has(agentId)) return previousIds
+      const nextIds = new Set(previousIds)
+      nextIds.delete(agentId)
+      return nextIds
+    })
+
+    if (selectedAgentId === agentId) {
+      setSelectedAgentId(null)
+    }
+
+    setFreshSessionState((previousState) => {
+      if (!previousState) return previousState
+      if (previousState.sourceAgentId === agentId || previousState.nextAgentId === agentId) {
+        return null
+      }
+      return previousState
+    })
+  }, [findLiveAgent, selectedAgentId, store])
+
   // ── Bulk actions ──
   const handleBulkStop = useCallback(async () => {
     const promises = Array.from(selectedIds).map((agentId) => store.abortAgent(agentId))
@@ -694,6 +727,7 @@ export function App() {
         onReply={handleRowReply}
         onStop={handleRowStop}
         onOpen={handleRowOpen}
+        onRemove={handleRemoveAgent}
       />
 
       <StatusBar
@@ -725,6 +759,7 @@ export function App() {
           onApprove={selectedPermission ? () => handleApprove(selectedPermission.id) : undefined}
           onDeny={selectedPermission ? () => handleDeny(selectedPermission.id) : undefined}
           onAbort={handleAbort}
+          onRemove={() => void handleRemoveAgent(selectedAgent.id)}
           onCreatePr={handleCreatePr}
           onOpenInEditor={handleOpenInEditor}
         />

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -10,7 +10,8 @@ import {
   Wrench,
   CircleNotch,
   CaretDown,
-  CaretRight
+  CaretRight,
+  Trash
 } from '@phosphor-icons/react'
 import type { AgentRuntime, Message } from '../types'
 import { formatBranchLabel } from '../types'
@@ -47,6 +48,7 @@ interface DetailDrawerProps {
   onApprove?: () => void
   onDeny?: () => void
   onAbort?: () => void
+  onRemove?: () => void
   onCreatePr?: () => void
   onOpenInEditor?: () => void
 }
@@ -64,6 +66,7 @@ export function DetailDrawer({
   onApprove,
   onDeny,
   onAbort,
+  onRemove,
   onCreatePr,
   onOpenInEditor
 }: DetailDrawerProps) {
@@ -321,6 +324,9 @@ export function DetailDrawer({
           <div className="flex-1" />
           {onCreatePr && (
             <ActionButton icon={<GitPullRequest size={12} />} label="Create PR" onClick={onCreatePr} />
+          )}
+          {onRemove && (
+            <ActionButton icon={<Trash size={12} />} label="Remove" variant="deny" onClick={onRemove} />
           )}
           <ActionButton icon={<Terminal size={12} />} label="Open Terminal" />
           <ActionButton icon={<ArrowSquareOut size={12} />} label="Open in Editor" onClick={onOpenInEditor} />

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -9,7 +9,8 @@ import {
   Square,
   Robot,
   Stop,
-  CheckCircle
+  CheckCircle,
+  Trash
 } from '@phosphor-icons/react'
 import type { AgentRuntime } from '../types'
 import { formatBranchLabel, isUrgent } from '../types'
@@ -26,6 +27,7 @@ interface FleetTableProps {
   onReply?: (agentId: string) => void
   onStop?: (agentId: string) => void
   onOpen?: (agentId: string) => void
+  onRemove?: (agentId: string) => void
 }
 
 type SortColumn = 'agent' | 'status' | 'task' | 'branch' | 'model' | 'activity'
@@ -50,7 +52,8 @@ export function FleetTable({
   onApprove,
   onReply,
   onStop,
-  onOpen
+  onOpen,
+  onRemove
 }: FleetTableProps) {
   const [sortColumn, setSortColumn] = useState<SortColumn | null>(null)
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
@@ -226,6 +229,7 @@ export function FleetTable({
               onReply={onReply ? () => onReply(agent.id) : undefined}
               onStop={onStop ? () => onStop(agent.id) : undefined}
               onOpen={onOpen ? () => onOpen(agent.id) : () => onSelect(agent.id)}
+              onRemove={onRemove ? () => onRemove(agent.id) : undefined}
             />
           ))}
         </tbody>
@@ -243,7 +247,8 @@ function AgentRow({
   onApprove,
   onReply,
   onStop,
-  onOpen
+  onOpen,
+  onRemove
 }: {
   agent: AgentRuntime
   selected: boolean
@@ -254,6 +259,7 @@ function AgentRow({
   onReply?: () => void
   onStop?: () => void
   onOpen?: () => void
+  onRemove?: () => void
 }) {
   const urgent = isUrgent(agent)
   const isStale = !!agent.blockedSince
@@ -322,15 +328,18 @@ function RowActions({
   onApprove,
   onReply,
   onStop,
-  onOpen
+  onOpen,
+  onRemove
 }: {
   agent: AgentRuntime
   onApprove?: () => void
   onReply?: () => void
   onStop?: () => void
   onOpen?: () => void
+  onRemove?: () => void
 }) {
   const buttonBase = 'w-6 h-6 flex items-center justify-center bg-kumo-fill border border-kumo-line rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors'
+  const destructiveButton = 'w-6 h-6 flex items-center justify-center bg-kumo-danger/10 border border-kumo-danger/20 rounded text-kumo-danger hover:bg-kumo-danger/20 transition-colors'
 
   return (
     <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -377,6 +386,13 @@ function RowActions({
           <Square size={12} weight="fill" />
         </button>
       )}
+      <button
+        className={destructiveButton}
+        title="Remove"
+        onClick={(event) => { event.stopPropagation(); onRemove?.() }}
+      >
+        <Trash size={12} />
+      </button>
     </div>
   )
 }

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -745,6 +745,22 @@ function handleAgentLaunched(payload: AgentLaunchedPayload): void {
   emit()
 }
 
+function removeAgentState(agentId: string): void {
+  const agent = state.agents.get(agentId)
+  if (!agent) return
+
+  state.agents.delete(agentId)
+  state.messages.delete(agent.sessionId)
+  state.fileChanges.delete(agent.sessionId)
+  state.eventLog.delete(agent.sessionId)
+
+  for (const [permissionId, permission] of state.permissions.entries()) {
+    if (permission.agentId === agentId || permission.sessionId === agent.sessionId) {
+      state.permissions.delete(permissionId)
+    }
+  }
+}
+
 function upsertAgent(payload: AgentLaunchedPayload, initialStatus?: AgentStatus): void {
   const hasPrompt = payload.prompt && payload.prompt.trim().length > 0
   const existingAgent = state.agents.get(payload.id)
@@ -1012,6 +1028,19 @@ export function useAgentStore() {
     return window.api.abortAgent(agentId)
   }, [])
 
+  const removeAgent = useCallback(async (agentId: string) => {
+    if (!window.api) return
+    const result = await window.api.removeAgent(agentId)
+    if (!result.ok) {
+      console.error('Failed to remove agent:', result.error)
+      return result
+    }
+
+    removeAgentState(agentId)
+    emit()
+    return result
+  }, [])
+
   const selectDirectory = useCallback(async () => {
     if (!window.api) return null
     const result = await window.api.selectDirectory()
@@ -1045,6 +1074,7 @@ export function useAgentStore() {
     prepareFreshAgent,
     respondToPermission,
     abortAgent,
+    removeAgent,
     selectDirectory,
     getMessagesForSession,
     getFileChangesForSession,

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -9,6 +9,7 @@ export interface OrchestratorApi {
   sendMessage: (agentId: string, text: string) => Promise<IpcResult>
   respondToPermission: (agentId: string, permissionId: string, response: 'once' | 'always' | 'reject') => Promise<IpcResult>
   abortAgent: (agentId: string) => Promise<IpcResult>
+  removeAgent: (agentId: string) => Promise<IpcResult>
   getMessages: (agentId: string) => Promise<IpcResult>
   listAgents: () => Promise<IpcResult<ListAgentsPayload>>
   getStatuses: () => Promise<IpcResult<AgentStatusesPayload>>


### PR DESCRIPTION
Let users remove agents from the fleet and detail views, clear their local UI state, and clean up the backing worktree when the removed agent was the last one using it.