### PR TITLE
Handle markdown link clicks at React level via openExternal IPC

### DIFF
--- a/src/renderer/src/components/Markdown.tsx
+++ b/src/renderer/src/components/Markdown.tsx
@@ -1,3 +1,4 @@
+import type { ComponentPropsWithoutRef, MouseEvent } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
@@ -6,12 +7,30 @@ interface MarkdownProps {
   className?: string
 }
 
+function ExternalLink({ href, children, ...props }: ComponentPropsWithoutRef<'a'>) {
+  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault()
+    if (href) {
+      window.api.openExternal(href)
+    }
+  }
+
+  return (
+    <a {...props} href={href} onClick={handleClick}>
+      {children}
+    </a>
+  )
+}
+
 export function Markdown({ children, className }: MarkdownProps) {
   return (
     <div className={`markdown-body ${className ?? ''}`}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         disallowedElements={['script', 'iframe', 'object', 'embed', 'form']}
+        components={{
+          a: ExternalLink
+        }}
       >
         {children}
       </ReactMarkdown>


### PR DESCRIPTION
The will-navigate handler added in 581069e doesn't reliably fire for link clicks in React SPAs. Intercept clicks directly in the Markdown component using a custom ReactMarkdown 'a' renderer that calls window.api.openExternal(), ensuring links always open in the system browser.