### PR TITLE
Fix settings icon shifting when row action icons appear

### DIFF
--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -509,7 +509,7 @@ function AgentRow({
         </span>
       </td>
       <td className="px-3 py-2">
-        <div className="flex items-center gap-1">
+        <div className="flex items-center justify-end gap-1">
           <RowActions
             agent={agent}
             onApprove={onApprove}


### PR DESCRIPTION
Right-align the actions container in FleetTable rows so the always-visible gear icon stays pinned to the right edge regardless of how many conditional status icons are rendered.