### PR TITLE
Display real app version in UI instead of hardcoded string

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -5,6 +5,7 @@ import { runtimeManager } from './services/runtime-manager'
 import { workspaceManager } from './services/workspace-manager'
 import { database } from './services/database'
 import { notificationService, type NotifiableEventType } from './services/notification-service'
+import { getAppVersion } from './version'
 
 /**
  * Register all IPC handlers for renderer <-> main communication.
@@ -501,6 +502,12 @@ export function registerIpcHandlers(): void {
       console.error('[IPC] notifications:set-preference failed:', error)
       return { ok: false, error: String(error) }
     }
+  })
+
+  // ── App Info ──
+
+  ipcMain.handle('app:version', () => {
+    return { ok: true, data: getAppVersion() }
   })
 
   // ── Shell Integration ──

--- a/src/main/services/update-checker.ts
+++ b/src/main/services/update-checker.ts
@@ -1,4 +1,5 @@
-import { app, BrowserWindow } from 'electron'
+import { BrowserWindow } from 'electron'
+import { getAppVersion } from '../version'
 
 const NPM_REGISTRY_URL = 'https://registry.npmjs.org/oc-orchestrator/latest'
 const CHECK_INTERVAL_MS = 4 * 60 * 60_000 // every 4 hours
@@ -20,7 +21,7 @@ async function checkForUpdate(): Promise<void> {
     const data = await response.json() as { version?: string }
     if (!data.version) return
 
-    const currentVersion = app.getVersion()
+    const currentVersion = getAppVersion()
     if (data.version !== currentVersion && isNewer(data.version, currentVersion)) {
       for (const win of BrowserWindow.getAllWindows()) {
         win.webContents.send('update:available', {

--- a/src/main/version.ts
+++ b/src/main/version.ts
@@ -1,0 +1,28 @@
+import { app } from 'electron'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+let cached: string | null = null
+
+/**
+ * Returns the app version from package.json.
+ *
+ * In dev mode `app.getVersion()` returns the Electron version (e.g. 41.1.0)
+ * instead of our own version, so we read package.json directly.
+ */
+export function getAppVersion(): string {
+  if (cached) return cached
+
+  try {
+    const pkgPath = app.isPackaged
+      ? join(process.resourcesPath, 'app.asar', 'package.json')
+      : join(__dirname, '../../package.json')
+
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { version: string }
+    cached = pkg.version
+  } catch {
+    cached = app.getVersion()
+  }
+
+  return cached
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -137,6 +137,10 @@ const api = {
   setNotificationPreference: (eventType: string, enabled: boolean): Promise<IpcResult> =>
     ipcRenderer.invoke('notifications:set-preference', eventType, enabled),
 
+  // ── App Info ──
+  getVersion: (): Promise<IpcResult<string>> =>
+    ipcRenderer.invoke('app:version'),
+
   // ── Shell Integration ──
   notifyAgentStatus: (agentId: string, status: string, agentName: string, projectName?: string): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:notify-status', agentId, status, agentName, projectName),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -54,6 +54,7 @@ export function App() {
   const [showModelPicker, setShowModelPicker] = useState(false)
   const [showMcpModal, setShowMcpModal] = useState(false)
   const [updateInfo, setUpdateInfo] = useState<{ currentVersion: string; latestVersion: string } | null>(null)
+  const [appVersion, setAppVersion] = useState('')
 
   const store = useAgentStore()
 
@@ -116,6 +117,13 @@ export function App() {
   useEffect(() => {
     setViewedAgentId(selectedAgentId)
   }, [selectedAgentId])
+
+  // ── Fetch app version ──
+  useEffect(() => {
+    window.api.getVersion().then((result) => {
+      if (result.ok && result.data) setAppVersion(result.data)
+    })
+  }, [])
 
   // ── Update notification ──
   useEffect(() => {
@@ -814,6 +822,7 @@ export function App() {
         agentCount={displayAgents.length}
         projectCount={projectNames.length}
         healthy={store.healthy}
+        version={appVersion}
       />
 
       {selectedAgent && (

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   X,
   GearSix,
@@ -63,6 +63,13 @@ const TAB_LIST: { id: TabId; label: string; icon: typeof GearSix }[] = [
 export function SettingsModal({ onClose }: SettingsModalProps) {
   const [activeTab, setActiveTab] = useState<TabId>('general')
   const [settings, setSettings] = useState(loadSettings)
+  const [appVersion, setAppVersion] = useState<string>('')
+
+  useEffect(() => {
+    window.api.getVersion().then((result) => {
+      if (result.ok && result.data) setAppVersion(result.data)
+    })
+  }, [])
 
   const updateSettings = (partial: Partial<AppSettings>) => {
     const updated = { ...settings, ...partial }
@@ -296,7 +303,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
               </div>
               <div className="text-center">
                 <h3 className="text-lg font-semibold text-kumo-strong">OC Orchestrator</h3>
-                <p className="text-sm text-kumo-subtle mt-1">Version 0.1.0</p>
+                <p className="text-sm text-kumo-subtle mt-1">Version {appVersion || '...'}</p>
               </div>
               <p className="text-xs text-kumo-subtle text-center max-w-xs">
                 Supervise concurrent coding agents from a single dashboard.

--- a/src/renderer/src/components/StatusBar.tsx
+++ b/src/renderer/src/components/StatusBar.tsx
@@ -2,9 +2,10 @@ interface StatusBarProps {
   agentCount: number
   projectCount: number
   healthy: boolean
+  version?: string
 }
 
-export function StatusBar({ agentCount, projectCount, healthy }: StatusBarProps) {
+export function StatusBar({ agentCount, projectCount, healthy, version }: StatusBarProps) {
   return (
     <div className="flex items-center justify-between px-4 h-7 bg-kumo-elevated border-t border-kumo-line text-[11px] text-kumo-subtle shrink-0">
       <div className="flex items-center gap-3">
@@ -12,6 +13,12 @@ export function StatusBar({ agentCount, projectCount, healthy }: StatusBarProps)
         <span>{healthy ? 'All runtimes healthy' : 'Some runtimes unhealthy'}</span>
         <span>&middot;</span>
         <span>{agentCount} agents across {projectCount} projects</span>
+        {version && (
+          <>
+            <span>&middot;</span>
+            <span>v{version}</span>
+          </>
+        )}
       </div>
       <div className="flex items-center gap-3">
         <span>

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -55,6 +55,9 @@ export interface OrchestratorApi {
   getNotificationPreferences: () => Promise<IpcResult<NotificationPreferences>>
   setNotificationPreference: (eventType: NotifiableEventType, enabled: boolean) => Promise<IpcResult>
 
+  // ── App Info ──
+  getVersion: () => Promise<IpcResult<string>>
+
   // ── Shell Integration ──
   notifyAgentStatus: (agentId: string, status: string, agentName: string, projectName?: string) => Promise<IpcResult>
   openInEditor: (options: { path: string; editor: 'vscode' | 'cursor' | 'windsurf' }) => Promise<IpcResult>


### PR DESCRIPTION
The About tab had a hardcoded "Version 0.1.0" that was already stale. Add an app:version IPC channel so the renderer can read the actual version from Electron, then show it in both the Settings > About tab and the bottom status bar for at-a-glance visibility.