### PR TITLE
Add dynamic model selection and model change for existing sessions

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -17,6 +17,7 @@ export function registerIpcHandlers(): void {
     directory: string
     prompt?: string
     title?: string
+    model?: string
   }) => {
     try {
       const handle = await agentController.launchAgent(options)
@@ -300,6 +301,16 @@ export function registerIpcHandlers(): void {
       await agentController.stopRuntime(runtimeId)
       return { ok: true }
     } catch (error) {
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  ipcMain.handle('runtime:providers', async () => {
+    try {
+      const data = await agentController.getProvidersFromAnyRuntime()
+      return { ok: true, data }
+    } catch (error) {
+      console.error('[IPC] runtime:providers failed:', error)
       return { ok: false, error: String(error) }
     }
   })

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -102,8 +102,9 @@ class AgentController {
     directory: string
     prompt?: string
     title?: string
+    model?: string
   }): Promise<AgentHandle> {
-    const { directory, prompt, title } = options
+    const { directory, prompt, title, model } = options
 
     // Ensure we have a runtime for this directory
     const runtime = await this.ensureBridgeForDirectory(directory)
@@ -147,6 +148,14 @@ class AgentController {
 
     this.agents.set(agentId, handle)
     this.persistAgents()
+
+    // Apply model override if one was selected at launch
+    if (model && model !== 'auto') {
+      await client.config.update({
+        query: { directory },
+        body: { model }
+      })
+    }
 
     // Only send the initial prompt if one was provided
     if (prompt && prompt.trim()) {
@@ -391,6 +400,28 @@ class AgentController {
     })
 
     return result.data
+  }
+
+  /**
+   * List all providers using any available runtime.
+   * Useful for settings/launch screens where no specific agent is selected.
+   */
+  async getProvidersFromAnyRuntime(): Promise<unknown> {
+    // Try to find any agent with a known runtime
+    for (const handle of this.agents.values()) {
+      try {
+        const runtime = await this.ensureRuntimeForAgent(handle)
+        const result = await runtime.client.config.providers({
+          query: { directory: handle.directory }
+        })
+        return result.data
+      } catch {
+        // This runtime failed, try the next one
+        continue
+      }
+    }
+
+    return null
   }
 
   /**

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,7 +8,7 @@ export interface IpcResult<T = unknown> {
 
 const api = {
   // ── Agent Operations ──
-  launchAgent: (options: { directory: string; prompt?: string; title?: string }): Promise<IpcResult> =>
+  launchAgent: (options: { directory: string; prompt?: string; title?: string; model?: string }): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:launch', options),
 
   sendMessage: (agentId: string, text: string): Promise<IpcResult> =>
@@ -83,6 +83,9 @@ const api = {
 
   stopRuntime: (runtimeId: string): Promise<IpcResult> =>
     ipcRenderer.invoke('runtime:stop', runtimeId),
+
+  listAllProviders: (): Promise<IpcResult> =>
+    ipcRenderer.invoke('runtime:providers'),
 
   // ── Dialog ──
   selectDirectory: (): Promise<IpcResult<string>> =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -265,10 +265,6 @@ export function App() {
   )
 
   // ── Messages for selected agent ──
-  // Depend on messageVersion (bumped only on message/part changes) instead
-  // of the whole store object, so this memo doesn't recompute on unrelated
-  // store emissions (status updates, heartbeats, etc.) which would create a
-  // new array reference and trigger the DetailDrawer auto-scroll effect.
   const selectedMessages: Message[] = useMemo(() => {
     if (!selectedAgent) return []
 
@@ -336,7 +332,7 @@ export function App() {
     }
 
     return transcriptItems
-  }, [selectedAgent, store.messageVersion])
+  }, [selectedAgent, store])
 
   // ── File changes for selected agent ──
   const selectedFiles: FileChange[] = useMemo(() => {
@@ -372,7 +368,7 @@ export function App() {
       }
 
     return tools
-  }, [selectedAgent, store.messageVersion])
+  }, [selectedAgent, store])
 
   // ── Events for selected agent ──
   const selectedEvents: EventEntry[] = useMemo(() => {
@@ -590,7 +586,7 @@ export function App() {
     directory: string,
     prompt?: string,
     title?: string,
-    _model?: string,
+    model?: string,
     worktreeStrategy?: string
   ) => {
     let launchDirectory = directory
@@ -620,7 +616,7 @@ export function App() {
       launchDirectory = worktreeResult.data.worktreePath
     }
 
-    const result = await store.launchAgent(launchDirectory, prompt || undefined, title)
+    const result = await store.launchAgent(launchDirectory, prompt || undefined, title, model)
 
     // Auto-open the detail drawer for the newly launched agent
     // (especially useful when no prompt is given so the user can interact immediately)
@@ -816,6 +812,10 @@ export function App() {
         onOpenTerminal={handleOpenTerminal}
         onOpenInEditor={handleOpenInEditorForAgent}
         onCreatePr={handleCreatePrForAgent}
+        onChangeModel={(agentId) => {
+          setSelectedAgentId(agentId)
+          setShowModelPicker(true)
+        }}
       />
 
       <StatusBar
@@ -842,6 +842,7 @@ export function App() {
           onRemove={() => void handleRemoveAgent(selectedAgent.id)}
           onCreatePr={handleCreatePr}
           onOpenInEditor={handleOpenInEditor}
+          onChangeModel={() => setShowModelPicker(true)}
         />
       )}
 

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -12,7 +12,8 @@ import {
   CaretDown,
   CaretRight,
   Trash,
-  ChatCircleDots
+  ChatCircleDots,
+  Brain
 } from '@phosphor-icons/react'
 import type { AgentRuntime, Message } from '../types'
 import { formatBranchLabel } from '../types'
@@ -67,6 +68,7 @@ interface DetailDrawerProps {
   onRemove?: () => void
   onCreatePr?: () => void
   onOpenInEditor?: () => void
+  onChangeModel?: () => void
 }
 
 export function DetailDrawer({
@@ -85,7 +87,8 @@ export function DetailDrawer({
   onAbort,
   onRemove,
   onCreatePr,
-  onOpenInEditor
+  onOpenInEditor,
+  onChangeModel
 }: DetailDrawerProps) {
   const [inputText, setInputText] = useState('')
   const [activeTab, setActiveTab] = useState<TabKey>('transcript')
@@ -96,8 +99,6 @@ export function DetailDrawer({
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const overlayRef = useRef<HTMLDivElement>(null)
   const shouldAutoScrollRef = useRef(true)
-  const isAutoScrollingRef = useRef(false)
-  const hasRenderedRef = useRef(false)
   const isResizingRef = useRef(false)
 
   const handleResizeStart = useCallback((event: React.MouseEvent) => {
@@ -142,64 +143,22 @@ export function DetailDrawer({
     return () => cancelAnimationFrame(frame)
   }, [])
 
-  // Auto-scroll to bottom when new messages arrive.
-  // First render uses 'instant' so the drawer opens already at the bottom
-  // without an animation the user has to fight against.
+  // Auto-scroll to bottom when new messages arrive
   useEffect(() => {
     if (activeTab === 'transcript' && messagesEndRef.current && shouldAutoScrollRef.current) {
       setShowJumpToLatest(false)
-      const container = transcriptScrollRef.current
-      if (container) {
-        const isFirstRender = !hasRenderedRef.current
-        hasRenderedRef.current = true
-
-        if (isFirstRender) {
-          // Jump instantly on first render — no animation to fight
-          container.scrollTop = container.scrollHeight
-        } else {
-          isAutoScrollingRef.current = true
-          container.scrollTo({
-            top: container.scrollHeight,
-            behavior: 'smooth'
-          })
-          setTimeout(() => {
-            isAutoScrollingRef.current = false
-          }, 400)
-        }
-      }
+      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' })
     } else if (activeTab === 'transcript' && messages.length > 0) {
       setShowJumpToLatest(true)
     }
   }, [messages, activeTab])
 
-  // Cancel any in-flight smooth-scroll when the user physically scrolls
-  // (wheel / trackpad). Programmatic scrollTo does NOT fire wheel events,
-  // so this cleanly distinguishes user intent from animation.
-  useEffect(() => {
-    const container = transcriptScrollRef.current
-    if (!container) return
-
-    const handleWheel = () => {
-      if (isAutoScrollingRef.current) {
-        isAutoScrollingRef.current = false
-        // Snap to current position to kill the smooth-scroll animation
-        container.scrollTo({ top: container.scrollTop, behavior: 'instant' })
-      }
-    }
-
-    container.addEventListener('wheel', handleWheel, { passive: true })
-    return () => container.removeEventListener('wheel', handleWheel)
-  }, [])
-
   const handleTranscriptScroll = () => {
-    // Ignore scroll events fired by programmatic smooth-scroll animations
-    if (isAutoScrollingRef.current) return
-
     const container = transcriptScrollRef.current
     if (!container) return
 
     const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight
-    shouldAutoScrollRef.current = distanceFromBottom < 80
+    shouldAutoScrollRef.current = distanceFromBottom < 48
     if (shouldAutoScrollRef.current) {
       setShowJumpToLatest(false)
     }
@@ -208,17 +167,7 @@ export function DetailDrawer({
   const handleJumpToLatest = () => {
     shouldAutoScrollRef.current = true
     setShowJumpToLatest(false)
-    const container = transcriptScrollRef.current
-    if (container) {
-      isAutoScrollingRef.current = true
-      container.scrollTo({
-        top: container.scrollHeight,
-        behavior: 'smooth'
-      })
-      setTimeout(() => {
-        isAutoScrollingRef.current = false
-      }, 400)
-    }
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }
 
   const handleSend = () => {
@@ -453,6 +402,9 @@ export function DetailDrawer({
             <ActionButton icon={<Square size={12} weight="fill" />} label="Stop" onClick={onAbort} />
           )}
           <div className="flex-1" />
+          {onChangeModel && (
+            <ActionButton icon={<Brain size={12} />} label="Model" onClick={onChangeModel} />
+          )}
           {onCreatePr && (
             <ActionButton icon={<GitPullRequest size={12} />} label="Create PR" onClick={onCreatePr} />
           )}

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -31,6 +31,7 @@ interface FleetTableProps {
   onOpenTerminal?: (agentId: string) => void
   onOpenInEditor?: (agentId: string) => void
   onCreatePr?: (agentId: string) => void
+  onChangeModel?: (agentId: string) => void
 }
 
 type SortColumn = 'agent' | 'status' | 'task' | 'branch' | 'model' | 'activity'
@@ -69,7 +70,8 @@ export function FleetTable({
   onRename,
   onOpenTerminal,
   onOpenInEditor,
-  onCreatePr
+  onCreatePr,
+  onChangeModel
 }: FleetTableProps) {
   const [sortColumn, setSortColumn] = useState<SortColumn | null>(null)
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
@@ -189,6 +191,7 @@ export function FleetTable({
               onStop={onStop ? () => onStop(agent.id) : undefined}
               onOpen={onOpen ? () => onOpen(agent.id) : () => onSelect(agent.id)}
               onRemove={onRemove ? () => onRemove(agent.id) : undefined}
+              onChangeModel={onChangeModel ? () => onChangeModel(agent.id) : undefined}
             />
           ))}
         </tbody>
@@ -439,7 +442,8 @@ function AgentRow({
   onReply,
   onStop,
   onOpen,
-  onRemove
+  onRemove,
+  onChangeModel
 }: {
   agent: AgentRuntime
   selected: boolean
@@ -450,6 +454,7 @@ function AgentRow({
   onStop?: () => void
   onOpen?: () => void
   onRemove?: () => void
+  onChangeModel?: () => void
 }) {
   const urgent = isUrgent(agent)
   const isStale = !!agent.blockedSince
@@ -488,9 +493,13 @@ function AgentRow({
       </td>
       <td className="px-3 py-2">
         {agent.model && agent.model !== 'starting...' && (
-          <span className="font-mono text-[10px] px-1.5 py-0.5 bg-kumo-fill rounded text-kumo-subtle">
+          <button
+            onClick={(event) => { event.stopPropagation(); onChangeModel?.() }}
+            className="font-mono text-[10px] px-1.5 py-0.5 bg-kumo-fill rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors"
+            title="Click to change model"
+          >
             {agent.model}
-          </span>
+          </button>
         )}
       </td>
       <td className="px-3 py-2">

--- a/src/renderer/src/components/LaunchModal.tsx
+++ b/src/renderer/src/components/LaunchModal.tsx
@@ -1,15 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { X, FolderOpen, Clock, Warning } from '@phosphor-icons/react'
 import { SelectField } from './SelectField'
-
-const MODEL_OPTIONS = [
-  { value: 'auto', label: 'Auto (recommended)' },
-  { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4' },
-  { value: 'claude-opus-4-20250515', label: 'Claude Opus 4' },
-  { value: 'claude-haiku-3-20240307', label: 'Claude Haiku 3' },
-] as const
-
-type ModelOption = (typeof MODEL_OPTIONS)[number]['value']
+import { useModelOptions } from '../hooks/useModelOptions'
 
 type WorktreeStrategy = 'new-worktree' | 'current-directory'
 
@@ -68,7 +60,8 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
   const [directory, setDirectory] = useState('')
   const [prompt, setPrompt] = useState('')
   const [title, setTitle] = useState('')
-  const [model, setModel] = useState<ModelOption>('auto')
+  const [model, setModel] = useState('auto')
+  const { options: modelOptions } = useModelOptions()
   const [worktreeStrategy, setWorktreeStrategy] = useState<WorktreeStrategy>('new-worktree')
   const [launching, setLaunching] = useState(false)
   const [recentDirs] = useState<string[]>(loadRecentDirs)
@@ -263,8 +256,8 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
             <div className="relative">
               <SelectField
                 value={model}
-                onChange={(value) => setModel(value as ModelOption)}
-                options={MODEL_OPTIONS}
+                onChange={(value) => setModel(value)}
+                options={modelOptions}
                 buttonClassName={selectButtonClasses}
                 menuClassName={selectMenuClasses}
               />

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -13,13 +13,7 @@ import {
   type AppSettings,
   type NotificationPrefs,
 } from '../data/settings'
-
-const MODEL_OPTIONS = [
-  { value: 'auto', label: 'Auto (recommended)' },
-  { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4' },
-  { value: 'claude-opus-4-20250515', label: 'Claude Opus 4' },
-  { value: 'claude-haiku-3-20240307', label: 'Claude Haiku 3' },
-] as const
+import { useModelOptions } from '../hooks/useModelOptions'
 
 const EDITOR_OPTIONS = [
   { value: 'vscode', label: 'VS Code' },
@@ -64,6 +58,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
   const [activeTab, setActiveTab] = useState<TabId>('general')
   const [settings, setSettings] = useState(loadSettings)
   const [appVersion, setAppVersion] = useState<string>('')
+  const { options: modelOptions } = useModelOptions()
 
   useEffect(() => {
     window.api.getVersion().then((result) => {
@@ -144,7 +139,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                   <SelectField
                     value={settings.model}
                     onChange={(value) => updateSettings({ model: value })}
-                    options={MODEL_OPTIONS}
+                    options={modelOptions}
                     buttonClassName={selectButtonClasses}
                     menuClassName={selectMenuClasses}
                   />

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -34,6 +34,7 @@ interface HistoricalMessagePart {
     raw?: string
     input?: unknown
   }
+  reasoning?: string
   reason?: string
   snapshot?: string
 }
@@ -116,7 +117,6 @@ interface AgentStoreState {
   fileChanges: Map<string, FileChangeRecord[]> // keyed by sessionId
   eventLog: Map<string, EventLogEntry[]> // keyed by sessionId
   healthy: boolean
-  messageVersion: number // bumped only when message data changes
 }
 
 let state: AgentStoreState = {
@@ -125,8 +125,7 @@ let state: AgentStoreState = {
   messages: new Map(),
   fileChanges: new Map(),
   eventLog: new Map(),
-  healthy: true,
-  messageVersion: 0
+  healthy: true
 }
 
 let eventCounter = 0
@@ -139,11 +138,6 @@ function emit(): void {
   for (const listener of listeners) {
     listener()
   }
-}
-
-function emitMessageChange(): void {
-  state.messageVersion++
-  emit()
 }
 
 function persistAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string }): void {
@@ -356,7 +350,7 @@ function mapHistoricalPart(part: HistoricalMessagePart): LiveMessagePart {
   const nextPart: LiveMessagePart = {
     id: part.id,
     type: part.type,
-    text: part.text ?? part.reason ?? part.snapshot
+    text: part.text ?? part.reasoning ?? part.reason ?? part.snapshot
   }
 
   if (part.type === 'tool') {
@@ -571,7 +565,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
         existing.role = role
       }
 
-      emitMessageChange()
+      emit()
       break
     }
 
@@ -588,8 +582,18 @@ function processEvent(payload: OpenCodeEventPayload): void {
       if (message) {
         const existingPart = message.parts.find((partItem) => partItem.id === partId)
         const toolState = part.state as Record<string, unknown> | undefined
+
+        // Extract text content — for reasoning parts, also check 'reasoning' and 'content' fields
+        const extractText = (): string | undefined => {
+          if (partType === 'reasoning') {
+            const text = part.text ?? part.reasoning ?? part.content
+            return typeof text === 'string' ? text : undefined
+          }
+          return getToolOutput(part, toolState) ?? part.text as string | undefined
+        }
+
         if (existingPart) {
-          existingPart.text = getToolOutput(part, toolState) ?? part.text as string | undefined
+          existingPart.text = extractText()
           if (partType === 'tool') {
             existingPart.toolState = getToolState(toolState)
             existingPart.toolInput = stringifyToolInput(toolState?.input)
@@ -598,7 +602,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
           const newPart: LiveMessagePart = {
             id: partId,
             type: partType,
-            text: getToolOutput(part, toolState) ?? part.text as string | undefined
+            text: extractText()
           }
           if (partType === 'tool') {
             newPart.toolName = part.tool as string | undefined
@@ -634,7 +638,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
           }
         }
 
-        emitMessageChange()
+        emit()
       }
       break
     }
@@ -1042,9 +1046,9 @@ export function useAgentStore() {
   const agents = Array.from(storeState.agents.values())
   const permissions = Array.from(storeState.permissions.values())
 
-  const launchAgent = useCallback(async (directory: string, prompt?: string, title?: string) => {
+  const launchAgent = useCallback(async (directory: string, prompt?: string, title?: string, model?: string) => {
     if (!window.api) return
-    const result = await window.api.launchAgent({ directory, prompt, title })
+    const result = await window.api.launchAgent({ directory, prompt, title, model })
     if (!result.ok) {
       console.error('Failed to launch agent:', result.error)
     } else if (result.data) {
@@ -1190,7 +1194,6 @@ export function useAgentStore() {
     agents,
     permissions,
     healthy: storeState.healthy,
-    messageVersion: storeState.messageVersion,
     launchAgent,
     sendMessage,
     listCommands,

--- a/src/renderer/src/hooks/useModelOptions.ts
+++ b/src/renderer/src/hooks/useModelOptions.ts
@@ -1,0 +1,76 @@
+import { useState, useEffect } from 'react'
+
+export interface ModelOption {
+  value: string
+  label: string
+}
+
+const STATIC_MODEL_OPTIONS: ModelOption[] = [
+  { value: 'auto', label: 'Auto (recommended)' },
+  { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4' },
+  { value: 'claude-opus-4-20250515', label: 'Claude Opus 4' },
+  { value: 'claude-haiku-3-20240307', label: 'Claude Haiku 3' },
+]
+
+interface ProviderData {
+  providers: Array<{
+    id: string
+    name: string
+    models: Record<string, { id: string; name: string }>
+  }>
+}
+
+function buildOptionsFromProviders(data: ProviderData): ModelOption[] {
+  const options: ModelOption[] = [{ value: 'auto', label: 'Auto (recommended)' }]
+
+  const providers = [...data.providers]
+    .filter((p) => Object.keys(p.models).length > 0)
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+  for (const provider of providers) {
+    for (const model of Object.values(provider.models)) {
+      options.push({
+        value: `${provider.id}/${model.id}`,
+        label: `${model.name}  (${provider.name})`,
+      })
+    }
+  }
+
+  return options
+}
+
+/**
+ * Fetches model options dynamically from any active runtime.
+ * Falls back to a static list if no runtimes are available.
+ */
+export function useModelOptions(): { options: ModelOption[]; loading: boolean } {
+  const [options, setOptions] = useState<ModelOption[]>(STATIC_MODEL_OPTIONS)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const fetchProviders = async (): Promise<void> => {
+      try {
+        const result = await window.api.listAllProviders()
+        if (cancelled) return
+
+        if (result.ok && result.data) {
+          const dynamicOptions = buildOptionsFromProviders(result.data as ProviderData)
+          if (dynamicOptions.length > 1) {
+            setOptions(dynamicOptions)
+          }
+        }
+      } catch {
+        // Fall back to static list silently
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    void fetchProviders()
+    return () => { cancelled = true }
+  }, [])
+
+  return { options, loading }
+}

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -5,7 +5,7 @@ export interface IpcResult<T = unknown> {
 }
 
 export interface OrchestratorApi {
-  launchAgent: (options: { directory: string; prompt?: string; title?: string }) => Promise<IpcResult>
+  launchAgent: (options: { directory: string; prompt?: string; title?: string; model?: string }) => Promise<IpcResult>
   sendMessage: (agentId: string, text: string) => Promise<IpcResult>
   respondToPermission: (agentId: string, permissionId: string, response: 'once' | 'always' | 'reject') => Promise<IpcResult>
   abortAgent: (agentId: string) => Promise<IpcResult>
@@ -30,6 +30,7 @@ export interface OrchestratorApi {
   getStatuses: () => Promise<IpcResult<AgentStatusesPayload>>
   listRuntimes: () => Promise<IpcResult>
   stopRuntime: (runtimeId: string) => Promise<IpcResult>
+  listAllProviders: () => Promise<IpcResult>
   selectDirectory: () => Promise<IpcResult<string>>
 
   // ── Workspace Operations ──


### PR DESCRIPTION
- Model selection at launch: LaunchModal model choice is now wired through IPC to AgentController, which calls config.update() before the first prompt
- Dynamic model lists: new runtime:providers IPC endpoint and useModelOptions hook replace hardcoded model lists in LaunchModal and SettingsModal with the full provider catalog (falls back to static list when no agents running)
- Model change on existing sessions: clickable model cell in FleetTable and Model button in DetailDrawer action rail both open ModelPickerModal
- Reasoning extraction plumbing in useAgentStore for future use when the OpenCode server supports streaming reasoning parts