### PR TITLE
Add gear icon to agent row for quick access to actions

### DIFF
--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -4,6 +4,7 @@ import {
   CaretUp,
   CaretDown,
   Check,
+  GearSix,
   Pause,
   PencilSimple,
   Square,
@@ -508,14 +509,23 @@ function AgentRow({
         </span>
       </td>
       <td className="px-3 py-2">
-        <RowActions
-          agent={agent}
-          onApprove={onApprove}
-          onReply={onReply}
-          onStop={onStop}
-          onOpen={onOpen}
-          onRemove={onRemove}
-        />
+        <div className="flex items-center gap-1">
+          <RowActions
+            agent={agent}
+            onApprove={onApprove}
+            onReply={onReply}
+            onStop={onStop}
+            onOpen={onOpen}
+            onRemove={onRemove}
+          />
+          <button
+            onClick={(event) => { event.stopPropagation(); onContextMenu(event) }}
+            className="w-6 h-6 flex items-center justify-center rounded text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill transition-colors"
+            title="Agent actions"
+          >
+            <GearSix size={13} />
+          </button>
+        </div>
       </td>
     </tr>
   )


### PR DESCRIPTION
Add a persistent cog icon to the left of each agent name in the fleet
table. Clicking it opens the same context menu as right-click, making
rename and other agent actions discoverable without right-clicking.

<img width="597" height="253" alt="image" src="https://github.com/user-attachments/assets/331e4a42-b81e-4e49-9910-d096c1d32fb9" />
