### PR TITLE
Fix model column not updating on selection or change

### DIFF
--- a/src/__tests__/format-model-name.test.ts
+++ b/src/__tests__/format-model-name.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { formatModelName } from '../renderer/src/hooks/useAgentStore'
+
+describe('formatModelName', () => {
+  describe('Claude models', () => {
+    it('extracts family and major version from full model ID', () => {
+      expect(formatModelName('claude-sonnet-4-20250514')).toBe('sonnet-4')
+      expect(formatModelName('claude-opus-4-20250515')).toBe('opus-4')
+      expect(formatModelName('claude-haiku-3-20240307')).toBe('haiku-3')
+    })
+
+    it('distinguishes minor versions from date suffixes', () => {
+      expect(formatModelName('claude-opus-4-5-20250630')).toBe('opus-4.5')
+      expect(formatModelName('claude-sonnet-4-1-20250601')).toBe('sonnet-4.1')
+    })
+
+    it('handles provider-prefixed model IDs', () => {
+      expect(formatModelName('anthropic/claude-sonnet-4-20250514')).toBe('sonnet-4')
+      expect(formatModelName('anthropic/claude-opus-4-5-20250630')).toBe('opus-4.5')
+    })
+
+    it('handles bare family-version strings', () => {
+      expect(formatModelName('sonnet-4')).toBe('sonnet-4')
+      expect(formatModelName('opus-4')).toBe('opus-4')
+    })
+  })
+
+  describe('GPT models', () => {
+    it('extracts gpt model names', () => {
+      expect(formatModelName('gpt-4-turbo')).toBe('gpt-4-turbo')
+      expect(formatModelName('gpt-4o')).toBe('gpt-4o')
+      expect(formatModelName('gpt-4o-mini')).toBe('gpt-4o-mini')
+    })
+  })
+
+  describe('OpenAI o-series', () => {
+    it('extracts o-series model names', () => {
+      expect(formatModelName('o1-preview')).toBe('o1-preview')
+      expect(formatModelName('o1-mini')).toBe('o1-mini')
+      expect(formatModelName('o3')).toBe('o3')
+    })
+  })
+
+  describe('Gemini models', () => {
+    it('extracts gemini model names', () => {
+      expect(formatModelName('gemini-1.5-pro')).toBe('gemini-1.5-pro')
+      expect(formatModelName('gemini-2.0-flash')).toBe('gemini-2.0-flash')
+    })
+  })
+
+  describe('unknown models', () => {
+    it('returns short names as-is', () => {
+      expect(formatModelName('some-model')).toBe('some-model')
+    })
+
+    it('truncates long unknown names to 16 chars', () => {
+      expect(formatModelName('very-long-unknown-model-name-here')).toBe('very-long-unknow')
+    })
+  })
+})

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -494,7 +494,9 @@ export function App() {
         }
         // Direct model set: /model provider/model-id
         const updateResult = await window.api.updateConfig(agentId, { model: commandArgs })
-        if (!updateResult.ok) {
+        if (updateResult.ok) {
+          store.setAgentModel(agentId, commandArgs)
+        } else {
           console.error('Failed to update model:', updateResult.error)
         }
         return true
@@ -663,6 +665,11 @@ export function App() {
     if (result?.ok && result.data) {
       const data = result.data as { id: string }
       setSelectedAgentId(data.id)
+
+      // Optimistically show the selected model in the table immediately
+      if (model && model !== 'auto') {
+        store.setAgentModel(data.id, model)
+      }
     }
   }, [store])
 
@@ -912,6 +919,7 @@ export function App() {
             if (!selectedAgentId) return
             const result = await window.api.updateConfig(selectedAgentId, { model: modelPath })
             if (result.ok) {
+              store.setAgentModel(selectedAgentId, modelPath)
               setShowModelPicker(false)
             } else {
               console.error('Failed to set model:', result.error)

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -492,12 +492,12 @@ function AgentRow({
       <td className="px-3 py-2 font-mono text-[11px] text-kumo-subtle">
         {formatBranchLabel(agent)}
       </td>
-      <td className="px-3 py-2">
+      <td className="px-3 py-2 min-w-[7rem] max-w-[10rem]">
         {agent.model && agent.model !== 'starting...' && (
           <button
             onClick={(event) => { event.stopPropagation(); onChangeModel?.() }}
-            className="font-mono text-[10px] px-1.5 py-0.5 bg-kumo-fill rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors"
-            title="Click to change model"
+            className="font-mono text-[10px] px-1.5 py-0.5 bg-kumo-fill rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors max-w-full truncate block"
+            title={agent.model}
           >
             {agent.model}
           </button>

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -1024,10 +1024,17 @@ function mapSessionStatus(statusType: string): AgentStatus {
   }
 }
 
-function formatModelName(modelId: string): string {
-  // Claude models: "claude-sonnet-4-20250514" -> "sonnet-4"
-  const claudeMatch = modelId.match(/(sonnet|opus|haiku)-?(\d[\d.]*)?/)
-  if (claudeMatch) return claudeMatch[0]
+export function formatModelName(modelId: string): string {
+  // Claude models: "claude-sonnet-4-20250514" -> "sonnet-4", "claude-opus-4-5-20250630" -> "opus-4.5"
+  const claudeMatch = modelId.match(/(sonnet|opus|haiku)-(\d+)(?:-(\d+))?/)
+  if (claudeMatch) {
+    const [, family, major, minor] = claudeMatch
+    // Skip date-like minor segments (6+ digits = date suffix, not a version)
+    if (minor && minor.length < 6) {
+      return `${family}-${major}.${minor}`
+    }
+    return `${family}-${major}`
+  }
 
   // GPT models: "gpt-4-turbo", "gpt-4o" -> "gpt-4-turbo", "gpt-4o"
   const gptMatch = modelId.match(/gpt-[\w.-]+/)
@@ -1335,6 +1342,13 @@ export function useAgentStore() {
     return extractToolCallsFromMessages(messages)
   }, [storeState])
 
+  const setAgentModel = useCallback((agentId: string, modelPath: string) => {
+    const agent = state.agents.get(agentId)
+    if (!agent) return
+    agent.model = formatModelName(modelPath)
+    emit()
+  }, [])
+
   const renameAgent = useCallback((agentId: string, newName: string) => {
     const agent = state.agents.get(agentId)
     if (!agent) return
@@ -1361,6 +1375,7 @@ export function useAgentStore() {
     abortAgent,
     removeAgent,
     renameAgent,
+    setAgentModel,
     selectDirectory,
     getMessagesForSession,
     getFileChangesForSession,


### PR DESCRIPTION
The model column was only populated from SSE message events, so it stayed empty when launching with a model or changing model mid-session. Add setAgentModel to the store and call it optimistically from launch, model picker, and /model command. Also fix formatModelName regex to distinguish opus-4 from opus-4.5, and add truncation with tooltip for long model names.