### PR TITLE
Fix question support by migrating to SDK v2

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -62,6 +62,36 @@ export function registerIpcHandlers(): void {
     }
   })
 
+  ipcMain.handle('agent:reply-question', async (_event, agentId: string, requestId: string, answers: string[][]) => {
+    try {
+      await agentController.replyToQuestion(agentId, requestId, answers)
+      return { ok: true }
+    } catch (error) {
+      console.error('[IPC] agent:reply-question failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  ipcMain.handle('agent:reject-question', async (_event, agentId: string, requestId: string) => {
+    try {
+      await agentController.rejectQuestion(agentId, requestId)
+      return { ok: true }
+    } catch (error) {
+      console.error('[IPC] agent:reject-question failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  ipcMain.handle('agent:list-questions', async () => {
+    try {
+      const questions = await agentController.getAllPendingQuestions()
+      return { ok: true, data: questions }
+    } catch (error) {
+      console.error('[IPC] agent:list-questions failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
   ipcMain.handle('agent:abort', async (_event, agentId: string) => {
     try {
       await agentController.abortAgent(agentId)

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow } from 'electron'
-import type { OpencodeClient } from '@opencode-ai/sdk/client'
+import type { OpencodeClient } from '@opencode-ai/sdk/v2/client'
 import { runtimeManager, type RuntimeInfo } from './runtime-manager'
 import { EventBridge } from './event-bridge'
 import { notificationService, type NotifiableEventType } from './notification-service'
@@ -118,10 +118,8 @@ class AgentController {
 
     // Create a new session
     const sessionResult = await client.session.create({
-      headers: { 'x-opencode-directory': directory },
-      body: {
-        title: sessionTitle
-      }
+      directory,
+      title: sessionTitle
     })
 
     const session = sessionResult.data
@@ -152,19 +150,17 @@ class AgentController {
     // Apply model override if one was selected at launch
     if (model && model !== 'auto') {
       await client.config.update({
-        query: { directory },
-        body: { model }
+        directory,
+        config: { model }
       })
     }
 
     // Only send the initial prompt if one was provided
     if (prompt && prompt.trim()) {
       await client.session.promptAsync({
-        headers: { 'x-opencode-directory': directory },
-        path: { id: session.id },
-        body: {
-          parts: [{ type: 'text', text: prompt }]
-        }
+        sessionID: session.id,
+        directory,
+        parts: [{ type: 'text', text: prompt }]
       })
     }
 
@@ -207,8 +203,8 @@ class AgentController {
     const sessionTitle = prompt ? prompt.slice(0, 80) : `${projectSlug}-${Date.now()}`
 
     const sessionResult = await runtime.client.session.create({
-      headers: { 'x-opencode-directory': handle.directory },
-      body: { title: sessionTitle }
+      directory: handle.directory,
+      title: sessionTitle
     })
 
     const session = sessionResult.data
@@ -223,11 +219,9 @@ class AgentController {
 
     if (prompt && prompt.trim()) {
       await runtime.client.session.promptAsync({
-        headers: { 'x-opencode-directory': handle.directory },
-        path: { id: session.id },
-        body: {
-          parts: [{ type: 'text', text: prompt }]
-        }
+        sessionID: session.id,
+        directory: handle.directory,
+        parts: [{ type: 'text', text: prompt }]
       })
     }
 
@@ -267,11 +261,9 @@ class AgentController {
     runtimeManager.touchRuntimeActivity(runtime.id)
 
     await runtime.client.session.promptAsync({
-      headers: { 'x-opencode-directory': handle.directory },
-      path: { id: handle.sessionId },
-      body: {
-        parts: [{ type: 'text', text }]
-      }
+      sessionID: handle.sessionId,
+      directory: handle.directory,
+      parts: [{ type: 'text', text }]
     })
   }
 
@@ -285,14 +277,61 @@ class AgentController {
     const runtime = await this.ensureRuntimeForAgent(handle)
     runtimeManager.touchRuntimeActivity(runtime.id)
 
-    await runtime.client.postSessionIdPermissionsPermissionId({
-      headers: { 'x-opencode-directory': handle.directory },
-      path: {
-        id: handle.sessionId,
-        permissionID: permissionId
-      },
-      body: { response }
+    await runtime.client.permission.reply({
+      requestID: permissionId,
+      directory: handle.directory,
+      reply: response
     })
+  }
+
+  /**
+   * Reply to a question request from the agent.
+   */
+  async replyToQuestion(agentId: string, requestId: string, answers: string[][]): Promise<void> {
+    const handle = this.agents.get(agentId)
+    if (!handle) throw new Error(`Agent ${agentId} not found`)
+
+    const runtime = await this.ensureRuntimeForAgent(handle)
+    runtimeManager.touchRuntimeActivity(runtime.id)
+
+    await runtime.client.question.reply({
+      requestID: requestId,
+      directory: handle.directory,
+      answers
+    })
+  }
+
+  /**
+   * Reject a question request from the agent.
+   */
+  async rejectQuestion(agentId: string, requestId: string): Promise<void> {
+    const handle = this.agents.get(agentId)
+    if (!handle) throw new Error(`Agent ${agentId} not found`)
+
+    const runtime = await this.ensureRuntimeForAgent(handle)
+    runtimeManager.touchRuntimeActivity(runtime.id)
+
+    await runtime.client.question.reject({
+      requestID: requestId,
+      directory: handle.directory
+    })
+  }
+
+  /**
+   * List pending questions for an agent's runtime.
+   */
+  async listQuestions(agentId: string): Promise<unknown> {
+    const handle = this.agents.get(agentId)
+    if (!handle) return []
+
+    const runtime = await this.ensureRuntimeForAgent(handle)
+    runtimeManager.touchRuntimeActivity(runtime.id)
+
+    const result = await runtime.client.question.list({
+      directory: handle.directory
+    })
+
+    return result.data
   }
 
   /**
@@ -306,8 +345,8 @@ class AgentController {
     runtimeManager.touchRuntimeActivity(runtime.id)
 
     await runtime.client.session.abort({
-      headers: { 'x-opencode-directory': handle.directory },
-      path: { id: handle.sessionId }
+      sessionID: handle.sessionId,
+      directory: handle.directory
     })
   }
 
@@ -322,7 +361,7 @@ class AgentController {
     runtimeManager.touchRuntimeActivity(runtime.id)
 
     const result = await runtime.client.command.list({
-      headers: { 'x-opencode-directory': handle.directory }
+      directory: handle.directory
     })
 
     return result.data
@@ -339,12 +378,10 @@ class AgentController {
     runtimeManager.touchRuntimeActivity(runtime.id)
 
     const result = await runtime.client.session.command({
-      headers: { 'x-opencode-directory': handle.directory },
-      path: { id: handle.sessionId },
-      body: {
-        command,
-        arguments: args
-      }
+      sessionID: handle.sessionId,
+      directory: handle.directory,
+      command,
+      arguments: args
     })
 
     return result.data
@@ -361,7 +398,7 @@ class AgentController {
     runtimeManager.touchRuntimeActivity(runtime.id)
 
     const result = await runtime.client.config.get({
-      query: { directory: handle.directory }
+      directory: handle.directory
     })
 
     return result.data
@@ -378,8 +415,8 @@ class AgentController {
     runtimeManager.touchRuntimeActivity(runtime.id)
 
     const result = await runtime.client.config.update({
-      query: { directory: handle.directory },
-      body: config
+      directory: handle.directory,
+      config: config as never
     })
 
     return result.data
@@ -396,7 +433,7 @@ class AgentController {
     runtimeManager.touchRuntimeActivity(runtime.id)
 
     const result = await runtime.client.config.providers({
-      query: { directory: handle.directory }
+      directory: handle.directory
     })
 
     return result.data
@@ -412,7 +449,7 @@ class AgentController {
       try {
         const runtime = await this.ensureRuntimeForAgent(handle)
         const result = await runtime.client.config.providers({
-          query: { directory: handle.directory }
+          directory: handle.directory
         })
         return result.data
       } catch {
@@ -435,7 +472,7 @@ class AgentController {
     runtimeManager.touchRuntimeActivity(runtime.id)
 
     const result = await runtime.client.mcp.status({
-      query: { directory: handle.directory }
+      directory: handle.directory
     })
 
     return result.data
@@ -452,8 +489,8 @@ class AgentController {
     runtimeManager.touchRuntimeActivity(runtime.id)
 
     const result = await runtime.client.mcp.connect({
-      path: { name },
-      query: { directory: handle.directory }
+      name,
+      directory: handle.directory
     })
 
     return result.data
@@ -470,8 +507,8 @@ class AgentController {
     runtimeManager.touchRuntimeActivity(runtime.id)
 
     const result = await runtime.client.mcp.disconnect({
-      path: { name },
-      query: { directory: handle.directory }
+      name,
+      directory: handle.directory
     })
 
     return result.data
@@ -488,9 +525,8 @@ class AgentController {
     runtimeManager.touchRuntimeActivity(runtime.id)
 
     const result = await runtime.client.session.summarize({
-      headers: { 'x-opencode-directory': handle.directory },
-      path: { id: handle.sessionId },
-      body: { providerID: '', modelID: '' }
+      sessionID: handle.sessionId,
+      directory: handle.directory
     })
 
     return result.data
@@ -507,8 +543,8 @@ class AgentController {
     runtimeManager.touchRuntimeActivity(runtime.id)
 
     const result = await runtime.client.session.share({
-      headers: { 'x-opencode-directory': handle.directory },
-      path: { id: handle.sessionId }
+      sessionID: handle.sessionId,
+      directory: handle.directory
     })
 
     return result.data
@@ -525,7 +561,7 @@ class AgentController {
     runtimeManager.touchRuntimeActivity(runtime.id)
 
     const result = await runtime.client.app.agents({
-      query: { directory: handle.directory }
+      directory: handle.directory
     })
 
     return result.data
@@ -542,7 +578,7 @@ class AgentController {
     runtimeManager.touchRuntimeActivity(runtime.id)
 
     const result = await runtime.client.tool.ids({
-      query: { directory: handle.directory }
+      directory: handle.directory
     })
 
     return result.data
@@ -559,12 +595,10 @@ class AgentController {
     runtimeManager.touchRuntimeActivity(runtime.id)
 
     await runtime.client.session.promptAsync({
-      headers: { 'x-opencode-directory': handle.directory },
-      path: { id: handle.sessionId },
-      body: {
-        parts: [{ type: 'text', text }],
-        model: { providerID, modelID }
-      }
+      sessionID: handle.sessionId,
+      directory: handle.directory,
+      parts: [{ type: 'text', text }],
+      model: { providerID, modelID }
     })
   }
 
@@ -579,8 +613,8 @@ class AgentController {
     runtimeManager.touchRuntimeActivity(runtime.id)
 
     const result = await runtime.client.session.messages({
-      headers: { 'x-opencode-directory': handle.directory },
-      path: { id: handle.sessionId }
+      sessionID: handle.sessionId,
+      directory: handle.directory
     })
 
     return result.data
@@ -607,7 +641,7 @@ class AgentController {
       try {
         const directory = handles[0].directory
         const result = await runtime.client.session.status({
-          headers: { 'x-opencode-directory': directory }
+          directory
         })
 
         if (result.data) {
@@ -628,6 +662,45 @@ class AgentController {
     }
 
     return statuses
+  }
+
+  /**
+   * Fetch all pending questions across all agents.
+   */
+  async getAllPendingQuestions(): Promise<Array<{ agentId: string; questions: unknown[] }>> {
+    const result: Array<{ agentId: string; questions: unknown[] }> = []
+
+    const byRuntime = new Map<string, AgentHandle[]>()
+    for (const handle of this.agents.values()) {
+      const existing = byRuntime.get(handle.runtimeId) ?? []
+      existing.push(handle)
+      byRuntime.set(handle.runtimeId, existing)
+    }
+
+    for (const [runtimeId, handles] of byRuntime) {
+      const runtime = runtimeManager.getRuntime(runtimeId)
+      if (!runtime) continue
+
+      try {
+        const directory = handles[0].directory
+        const questionsResult = await runtime.client.question.list({
+          directory
+        })
+
+        if (questionsResult.data && Array.isArray(questionsResult.data)) {
+          for (const q of questionsResult.data as Array<{ id: string; sessionID: string }>) {
+            const agent = handles.find((h) => h.sessionId === q.sessionID)
+            if (agent) {
+              result.push({ agentId: agent.id, questions: [q] })
+            }
+          }
+        }
+      } catch (error) {
+        console.error(`[AgentController] Failed to get questions for runtime ${runtimeId}:`, error)
+      }
+    }
+
+    return result
   }
 
   /**

--- a/src/main/services/event-bridge.ts
+++ b/src/main/services/event-bridge.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow } from 'electron'
-import type { OpencodeClient } from '@opencode-ai/sdk/client'
+import type { OpencodeClient } from '@opencode-ai/sdk/v2/client'
 import { runtimeManager } from './runtime-manager'
 
 const INITIAL_BACKOFF_MS = 1_000
@@ -43,9 +43,7 @@ export class EventBridge {
   private async connectStream(): Promise<void> {
     try {
       const result = await this.client.event.subscribe({
-        headers: {
-          'x-opencode-directory': this.directory
-        }
+        directory: this.directory
       })
 
       // Connection succeeded — reset backoff state

--- a/src/main/services/runtime-manager.ts
+++ b/src/main/services/runtime-manager.ts
@@ -1,5 +1,5 @@
 import { createOpencodeServer } from '@opencode-ai/sdk/server'
-import { createOpencodeClient, type OpencodeClient } from '@opencode-ai/sdk/client'
+import { createOpencodeClient, type OpencodeClient } from '@opencode-ai/sdk/v2/client'
 import { BrowserWindow } from 'electron'
 import { createServer } from 'node:net'
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -77,6 +77,15 @@ const api = {
   getStatuses: (): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:statuses'),
 
+  replyToQuestion: (agentId: string, requestId: string, answers: string[][]): Promise<IpcResult> =>
+    ipcRenderer.invoke('agent:reply-question', agentId, requestId, answers),
+
+  rejectQuestion: (agentId: string, requestId: string): Promise<IpcResult> =>
+    ipcRenderer.invoke('agent:reject-question', agentId, requestId),
+
+  listQuestions: (): Promise<IpcResult> =>
+    ipcRenderer.invoke('agent:list-questions'),
+
   // ── Runtime Operations ──
   listRuntimes: (): Promise<IpcResult> =>
     ipcRenderer.invoke('runtime:list'),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -174,8 +174,24 @@ export function App() {
       }
     })
 
+    const questionInterrupts = store.questions.map((q): Interrupt => {
+      const agent = store.agents.find((agnt) => agnt.id === q.agentId)
+      const firstQuestion = q.questions[0]
+      return {
+        id: q.id,
+        runtimeId: q.agentId,
+        agentName: agent?.name ?? 'unknown',
+        projectName: agent?.projectName ?? 'unknown',
+        kind: 'needs_input',
+        reason: firstQuestion?.header ?? firstQuestion?.question ?? 'Agent has a question',
+        createdAt: formatTimeAgo(q.createdAt)
+      }
+    })
+
+    // Only include generic needs_input interrupts for agents that don't have a structured question
+    const agentsWithQuestions = new Set(store.questions.map((q) => q.agentId))
     const inputInterrupts = store.agents
-      .filter((agent) => agent.status === 'needs_input')
+      .filter((agent) => agent.status === 'needs_input' && !agentsWithQuestions.has(agent.id))
       .map((agent): Interrupt => ({
         id: `input-${agent.id}`,
         runtimeId: agent.id,
@@ -186,8 +202,8 @@ export function App() {
         createdAt: formatTimeAgo(agent.blockedSince ?? agent.lastActivityAt)
       }))
 
-    return [...permissionInterrupts, ...inputInterrupts]
-  }, [store.permissions, store.agents])
+    return [...permissionInterrupts, ...questionInterrupts, ...inputInterrupts]
+  }, [store.permissions, store.questions, store.agents])
 
   // ── Display data: always live (no mock fallback) ──
   const displayAgents = liveAgentsAsRuntimes
@@ -385,6 +401,12 @@ export function App() {
     return store.permissions.find((perm) => perm.agentId === selectedAgent.id) ?? null
   }, [selectedAgent, store.permissions])
 
+  // ── Question for selected agent ──
+  const selectedQuestion = useMemo(() => {
+    if (!selectedAgent) return null
+    return store.questions.find((q) => q.agentId === selectedAgent.id) ?? null
+  }, [selectedAgent, store.questions])
+
   // ── Counts ──
   const counts = useMemo(
     () => ({
@@ -544,6 +566,16 @@ export function App() {
     if (!selectedAgentId) return
     await store.respondToPermission(selectedAgentId, permissionId, 'reject')
   }, [selectedAgentId, store])
+
+  const handleReplyQuestion = useCallback(async (answers: string[][]) => {
+    if (!selectedAgentId || !selectedQuestion) return
+    await store.replyToQuestion(selectedAgentId, selectedQuestion.id, answers)
+  }, [selectedAgentId, selectedQuestion, store])
+
+  const handleRejectQuestion = useCallback(async () => {
+    if (!selectedAgentId || !selectedQuestion) return
+    await store.rejectQuestion(selectedAgentId, selectedQuestion.id)
+  }, [selectedAgentId, selectedQuestion, store])
 
   const handleAbort = useCallback(async () => {
     if (!selectedAgentId) return
@@ -838,6 +870,7 @@ export function App() {
           agent={selectedAgent}
           messages={selectedMessages}
           permission={selectedPermission}
+          question={selectedQuestion}
           files={selectedFiles}
           tools={selectedTools}
           events={selectedEvents}
@@ -846,6 +879,8 @@ export function App() {
           onSendMessage={handleSendMessage}
           onApprove={selectedPermission ? () => handleApprove(selectedPermission.id) : undefined}
           onDeny={selectedPermission ? () => handleDeny(selectedPermission.id) : undefined}
+          onReplyQuestion={selectedQuestion ? handleReplyQuestion : undefined}
+          onRejectQuestion={selectedQuestion ? handleRejectQuestion : undefined}
           onAbort={handleAbort}
           onRemove={() => void handleRemoveAgent(selectedAgent.id)}
           onCreatePr={handleCreatePr}

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -17,7 +17,7 @@ import {
 } from '@phosphor-icons/react'
 import type { AgentRuntime, Message } from '../types'
 import { formatBranchLabel } from '../types'
-import type { LivePermission } from '../hooks/useAgentStore'
+import type { LivePermission, LiveQuestion } from '../hooks/useAgentStore'
 import { StatusBadge } from './StatusBadge'
 import { Markdown } from './Markdown'
 import { FilesChanged } from './FilesChanged'
@@ -56,6 +56,7 @@ interface DetailDrawerProps {
   agent: AgentRuntime
   messages: Message[]
   permission?: LivePermission | null
+  question?: LiveQuestion | null
   files?: FileChange[]
   tools?: ToolCall[]
   events?: EventEntry[]
@@ -65,6 +66,8 @@ interface DetailDrawerProps {
   onSendMessage?: (text: string) => void
   onApprove?: () => void
   onDeny?: () => void
+  onReplyQuestion?: (answers: string[][]) => void
+  onRejectQuestion?: () => void
   onAbort?: () => void
   onRemove?: () => void
   onCreatePr?: () => void
@@ -77,6 +80,7 @@ export function DetailDrawer({
   agent,
   messages,
   permission,
+  question,
   files = [],
   tools = [],
   events = [],
@@ -86,6 +90,8 @@ export function DetailDrawer({
   onSendMessage,
   onApprove,
   onDeny,
+  onReplyQuestion,
+  onRejectQuestion,
   onAbort,
   onRemove,
   onCreatePr,
@@ -359,8 +365,51 @@ export function DetailDrawer({
                 </div>
               )}
 
-              {/* Waiting for input card */}
-              {!permission && agent.status === 'needs_input' && (
+              {/* Question card */}
+              {!permission && question && agent.status === 'needs_input' && (
+                <div className="bg-status-input-bg/30 border border-status-input/20 rounded-lg p-3 flex flex-col gap-2">
+                  <div className="text-xs font-semibold text-status-input flex items-center gap-1.5">
+                    <ChatCircleDots size={14} weight="fill" /> Question
+                  </div>
+                  {question.questions.map((q, qi) => (
+                    <div key={qi} className="flex flex-col gap-1.5">
+                      {q.header && (
+                        <div className="text-xs font-medium text-kumo-default">{q.header}</div>
+                      )}
+                      <div className="text-xs text-kumo-subtle">{q.question}</div>
+                      {q.options.length > 0 && (
+                        <div className="flex flex-col gap-1 mt-1">
+                          {q.options.map((opt, oi) => (
+                            <button
+                              key={oi}
+                              type="button"
+                              onClick={() => onReplyQuestion?.([[opt.label]])}
+                              className="flex flex-col items-start px-2.5 py-1.5 text-left text-[11px] rounded-md bg-kumo-overlay border border-kumo-interact/20 hover:border-status-input/40 hover:bg-status-input-bg/20 transition-colors"
+                            >
+                              <span className="font-medium text-kumo-default">{opt.label}</span>
+                              {opt.description && (
+                                <span className="text-kumo-subtle">{opt.description}</span>
+                              )}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                  {onRejectQuestion && (
+                    <button
+                      type="button"
+                      onClick={onRejectQuestion}
+                      className="self-start flex items-center gap-1 px-2.5 py-1.5 mt-1 text-[11px] font-medium rounded-md bg-kumo-danger/10 border border-kumo-danger/20 text-kumo-danger hover:bg-kumo-danger/20 transition-colors"
+                    >
+                      <XCircle size={12} /> Dismiss
+                    </button>
+                  )}
+                </div>
+              )}
+
+              {/* Waiting for input (no structured question) */}
+              {!permission && !question && agent.status === 'needs_input' && (
                 <div className="bg-status-input-bg/30 border border-status-input/20 rounded-lg p-3 flex flex-col gap-2">
                   <div className="text-xs font-semibold text-status-input flex items-center gap-1.5">
                     <ChatCircleDots size={14} weight="fill" /> Waiting for your response

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -77,6 +77,27 @@ export interface LivePermission {
   createdAt: number
 }
 
+export interface LiveQuestionOption {
+  label: string
+  description: string
+}
+
+export interface LiveQuestionInfo {
+  question: string
+  header: string
+  options: LiveQuestionOption[]
+  multiple?: boolean
+  custom?: boolean
+}
+
+export interface LiveQuestion {
+  id: string
+  agentId: string
+  sessionId: string
+  questions: LiveQuestionInfo[]
+  createdAt: number
+}
+
 export interface LiveMessage {
   id: string
   role: 'user' | 'assistant'
@@ -113,6 +134,7 @@ export interface EventLogEntry {
 interface AgentStoreState {
   agents: Map<string, LiveAgent>
   permissions: Map<string, LivePermission>
+  questions: Map<string, LiveQuestion>
   messages: Map<string, LiveMessage[]> // keyed by sessionId
   fileChanges: Map<string, FileChangeRecord[]> // keyed by sessionId
   eventLog: Map<string, EventLogEntry[]> // keyed by sessionId
@@ -122,6 +144,7 @@ interface AgentStoreState {
 let state: AgentStoreState = {
   agents: new Map(),
   permissions: new Map(),
+  questions: new Map(),
   messages: new Map(),
   fileChanges: new Map(),
   eventLog: new Map(),
@@ -215,6 +238,14 @@ function generateEventSummary(type: string, props: Record<string, unknown>): str
       return `Permission requested: ${props.title ?? props.type ?? 'unknown'}`
     case 'permission.replied':
       return 'Permission resolved'
+    case 'question.asked': {
+      const questions = props.questions as Array<{ header?: string }> | undefined
+      return `Question asked: ${questions?.[0]?.header ?? 'unknown'}`
+    }
+    case 'question.replied':
+      return 'Question answered'
+    case 'question.rejected':
+      return 'Question dismissed'
     case 'file.edited':
       return `File edited: ${props.file ?? props.path ?? 'unknown'}`
     case 'file.created':
@@ -688,6 +719,63 @@ function processEvent(payload: OpenCodeEventPayload): void {
       break
     }
 
+    case 'question.asked': {
+      const requestId = props.id as string
+      const sessionId = props.sessionID as string
+      const questions = props.questions as LiveQuestionInfo[] | undefined
+
+      const agent = findAgentBySession(sessionId)
+      if (agent && questions) {
+        notifyIfNeeded(agent, 'needs_input')
+        agent.status = 'needs_input'
+        agent.blockedSince = agent.blockedSince ?? Date.now()
+        agent.lastActivityAt = Date.now()
+
+        state.questions.set(requestId, {
+          id: requestId,
+          agentId: agent.id,
+          sessionId,
+          questions,
+          createdAt: Date.now()
+        })
+
+        emit()
+      }
+      break
+    }
+
+    case 'question.replied': {
+      const requestId = props.requestID as string
+      state.questions.delete(requestId)
+
+      const sessionId = props.sessionID as string
+      const agent = findAgentBySession(sessionId)
+      if (agent) {
+        agent.status = 'running'
+        agent.blockedSince = undefined
+        agent.lastActivityAt = Date.now()
+      }
+
+      emit()
+      break
+    }
+
+    case 'question.rejected': {
+      const requestId = props.requestID as string
+      state.questions.delete(requestId)
+
+      const sessionId = props.sessionID as string
+      const agent = findAgentBySession(sessionId)
+      if (agent) {
+        agent.status = 'running'
+        agent.blockedSince = undefined
+        agent.lastActivityAt = Date.now()
+      }
+
+      emit()
+      break
+    }
+
     case 'session.diff': {
       const sessionId = props.sessionID as string
       const diffs = props.diff as Array<Record<string, unknown>> | undefined
@@ -809,6 +897,12 @@ function handleSessionReset(payload: { id: string; sessionId: string; oldSession
     }
   }
 
+  for (const [questionId, question] of state.questions.entries()) {
+    if (question.agentId === payload.id || question.sessionId === agent.sessionId) {
+      state.questions.delete(questionId)
+    }
+  }
+
   // Update agent with new session
   agent.sessionId = payload.sessionId
   agent.branchName = payload.branchName
@@ -840,6 +934,12 @@ function removeAgentState(agentId: string): void {
   for (const [permissionId, permission] of state.permissions.entries()) {
     if (permission.agentId === agentId || permission.sessionId === agent.sessionId) {
       state.permissions.delete(permissionId)
+    }
+  }
+
+  for (const [questionId, question] of state.questions.entries()) {
+    if (question.agentId === agentId || question.sessionId === agent.sessionId) {
+      state.questions.delete(questionId)
     }
   }
 }
@@ -1022,6 +1122,27 @@ export function useAgentStore() {
       }
 
       if (shouldEmit) emit()
+
+      // Fetch pending questions for agents that are in needs_input state
+      try {
+        const questionsResult = await window.api.listQuestions()
+        if (!cancelled && questionsResult.ok && questionsResult.data) {
+          for (const entry of questionsResult.data as Array<{ agentId: string; questions: Array<{ id: string; sessionID: string; questions: LiveQuestionInfo[] }> }>) {
+            for (const q of entry.questions) {
+              state.questions.set(q.id, {
+                id: q.id,
+                agentId: entry.agentId,
+                sessionId: q.sessionID,
+                questions: q.questions,
+                createdAt: Date.now()
+              })
+            }
+          }
+          emit()
+        }
+      } catch {
+        // Questions API may not be available on older servers
+      }
     }
 
     const cleanups = [
@@ -1045,6 +1166,7 @@ export function useAgentStore() {
 
   const agents = Array.from(storeState.agents.values())
   const permissions = Array.from(storeState.permissions.values())
+  const questions = Array.from(storeState.questions.values())
 
   const launchAgent = useCallback(async (directory: string, prompt?: string, title?: string, model?: string) => {
     if (!window.api) return
@@ -1134,6 +1256,38 @@ export function useAgentStore() {
     return window.api.respondToPermission(agentId, permissionId, response)
   }, [])
 
+  const replyToQuestion = useCallback(async (agentId: string, requestId: string, answers: string[][]) => {
+    if (!window.api) return
+
+    // Optimistically clear question and set running
+    state.questions.delete(requestId)
+    const agent = state.agents.get(agentId)
+    if (agent) {
+      agent.status = 'running'
+      agent.blockedSince = undefined
+      agent.lastActivityAt = Date.now()
+    }
+    emit()
+
+    return window.api.replyToQuestion(agentId, requestId, answers)
+  }, [])
+
+  const rejectQuestion = useCallback(async (agentId: string, requestId: string) => {
+    if (!window.api) return
+
+    // Optimistically clear question and set running
+    state.questions.delete(requestId)
+    const agent = state.agents.get(agentId)
+    if (agent) {
+      agent.status = 'running'
+      agent.blockedSince = undefined
+      agent.lastActivityAt = Date.now()
+    }
+    emit()
+
+    return window.api.rejectQuestion(agentId, requestId)
+  }, [])
+
   const abortAgent = useCallback(async (agentId: string) => {
     if (!window.api) return
     return window.api.abortAgent(agentId)
@@ -1193,6 +1347,7 @@ export function useAgentStore() {
   return {
     agents,
     permissions,
+    questions,
     healthy: storeState.healthy,
     launchAgent,
     sendMessage,
@@ -1201,6 +1356,8 @@ export function useAgentStore() {
     prepareFreshAgent,
     resetSession,
     respondToPermission,
+    replyToQuestion,
+    rejectQuestion,
     abortAgent,
     removeAgent,
     renameAgent,

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -28,6 +28,9 @@ export interface OrchestratorApi {
   listAgents: () => Promise<IpcResult<ListAgentsPayload>>
   updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string }) => Promise<IpcResult>
   getStatuses: () => Promise<IpcResult<AgentStatusesPayload>>
+  replyToQuestion: (agentId: string, requestId: string, answers: string[][]) => Promise<IpcResult>
+  rejectQuestion: (agentId: string, requestId: string) => Promise<IpcResult>
+  listQuestions: () => Promise<IpcResult<PendingQuestionsPayload>>
   listRuntimes: () => Promise<IpcResult>
   stopRuntime: (runtimeId: string) => Promise<IpcResult>
   listAllProviders: () => Promise<IpcResult>
@@ -149,6 +152,34 @@ export type AgentStatusesPayload = Record<string, {
   status: {
     type: string
   }
+}>
+
+export interface QuestionOption {
+  label: string
+  description: string
+}
+
+export interface QuestionInfo {
+  question: string
+  header: string
+  options: QuestionOption[]
+  multiple?: boolean
+  custom?: boolean
+}
+
+export interface QuestionRequest {
+  id: string
+  sessionID: string
+  questions: QuestionInfo[]
+  tool?: {
+    messageID: string
+    callID: string
+  }
+}
+
+export type PendingQuestionsPayload = Array<{
+  agentId: string
+  questions: QuestionRequest[]
 }>
 
 export interface RuntimeStartedPayload {


### PR DESCRIPTION
The app was using @opencode-ai/sdk/client (v1) which has no question support — SessionStatus only defines idle/retry/busy with no waiting type. Questions in OpenCode use a separate event channel (question.asked, question.replied, question.rejected) that only exists in the v2 SDK.

Migrates all SDK imports and API calls from v1 to v2, adds question event handling in the store, IPC plumbing for reply/reject, and renders structured question cards with clickable options in the DetailDrawer.

<img width="1418" height="687" alt="image" src="https://github.com/user-attachments/assets/1c233827-9f8b-420c-bab3-2c6dd331c383" />
