### PR TITLE
Fix notification click not bringing app to foreground on macOS

### DIFF
--- a/src/main/services/notification-service.ts
+++ b/src/main/services/notification-service.ts
@@ -152,10 +152,16 @@ class NotificationService {
 
     const mainWindow = windows[0]
 
+    // app.show() activates the Electron app at the OS level (macOS dock bounce),
+    // which is required before mainWindow.focus() will actually bring it to front
+    // when the app isn't the currently focused application.
+    app.show()
+
     if (mainWindow.isMinimized()) {
       mainWindow.restore()
     }
 
+    mainWindow.show()
     mainWindow.focus()
     mainWindow.webContents.send('notification:select-agent', { agentId })
   }


### PR DESCRIPTION
mainWindow.focus() alone doesn't activate the app when it's not the currently focused application. Call app.show() first to activate at the OS level, then mainWindow.show() + focus() to bring the window forward.