### PR TITLE
Fix agent stuck in 'running' state after stop, preventing resume

### DIFF
--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -471,8 +471,8 @@ export function DetailDrawer({
           {onDeny && (
             <ActionButton icon={<XCircle size={12} />} label="Deny" variant="deny" onClick={onDeny} />
           )}
-          {onAbort && (agent.status === 'running' || agent.status === 'needs_approval' || agent.status === 'needs_input') && (
-            <ActionButton icon={<Square size={12} weight="fill" />} label="Stop" onClick={onAbort} />
+          {onAbort && (agent.status === 'running' || agent.status === 'needs_approval' || agent.status === 'needs_input' || agent.status === 'stopping') && (
+            <ActionButton icon={<Square size={12} weight="fill" />} label={agent.status === 'stopping' ? 'Stopping…' : 'Stop'} onClick={onAbort} disabled={agent.status === 'stopping'} />
           )}
           <div className="flex-1" />
           {onChangeModel && (
@@ -660,11 +660,13 @@ function ActionButton({
   icon,
   label,
   variant = 'default',
+  disabled = false,
   onClick
 }: {
   icon: React.ReactNode
   label: string
   variant?: 'default' | 'approve' | 'deny'
+  disabled?: boolean
   onClick?: () => void
 }) {
   const styles = {
@@ -676,7 +678,8 @@ function ActionButton({
   return (
     <button
       onClick={onClick}
-      className={`flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md border transition-colors ${styles[variant]}`}
+      disabled={disabled}
+      className={`flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md border transition-colors ${styles[variant]} ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
     >
       {icon}
       {label}

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -383,6 +383,7 @@ function ContextMenu({
   }, [posX, posY])
 
   const isRunning = agent.status === 'running' || agent.status === 'needs_approval' || agent.status === 'needs_input'
+  const isStopping = agent.status === 'stopping'
 
   const itemClass = 'flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] text-kumo-default rounded hover:bg-kumo-fill transition-colors text-left'
   const dangerItemClass = 'flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] text-kumo-danger rounded hover:bg-kumo-danger/10 transition-colors text-left'
@@ -407,9 +408,9 @@ function ContextMenu({
           <Check size={13} weight="bold" /> Approve
         </button>
       )}
-      {isRunning && (
-        <button className={itemClass} onClick={onStop}>
-          <Square size={13} weight="fill" /> Stop
+      {(isRunning || isStopping) && (
+        <button className={itemClass} onClick={onStop} disabled={isStopping}>
+          <Square size={13} weight="fill" /> {isStopping ? 'Stopping…' : 'Stop'}
         </button>
       )}
       <button className={itemClass} onClick={onCreatePr}>
@@ -585,10 +586,11 @@ function RowActions({
       >
         <ArrowRight size={12} weight="bold" />
       </button>
-      {(agent.status === 'running' || agent.status === 'needs_input' || agent.status === 'needs_approval') && (
+      {(agent.status === 'running' || agent.status === 'needs_input' || agent.status === 'needs_approval' || agent.status === 'stopping') && (
         <button
-          className={buttonBase}
-          title="Stop"
+          className={`${buttonBase} ${agent.status === 'stopping' ? 'opacity-50 cursor-not-allowed' : ''}`}
+          title={agent.status === 'stopping' ? 'Stopping…' : 'Stop'}
+          disabled={agent.status === 'stopping'}
           onClick={(event) => { event.stopPropagation(); onStop?.() }}
         >
           <Square size={12} weight="fill" />

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -482,6 +482,11 @@ function processEvent(payload: OpenCodeEventPayload): void {
       const agent = findAgentBySession(sessionId)
       if (agent) {
         const newStatus = mapSessionStatus(statusInfo.type)
+        // While stopping, only allow transitions to terminal states (idle/completed/errored).
+        // Ignore 'running' or 'needs_input' events that may arrive after abort was sent.
+        if (agent.status === 'stopping' && newStatus !== 'idle' && newStatus !== 'completed' && newStatus !== 'errored') {
+          break
+        }
         if (agent.status !== newStatus) {
           notifyIfNeeded(agent, newStatus)
           agent.status = newStatus
@@ -643,11 +648,11 @@ function processEvent(payload: OpenCodeEventPayload): void {
           message.parts.push(newPart)
         }
 
-        // Update agent activity (but don't clobber blocked states like needs_input/needs_approval)
+        // Update agent activity (but don't clobber blocked/stopping states)
         const agent = findAgentBySession(sessionId)
         if (agent) {
           agent.lastActivityAt = Date.now()
-          if (agent.status !== 'needs_input' && agent.status !== 'needs_approval') {
+          if (agent.status !== 'needs_input' && agent.status !== 'needs_approval' && agent.status !== 'stopping') {
             agent.status = 'running'
             agent.blockedSince = undefined
           }
@@ -710,8 +715,10 @@ function processEvent(payload: OpenCodeEventPayload): void {
       const sessionId = props.sessionID as string
       const agent = findAgentBySession(sessionId)
       if (agent) {
-        agent.status = 'running'
-        agent.blockedSince = undefined
+        if (agent.status !== 'stopping') {
+          agent.status = 'running'
+          agent.blockedSince = undefined
+        }
         agent.lastActivityAt = Date.now()
       }
 
@@ -751,8 +758,10 @@ function processEvent(payload: OpenCodeEventPayload): void {
       const sessionId = props.sessionID as string
       const agent = findAgentBySession(sessionId)
       if (agent) {
-        agent.status = 'running'
-        agent.blockedSince = undefined
+        if (agent.status !== 'stopping') {
+          agent.status = 'running'
+          agent.blockedSince = undefined
+        }
         agent.lastActivityAt = Date.now()
       }
 
@@ -767,8 +776,10 @@ function processEvent(payload: OpenCodeEventPayload): void {
       const sessionId = props.sessionID as string
       const agent = findAgentBySession(sessionId)
       if (agent) {
-        agent.status = 'running'
-        agent.blockedSince = undefined
+        if (agent.status !== 'stopping') {
+          agent.status = 'running'
+          agent.blockedSince = undefined
+        }
         agent.lastActivityAt = Date.now()
       }
 
@@ -1199,8 +1210,11 @@ export function useAgentStore() {
   const sendMessage = useCallback(async (agentId: string, text: string) => {
     if (!window.api) return
 
-    // Optimistically update task summary and status
+    // Don't allow sending while agent is stopping
     const agent = state.agents.get(agentId)
+    if (agent?.status === 'stopping') return
+
+    // Optimistically update task summary and status
     if (agent && text.trim()) {
       agent.taskSummary = text.trim().slice(0, 120)
       agent.status = 'running'
@@ -1290,7 +1304,42 @@ export function useAgentStore() {
 
   const abortAgent = useCallback(async (agentId: string) => {
     if (!window.api) return
-    return window.api.abortAgent(agentId)
+
+    // Optimistically set 'stopping' so the UI reflects intent immediately
+    const agent = state.agents.get(agentId)
+    if (agent) {
+      agent.status = 'stopping'
+      agent.lastActivityAt = Date.now()
+      emit()
+    }
+
+    const result = await window.api.abortAgent(agentId)
+
+    // If abort failed, the server never got the request — fall back to idle
+    // so the user isn't stuck in a phantom 'stopping'/'running' state
+    if (!result.ok) {
+      const agentAfter = state.agents.get(agentId)
+      if (agentAfter && agentAfter.status === 'stopping') {
+        agentAfter.status = 'idle'
+        agentAfter.lastActivityAt = Date.now()
+        emit()
+      }
+    } else {
+      // Safety timeout: if the server acknowledged the abort but the SSE event
+      // (session.idle/completed) never arrives (broken stream, runtime crash),
+      // force-transition to idle so the user isn't stuck forever.
+      setTimeout(() => {
+        const agentAfter = state.agents.get(agentId)
+        if (agentAfter && agentAfter.status === 'stopping') {
+          console.warn(`[AgentStore] Agent ${agentId} stuck in 'stopping' for 10s, forcing idle`)
+          agentAfter.status = 'idle'
+          agentAfter.lastActivityAt = Date.now()
+          emit()
+        }
+      }, 10_000)
+    }
+
+    return result
   }, [])
 
   const resetSession = useCallback(async (agentId: string, prompt?: string) => {


### PR DESCRIPTION
abortAgent() never set the 'stopping' status, so the agent stayed 'running' until an SSE event arrived. Multiple race conditions (late message.part.updated, permission.replied, question.replied events) could flip it back to 'running' even after abort. If the SSE stream was broken, the agent was stuck forever.

Now abortAgent sets 'stopping' optimistically, guards all event handlers from overwriting it with 'running', falls back to 'idle' on abort failure, and has a 10s safety timeout for when the server never responds.