### PR TITLE
Simplify sql.js query helpers

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-// In dev, run electron-builder install-app-deps to set up native modules.
-// For global npm installs, skip gracefully (no native modules to rebuild).
+// Set up Electron app dependencies when available; skip cleanly for global installs.
 
 const { execSync } = require('child_process')
 

--- a/src/__tests__/database.test.ts
+++ b/src/__tests__/database.test.ts
@@ -20,6 +20,18 @@ interface EventRecord {
 
 // ── Minimal test database matching the production Database API ──
 
+function readCurrentRow<T>(statement: ReturnType<SqlJsDatabase['prepare']>): T {
+  const columns = statement.getColumnNames()
+  const values = statement.get()
+  const row = {} as Record<string, unknown>
+
+  for (let idx = 0; idx < columns.length; idx++) {
+    row[columns[idx]] = values[idx]
+  }
+
+  return row as T
+}
+
 class TestDatabase {
   private db: SqlJsDatabase
 
@@ -57,36 +69,29 @@ class TestDatabase {
   }
 
   private queryOne<T>(sql: string, params: unknown[] = []): T | undefined {
-    const stmt = this.db.prepare(sql)
-    stmt.bind(params)
-    if (stmt.step()) {
-      const columns = stmt.getColumnNames()
-      const values = stmt.get()
-      stmt.free()
-      const row = {} as Record<string, unknown>
-      for (let idx = 0; idx < columns.length; idx++) {
-        row[columns[idx]] = values[idx]
-      }
-      return row as T
+    const statement = this.db.prepare(sql)
+    statement.bind(params)
+
+    if (!statement.step()) {
+      statement.free()
+      return undefined
     }
-    stmt.free()
-    return undefined
+
+    const row = readCurrentRow<T>(statement)
+    statement.free()
+    return row
   }
 
   private queryAll<T>(sql: string, params: unknown[] = []): T[] {
-    const stmt = this.db.prepare(sql)
-    stmt.bind(params)
+    const statement = this.db.prepare(sql)
+    statement.bind(params)
     const results: T[] = []
-    while (stmt.step()) {
-      const columns = stmt.getColumnNames()
-      const values = stmt.get()
-      const row = {} as Record<string, unknown>
-      for (let idx = 0; idx < columns.length; idx++) {
-        row[columns[idx]] = values[idx]
-      }
-      results.push(row as T)
+
+    while (statement.step()) {
+      results.push(readCurrentRow<T>(statement))
     }
-    stmt.free()
+
+    statement.free()
     return results
   }
 
@@ -109,8 +114,7 @@ class TestDatabase {
   }
 
   deleteProject(projectId: string): boolean {
-    const before = this.getProject(projectId)
-    if (!before) return false
+    if (!this.getProject(projectId)) return false
     this.db.run('DELETE FROM projects WHERE id = ?', [projectId])
     return true
   }

--- a/src/main/services/database.ts
+++ b/src/main/services/database.ts
@@ -50,6 +50,18 @@ function getDb(): SqlJsDatabase {
   return db
 }
 
+function readCurrentRow<T>(statement: ReturnType<SqlJsDatabase['prepare']>): T {
+  const columns = statement.getColumnNames()
+  const values = statement.get()
+  const row = {} as Record<string, unknown>
+
+  for (let idx = 0; idx < columns.length; idx++) {
+    row[columns[idx]] = values[idx]
+  }
+
+  return row as T
+}
+
 class Database {
   private initialized = false
 
@@ -160,37 +172,30 @@ class Database {
 
   private queryOne<T>(sql: string, params: unknown[] = []): T | undefined {
     const sqlDb = getDb()
-    const stmt = sqlDb.prepare(sql)
-    stmt.bind(params)
-    if (stmt.step()) {
-      const columns = stmt.getColumnNames()
-      const values = stmt.get()
-      stmt.free()
-      const row = {} as Record<string, unknown>
-      for (let idx = 0; idx < columns.length; idx++) {
-        row[columns[idx]] = values[idx]
-      }
-      return row as T
+    const statement = sqlDb.prepare(sql)
+    statement.bind(params)
+
+    if (!statement.step()) {
+      statement.free()
+      return undefined
     }
-    stmt.free()
-    return undefined
+
+    const row = readCurrentRow<T>(statement)
+    statement.free()
+    return row
   }
 
   private queryAll<T>(sql: string, params: unknown[] = []): T[] {
     const sqlDb = getDb()
-    const stmt = sqlDb.prepare(sql)
-    stmt.bind(params)
+    const statement = sqlDb.prepare(sql)
+    statement.bind(params)
     const results: T[] = []
-    while (stmt.step()) {
-      const columns = stmt.getColumnNames()
-      const values = stmt.get()
-      const row = {} as Record<string, unknown>
-      for (let idx = 0; idx < columns.length; idx++) {
-        row[columns[idx]] = values[idx]
-      }
-      results.push(row as T)
+
+    while (statement.step()) {
+      results.push(readCurrentRow<T>(statement))
     }
-    stmt.free()
+
+    statement.free()
     return results
   }
 
@@ -223,8 +228,7 @@ class Database {
   }
 
   deleteProject(projectId: string): boolean {
-    const before = this.getProject(projectId)
-    if (!before) return false
+    if (!this.getProject(projectId)) return false
     this.execute('DELETE FROM projects WHERE id = ?', [projectId])
     return true
   }


### PR DESCRIPTION
Reduce duplicated row-mapping logic in the database service and its tests while keeping behavior unchanged.