### PR TITLE
Fix notification clicks not navigating to the correct agent

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -545,6 +545,16 @@ export function registerIpcHandlers(): void {
     }
   })
 
+  ipcMain.handle('notifications:get-pending-agent', async () => {
+    try {
+      const agentId = notificationService.getPendingAgentId()
+      return { ok: true, data: agentId }
+    } catch (error) {
+      console.error('[IPC] notifications:get-pending-agent failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
   // ── App Info ──
 
   ipcMain.handle('app:version', () => {

--- a/src/main/services/notification-service.ts
+++ b/src/main/services/notification-service.ts
@@ -49,6 +49,12 @@ class NotificationService {
 
   private sentNotifications = new Map<string, number>()
 
+  // Prevent Notification objects from being garbage-collected before the
+  // user interacts with them.  Without this reference the 'click' handler
+  // is silently lost on macOS because V8 collects the otherwise-unreachable
+  // Notification instance.
+  private activeNotifications = new Set<Notification>()
+
   setPreference(eventType: NotifiableEventType, enabled: boolean): void {
     this.preferences[eventType] = enabled
   }
@@ -137,20 +143,60 @@ class NotificationService {
       silent: false
     })
 
+    // Prevent GC from collecting the notification before the user clicks it.
+    // Without this reference the 'click' handler is silently lost because V8
+    // collects the otherwise-unreachable Notification instance while the OS
+    // banner is still visible.
+    this.activeNotifications.add(notification)
+
     notification.on('click', () => {
+      console.log(`[NotificationService] Notification clicked for agent ${agentId}`)
       this.handleNotificationClick(agentId)
+      this.activeNotifications.delete(notification)
+    })
+
+    // On macOS the 'close' event fires when the banner auto-dismisses (~5s),
+    // but the user can still click the notification later in Notification
+    // Center.  Do NOT remove the reference on 'close' — that would allow GC
+    // to collect the object and silently drop the click handler.  Instead,
+    // clean up stale entries periodically.
+    notification.on('close', () => {
+      // Schedule cleanup after a generous window so clicks from Notification
+      // Center still work.  5 minutes is long enough for any realistic
+      // interaction; the Set is tiny so the memory cost is negligible.
+      setTimeout(() => {
+        this.activeNotifications.delete(notification)
+      }, 5 * 60 * 1000)
     })
 
     notification.show()
   }
 
+  // Stores the agent ID from the most recent notification click so the
+  // renderer can pull it if the initial IPC send arrives before the window
+  // is ready (e.g. waking from background on macOS).
+  private pendingAgentId: string | null = null
+
+  getPendingAgentId(): string | null {
+    const id = this.pendingAgentId
+    this.pendingAgentId = null
+    return id
+  }
+
   private handleNotificationClick(agentId: string): void {
     const windows = BrowserWindow.getAllWindows()
     if (windows.length === 0) {
+      console.warn('[NotificationService] No windows available for notification click')
       return
     }
 
     const mainWindow = windows[0]
+
+    console.log(`[NotificationService] Handling click: agentId=${agentId}, windowFocused=${mainWindow.isFocused()}, minimized=${mainWindow.isMinimized()}`)
+
+    // Stash the agent ID so the renderer can pull it on focus if the
+    // push-based IPC message gets lost during the window wake-up.
+    this.pendingAgentId = agentId
 
     // app.show() activates the Electron app at the OS level (macOS dock bounce),
     // which is required before mainWindow.focus() will actually bring it to front

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -149,6 +149,9 @@ const api = {
   setNotificationPreference: (eventType: string, enabled: boolean): Promise<IpcResult> =>
     ipcRenderer.invoke('notifications:set-preference', eventType, enabled),
 
+  getPendingNotificationAgent: (): Promise<IpcResult<string | null>> =>
+    ipcRenderer.invoke('notifications:get-pending-agent'),
+
   // ── App Info ──
   getVersion: (): Promise<IpcResult<string>> =>
     ipcRenderer.invoke('app:version'),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -132,12 +132,39 @@ export function App() {
   }, [])
 
   // ── Navigate to agent when desktop notification is clicked ──
+  const navigateToAgent = useCallback((agentId: string) => {
+    console.log('[App] Navigating to agent:', agentId)
+    setFilter('all')
+    setSearchQuery('')
+    setSelectedAgentId(agentId)
+  }, [])
+
+  // Push path: main process sends agentId directly via IPC
   useEffect(() => {
     if (!window.api?.onNotificationSelectAgent) return
     return window.api.onNotificationSelectAgent((data) => {
-      setSelectedAgentId(data.agentId)
+      console.log('[App] Notification select-agent received (push):', data.agentId)
+      navigateToAgent(data.agentId)
     })
-  }, [])
+  }, [navigateToAgent])
+
+  // Pull path: when the window gains focus, check if there's a pending
+  // notification click that the push path may have missed (e.g. the
+  // renderer was throttled while the app was in the background on macOS).
+  useEffect(() => {
+    if (!window.api?.getPendingNotificationAgent) return
+
+    const checkPending = async (): Promise<void> => {
+      const result = await window.api.getPendingNotificationAgent()
+      if (result.ok && result.data) {
+        console.log('[App] Notification select-agent received (pull on focus):', result.data)
+        navigateToAgent(result.data)
+      }
+    }
+
+    window.addEventListener('focus', checkPending)
+    return () => window.removeEventListener('focus', checkPending)
+  }, [navigateToAgent])
 
   // ── Convert live agents to AgentRuntime shape ──
   const liveAgentsAsRuntimes: AgentRuntime[] = useMemo(() => {
@@ -275,9 +302,15 @@ export function App() {
     return agents
   }, [displayAgents, filter, searchQuery, sortColumn, sortDirection])
 
+  // Look up in displayAgents first (preferred — includes latest derived fields),
+  // but fall back to the full unfiltered list so notification-driven navigation
+  // always finds the agent even if a filter or search would otherwise hide it.
   const selectedAgent = useMemo(
-    () => displayAgents.find((agent) => agent.id === selectedAgentId) ?? null,
-    [displayAgents, selectedAgentId]
+    () =>
+      displayAgents.find((agent) => agent.id === selectedAgentId)
+      ?? liveAgentsAsRuntimes.find((agent) => agent.id === selectedAgentId)
+      ?? null,
+    [displayAgents, liveAgentsAsRuntimes, selectedAgentId]
   )
 
   // ── Messages for selected agent ──

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -58,6 +58,7 @@ export interface OrchestratorApi {
   // ── Notifications ──
   getNotificationPreferences: () => Promise<IpcResult<NotificationPreferences>>
   setNotificationPreference: (eventType: NotifiableEventType, enabled: boolean) => Promise<IpcResult>
+  getPendingNotificationAgent: () => Promise<IpcResult<string | null>>
 
   // ── App Info ──
   getVersion: () => Promise<IpcResult<string>>


### PR DESCRIPTION
Two delivery mechanisms ensure the renderer always navigates to the clicked agent:

1. Push: main process sends 'notification:select-agent' IPC immediately on click (existing path, now with GC fix).
2. Pull: main process stashes the agentId; renderer polls for it on window 'focus' via a new 'notifications:get-pending-agent' invoke. This catches the case where the push message arrives while the renderer is still waking from background throttling on macOS.

Also fixes:
- Notification objects are retained in a Set to prevent V8 from GC-ing them (and their click handlers) while the macOS banner is visible.
- The 'close' cleanup is delayed 5 min so Notification Center clicks still work after the banner auto-dismisses.
- Renderer clears active filter/search on notification click.
- selectedAgent lookup falls back to the unfiltered agent list.