### PR TITLE
Wire up notification click to navigate directly to agent

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -191,6 +191,12 @@ const api = {
     const handler = (_event: Electron.IpcRendererEvent, data: unknown) => callback(data as never)
     ipcRenderer.on('update:available', handler)
     return () => ipcRenderer.removeListener('update:available', handler)
+  },
+
+  onNotificationSelectAgent: (callback: (data: { agentId: string }) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: unknown) => callback(data as never)
+    ipcRenderer.on('notification:select-agent', handler)
+    return () => ipcRenderer.removeListener('notification:select-agent', handler)
   }
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -118,6 +118,14 @@ export function App() {
     return window.api.onUpdateAvailable((data) => setUpdateInfo(data))
   }, [])
 
+  // ── Navigate to agent when desktop notification is clicked ──
+  useEffect(() => {
+    if (!window.api?.onNotificationSelectAgent) return
+    return window.api.onNotificationSelectAgent((data) => {
+      setSelectedAgentId(data.agentId)
+    })
+  }, [])
+
   // ── Convert live agents to AgentRuntime shape ──
   const liveAgentsAsRuntimes: AgentRuntime[] = useMemo(() => {
     return store.agents.map((agent): AgentRuntime => ({

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -68,6 +68,7 @@ export interface OrchestratorApi {
   onRuntimeStopped: (callback: (data: { id: string }) => void) => () => void
   onEventError: (callback: (data: { runtimeId: string; error: string }) => void) => () => void
   onUpdateAvailable: (callback: (data: { currentVersion: string; latestVersion: string }) => void) => () => void
+  onNotificationSelectAgent: (callback: (data: { agentId: string }) => void) => () => void
 }
 
 export interface WorktreeListEntry {


### PR DESCRIPTION
The main process already sent a notification:select-agent IPC message on desktop notification click, but the renderer never listened for it. Complete the circuit so clicking a notification opens the detail drawer for that specific agent.