### PR TITLE
Wire up terminal button in detail drawer

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -563,6 +563,14 @@ export function App() {
     window.api.openInEditor({ path: liveAgent.directory, editor: settings.editor as 'vscode' | 'cursor' | 'windsurf' })
   }, [selectedAgentId, findLiveAgent])
 
+  const handleOpenTerminalForDrawer = useCallback(() => {
+    if (!selectedAgentId) return
+    const liveAgent = findLiveAgent(selectedAgentId)
+    if (!liveAgent) return
+    const settings = loadSettings()
+    window.api.openTerminal({ path: liveAgent.directory, terminal: settings.terminal })
+  }, [selectedAgentId, findLiveAgent])
+
   const handleCreatePrForAgent = useCallback(async (agentId: string) => {
     await store.sendMessage(agentId, loadSettings().createPrPrompt)
   }, [store])
@@ -843,6 +851,7 @@ export function App() {
           onCreatePr={handleCreatePr}
           onOpenInEditor={handleOpenInEditor}
           onChangeModel={() => setShowModelPicker(true)}
+          onOpenTerminal={handleOpenTerminalForDrawer}
         />
       )}
 

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -70,6 +70,7 @@ interface DetailDrawerProps {
   onCreatePr?: () => void
   onOpenInEditor?: () => void
   onChangeModel?: () => void
+  onOpenTerminal?: () => void
 }
 
 export function DetailDrawer({
@@ -89,7 +90,8 @@ export function DetailDrawer({
   onRemove,
   onCreatePr,
   onOpenInEditor,
-  onChangeModel
+  onChangeModel,
+  onOpenTerminal
 }: DetailDrawerProps) {
   const [inputText, setInputText] = useState('')
   const [activeTab, setActiveTab] = useState<TabKey>('transcript')
@@ -409,7 +411,7 @@ export function DetailDrawer({
           {onCreatePr && (
             <ActionButton icon={<GitPullRequest size={12} />} label="Create PR" onClick={onCreatePr} />
           )}
-          <ActionButton icon={<Terminal size={12} />} label="Terminal" />
+          <ActionButton icon={<Terminal size={12} />} label="Terminal" onClick={onOpenTerminal} />
           <ActionButton icon={<ArrowSquareOut size={12} />} label="Editor" onClick={onOpenInEditor} />
         </div>
 


### PR DESCRIPTION
The Terminal button in the DetailDrawer action bar was rendering without an onClick handler, making it a no-op. Added onOpenTerminal prop and connected it through App.tsx using the same pattern as the existing editor button.