### PR TITLE
Add manual mark-as-completed status with toggle and dedicated filter

### DIFF
--- a/src/__tests__/filter-sort.test.ts
+++ b/src/__tests__/filter-sort.test.ts
@@ -9,11 +9,12 @@ type AgentStatus =
   | 'needs_approval'
   | 'idle'
   | 'completed'
+  | 'completed_manual'
   | 'errored'
   | 'disconnected'
   | 'stopping'
 
-type FilterValue = 'all' | 'blocked' | 'running' | 'idle' | string
+type FilterValue = 'all' | 'blocked' | 'running' | 'idle' | 'completed' | string
 
 interface AgentRow {
   id: string
@@ -37,10 +38,16 @@ function matchesFilter(agent: { status: AgentStatus; projectName: string }, filt
     case 'running':
       return agent.status === 'running'
     case 'idle':
-      return agent.status === 'idle' || agent.status === 'completed'
+      return agent.status === 'idle'
+    case 'completed':
+      return agent.status === 'completed' || agent.status === 'completed_manual'
     default:
       return agent.projectName === filter
   }
+}
+
+function canToggleManualComplete(status: AgentStatus): boolean {
+  return status === 'idle' || status === 'completed' || status === 'completed_manual'
 }
 
 // ── Sorting and search logic ──
@@ -123,7 +130,7 @@ describe('matchesFilter', () => {
   it('returns true for "all" filter regardless of status', () => {
     const statuses: AgentStatus[] = [
       'starting', 'running', 'needs_input', 'needs_approval',
-      'idle', 'completed', 'errored', 'disconnected', 'stopping'
+      'idle', 'completed', 'completed_manual', 'errored', 'disconnected', 'stopping'
     ]
     for (const status of statuses) {
       expect(matchesFilter({ status, projectName: 'proj' }, 'all')).toBe(true)
@@ -145,11 +152,20 @@ describe('matchesFilter', () => {
     expect(matchesFilter({ status: 'needs_input', projectName: 'proj' }, 'running')).toBe(false)
   })
 
-  it('returns true for "idle" filter when idle or completed', () => {
+  it('returns true for "idle" filter only when idle', () => {
     expect(matchesFilter({ status: 'idle', projectName: 'proj' }, 'idle')).toBe(true)
-    expect(matchesFilter({ status: 'completed', projectName: 'proj' }, 'idle')).toBe(true)
+    expect(matchesFilter({ status: 'completed', projectName: 'proj' }, 'idle')).toBe(false)
+    expect(matchesFilter({ status: 'completed_manual', projectName: 'proj' }, 'idle')).toBe(false)
     expect(matchesFilter({ status: 'running', projectName: 'proj' }, 'idle')).toBe(false)
     expect(matchesFilter({ status: 'errored', projectName: 'proj' }, 'idle')).toBe(false)
+  })
+
+  it('returns true for "completed" filter when completed or completed_manual', () => {
+    expect(matchesFilter({ status: 'completed', projectName: 'proj' }, 'completed')).toBe(true)
+    expect(matchesFilter({ status: 'completed_manual', projectName: 'proj' }, 'completed')).toBe(true)
+    expect(matchesFilter({ status: 'idle', projectName: 'proj' }, 'completed')).toBe(false)
+    expect(matchesFilter({ status: 'running', projectName: 'proj' }, 'completed')).toBe(false)
+    expect(matchesFilter({ status: 'errored', projectName: 'proj' }, 'completed')).toBe(false)
   })
 
   it('matches by project name for custom filter values', () => {
@@ -301,5 +317,31 @@ describe('sortUrgentFirst', () => {
     sortUrgentFirst(agents)
     expect(agents[0].id).toBe(original[0].id)
     expect(agents[1].id).toBe(original[1].id)
+  })
+
+  it('does not treat completed_manual as urgent', () => {
+    const running = createAgent({ id: 'r', status: 'running' })
+    const manual = createAgent({ id: 'm', status: 'completed_manual' })
+    const blocked = createAgent({ id: 'b', status: 'needs_input' })
+    const sorted = sortUrgentFirst([manual, running, blocked])
+    expect(sorted[0].id).toBe('b')
+  })
+})
+
+describe('canToggleManualComplete', () => {
+  it('returns true for idle, completed, and completed_manual', () => {
+    expect(canToggleManualComplete('idle')).toBe(true)
+    expect(canToggleManualComplete('completed')).toBe(true)
+    expect(canToggleManualComplete('completed_manual')).toBe(true)
+  })
+
+  it('returns false for active/blocked statuses', () => {
+    expect(canToggleManualComplete('running')).toBe(false)
+    expect(canToggleManualComplete('starting')).toBe(false)
+    expect(canToggleManualComplete('needs_input')).toBe(false)
+    expect(canToggleManualComplete('needs_approval')).toBe(false)
+    expect(canToggleManualComplete('errored')).toBe(false)
+    expect(canToggleManualComplete('disconnected')).toBe(false)
+    expect(canToggleManualComplete('stopping')).toBe(false)
   })
 })

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -413,7 +413,8 @@ export function App() {
       all: displayAgents.length,
       blocked: displayAgents.filter((agent) => agent.status === 'needs_input' || agent.status === 'needs_approval').length,
       running: displayAgents.filter((agent) => agent.status === 'running').length,
-      idle: displayAgents.filter((agent) => agent.status === 'idle' || agent.status === 'completed').length
+      idle: displayAgents.filter((agent) => agent.status === 'idle').length,
+      completed: displayAgents.filter((agent) => agent.status === 'completed' || agent.status === 'completed_manual').length
     }),
     [displayAgents]
   )
@@ -464,6 +465,10 @@ export function App() {
   const handleRowOpen = useCallback((agentId: string) => {
     setSelectedAgentId(agentId)
   }, [])
+
+  const handleToggleComplete = useCallback((agentId: string) => {
+    store.toggleManualComplete(agentId)
+  }, [store])
 
   const handleRemoveAgent = useCallback(async (agentId: string) => {
     const liveAgent = findLiveAgent(agentId)
@@ -863,6 +868,7 @@ export function App() {
           setSelectedAgentId(agentId)
           setShowModelPicker(true)
         }}
+        onToggleComplete={handleToggleComplete}
       />
 
       <StatusBar
@@ -894,6 +900,7 @@ export function App() {
           onOpenInEditor={handleOpenInEditor}
           onChangeModel={() => setShowModelPicker(true)}
           onOpenTerminal={handleOpenTerminalForDrawer}
+          onToggleComplete={() => handleToggleComplete(selectedAgent.id)}
         />
       )}
 

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -3,8 +3,10 @@ import {
   X,
   Square,
   Check,
+  CheckCircle,
   XCircle,
   ArrowSquareOut,
+  ArrowCounterClockwise,
   GitPullRequest,
   Terminal,
   Wrench,
@@ -17,7 +19,7 @@ import {
   PaperPlaneTilt
 } from '@phosphor-icons/react'
 import type { AgentRuntime, Message } from '../types'
-import { formatBranchLabel } from '../types'
+import { formatBranchLabel, canToggleManualComplete } from '../types'
 import type { LivePermission, LiveQuestion } from '../hooks/useAgentStore'
 import { StatusBadge } from './StatusBadge'
 import { Markdown } from './Markdown'
@@ -75,6 +77,7 @@ interface DetailDrawerProps {
   onOpenInEditor?: () => void
   onChangeModel?: () => void
   onOpenTerminal?: () => void
+  onToggleComplete?: () => void
 }
 
 export function DetailDrawer({
@@ -98,7 +101,8 @@ export function DetailDrawer({
   onCreatePr,
   onOpenInEditor,
   onChangeModel,
-  onOpenTerminal
+  onOpenTerminal,
+  onToggleComplete
 }: DetailDrawerProps) {
   const [inputText, setInputText] = useState('')
   const [activeTab, setActiveTab] = useState<TabKey>('transcript')
@@ -440,6 +444,13 @@ export function DetailDrawer({
           )}
           {onAbort && (agent.status === 'running' || agent.status === 'needs_approval' || agent.status === 'needs_input' || agent.status === 'stopping') && (
             <ActionButton icon={<Square size={12} weight="fill" />} label={agent.status === 'stopping' ? 'Stopping…' : 'Stop'} onClick={onAbort} disabled={agent.status === 'stopping'} />
+          )}
+          {onToggleComplete && canToggleManualComplete(agent.status) && (
+            <ActionButton
+              icon={agent.status === 'completed_manual' ? <ArrowCounterClockwise size={12} /> : <CheckCircle size={12} />}
+              label={agent.status === 'completed_manual' ? 'Unmark' : 'Complete'}
+              onClick={onToggleComplete}
+            />
           )}
           <div className="flex-1" />
           {onChangeModel && (

--- a/src/renderer/src/components/FilterBar.tsx
+++ b/src/renderer/src/components/FilterBar.tsx
@@ -1,7 +1,7 @@
 import { MagnifyingGlass } from '@phosphor-icons/react'
 import type { AgentStatus } from '../types'
 
-export type FilterValue = 'all' | 'blocked' | 'running' | 'idle' | string
+export type FilterValue = 'all' | 'blocked' | 'running' | 'idle' | 'completed' | string
 
 interface FilterBarProps {
   filter: FilterValue
@@ -13,6 +13,7 @@ interface FilterBarProps {
     blocked: number
     running: number
     idle: number
+    completed: number
   }
   projects: string[]
 }
@@ -47,6 +48,7 @@ export function FilterBar({
       <FilterPill label={`Blocked (${counts.blocked})`} active={filter === 'blocked'} onClick={() => onFilterChange('blocked')} />
       <FilterPill label={`Running (${counts.running})`} active={filter === 'running'} onClick={() => onFilterChange('running')} />
       <FilterPill label={`Idle (${counts.idle})`} active={filter === 'idle'} onClick={() => onFilterChange('idle')} />
+      <FilterPill label={`Completed (${counts.completed})`} active={filter === 'completed'} onClick={() => onFilterChange('completed')} />
 
       <div className="w-px h-5 bg-kumo-line" />
 
@@ -95,7 +97,9 @@ export function matchesFilter(agent: { status: AgentStatus; projectName: string 
     case 'running':
       return agent.status === 'running'
     case 'idle':
-      return agent.status === 'idle' || agent.status === 'completed'
+      return agent.status === 'idle'
+    case 'completed':
+      return agent.status === 'completed' || agent.status === 'completed_manual'
     default:
       return agent.projectName === filter
   }

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -4,6 +4,7 @@ import {
   CaretUp,
   CaretDown,
   Check,
+  CheckCircle,
   GearSix,
   Pause,
   PencilSimple,
@@ -12,10 +13,11 @@ import {
   Trash,
   Terminal,
   GitPullRequest,
-  ArrowSquareOut
+  ArrowSquareOut,
+  ArrowCounterClockwise
 } from '@phosphor-icons/react'
 import type { AgentRuntime } from '../types'
-import { formatBranchLabel, isUrgent } from '../types'
+import { formatBranchLabel, isUrgent, canToggleManualComplete } from '../types'
 import { StatusBadge } from './StatusBadge'
 
 interface FleetTableProps {
@@ -33,6 +35,7 @@ interface FleetTableProps {
   onOpenInEditor?: (agentId: string) => void
   onCreatePr?: (agentId: string) => void
   onChangeModel?: (agentId: string) => void
+  onToggleComplete?: (agentId: string) => void
 }
 
 type SortColumn = 'agent' | 'status' | 'task' | 'branch' | 'model' | 'activity'
@@ -72,7 +75,8 @@ export function FleetTable({
   onOpenTerminal,
   onOpenInEditor,
   onCreatePr,
-  onChangeModel
+  onChangeModel,
+  onToggleComplete
 }: FleetTableProps) {
   const [sortColumn, setSortColumn] = useState<SortColumn | null>(null)
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
@@ -193,6 +197,7 @@ export function FleetTable({
               onOpen={onOpen ? () => onOpen(agent.id) : () => onSelect(agent.id)}
               onRemove={onRemove ? () => onRemove(agent.id) : undefined}
               onChangeModel={onChangeModel ? () => onChangeModel(agent.id) : undefined}
+              onToggleComplete={onToggleComplete ? () => onToggleComplete(agent.id) : undefined}
             />
           ))}
         </tbody>
@@ -235,6 +240,10 @@ export function FleetTable({
           }}
           onCreatePr={() => {
             onCreatePr?.(contextMenu.agentId)
+            closeContextMenu()
+          }}
+          onToggleComplete={() => {
+            onToggleComplete?.(contextMenu.agentId)
             closeContextMenu()
           }}
         />
@@ -337,7 +346,8 @@ function ContextMenu({
   onRemove,
   onOpenTerminal,
   onOpenInEditor,
-  onCreatePr
+  onCreatePr,
+  onToggleComplete
 }: {
   agent: AgentRuntime
   posX: number
@@ -351,6 +361,7 @@ function ContextMenu({
   onOpenTerminal: () => void
   onOpenInEditor: () => void
   onCreatePr: () => void
+  onToggleComplete: () => void
 }) {
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -416,6 +427,14 @@ function ContextMenu({
       <button className={itemClass} onClick={onCreatePr}>
         <GitPullRequest size={13} /> Create PR
       </button>
+      {canToggleManualComplete(agent.status) && (
+        <button className={itemClass} onClick={onToggleComplete}>
+          {agent.status === 'completed_manual'
+            ? <><ArrowCounterClockwise size={13} /> Unmark Completed</>
+            : <><CheckCircle size={13} /> Mark Completed</>
+          }
+        </button>
+      )}
 
       <div className="my-1 border-t border-kumo-line" />
 
@@ -445,7 +464,8 @@ function AgentRow({
   onStop,
   onOpen,
   onRemove,
-  onChangeModel
+  onChangeModel,
+  onToggleComplete
 }: {
   agent: AgentRuntime
   selected: boolean
@@ -457,6 +477,7 @@ function AgentRow({
   onOpen?: () => void
   onRemove?: () => void
   onChangeModel?: () => void
+  onToggleComplete?: () => void
 }) {
   const urgent = isUrgent(agent)
   const isStale = !!agent.blockedSince
@@ -518,6 +539,7 @@ function AgentRow({
             onStop={onStop}
             onOpen={onOpen}
             onRemove={onRemove}
+            onToggleComplete={onToggleComplete}
           />
           <button
             onClick={(event) => { event.stopPropagation(); onContextMenu(event) }}
@@ -538,7 +560,8 @@ function RowActions({
   onReply,
   onStop,
   onOpen,
-  onRemove
+  onRemove,
+  onToggleComplete
 }: {
   agent: AgentRuntime
   onApprove?: () => void
@@ -546,6 +569,7 @@ function RowActions({
   onStop?: () => void
   onOpen?: () => void
   onRemove?: () => void
+  onToggleComplete?: () => void
 }) {
   const buttonBase = 'w-6 h-6 flex items-center justify-center bg-kumo-fill border border-kumo-line rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors'
   const destructiveButton = 'w-6 h-6 flex items-center justify-center bg-kumo-danger/10 border border-kumo-danger/20 rounded text-kumo-danger hover:bg-kumo-danger/20 transition-colors'
@@ -577,6 +601,18 @@ function RowActions({
           onClick={(event) => { event.stopPropagation(); onStop?.() }}
         >
           <Pause size={12} weight="bold" />
+        </button>
+      )}
+      {canToggleManualComplete(agent.status) && (
+        <button
+          className={buttonBase}
+          title={agent.status === 'completed_manual' ? 'Unmark Completed' : 'Mark Completed'}
+          onClick={(event) => { event.stopPropagation(); onToggleComplete?.() }}
+        >
+          {agent.status === 'completed_manual'
+            ? <ArrowCounterClockwise size={12} weight="bold" />
+            : <CheckCircle size={12} weight="bold" />
+          }
         </button>
       )}
       <button

--- a/src/renderer/src/components/StatusBadge.tsx
+++ b/src/renderer/src/components/StatusBadge.tsx
@@ -11,6 +11,7 @@ const statusStyles: Record<string, string> = {
   needs_approval: 'bg-status-approval-bg text-status-approval',
   idle: 'bg-status-idle-bg text-status-idle',
   completed: 'bg-status-completed-bg text-status-completed',
+  completed_manual: 'bg-status-completed-bg text-status-completed',
   errored: 'bg-status-errored-bg text-status-errored',
   starting: 'bg-kumo-fill text-kumo-subtle',
   stopping: 'bg-kumo-fill text-kumo-subtle',

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -652,7 +652,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
         const agent = findAgentBySession(sessionId)
         if (agent) {
           agent.lastActivityAt = Date.now()
-          if (agent.status !== 'needs_input' && agent.status !== 'needs_approval' && agent.status !== 'stopping') {
+          if (agent.status !== 'needs_input' && agent.status !== 'needs_approval' && agent.status !== 'stopping' && agent.status !== 'completed_manual') {
             agent.status = 'running'
             agent.blockedSince = undefined
           }
@@ -1407,6 +1407,18 @@ export function useAgentStore() {
     emit()
   }, [])
 
+  const toggleManualComplete = useCallback((agentId: string) => {
+    const agent = state.agents.get(agentId)
+    if (!agent) return
+    if (agent.status === 'completed_manual') {
+      agent.status = 'idle'
+    } else if (agent.status === 'idle' || agent.status === 'completed') {
+      agent.status = 'completed_manual'
+    }
+    agent.lastActivityAt = Date.now()
+    emit()
+  }, [])
+
   return {
     agents,
     permissions,
@@ -1425,6 +1437,7 @@ export function useAgentStore() {
     removeAgent,
     renameAgent,
     setAgentModel,
+    toggleManualComplete,
     selectDirectory,
     getMessagesForSession,
     getFileChangesForSession,

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -7,6 +7,7 @@ export type AgentStatus =
   | 'needs_approval'
   | 'idle'
   | 'completed'
+  | 'completed_manual'
   | 'errored'
   | 'disconnected'
   | 'stopping'
@@ -72,6 +73,10 @@ export function isUrgent(agent: AgentRuntime): boolean {
   return isBlocked(agent.status) || agent.status === 'errored'
 }
 
+export function canToggleManualComplete(status: AgentStatus): boolean {
+  return status === 'idle' || status === 'completed' || status === 'completed_manual'
+}
+
 export function formatBranchLabel(agent: Pick<AgentRuntime, 'branchName'>): string {
   return agent.branchName ?? ''
 }
@@ -84,6 +89,7 @@ export function statusLabel(status: AgentStatus): string {
     needs_approval: 'Needs Approval',
     idle: 'Idle',
     completed: 'Completed',
+    completed_manual: 'Completed',
     errored: 'Errored',
     disconnected: 'Disconnected',
     stopping: 'Stopping'


### PR DESCRIPTION
Allow users to manually mark idle/completed agents as completed and unmark them later. Adds a new completed_manual status, a Completed filter pill (split from the old Idle filter), toggle buttons in the row actions, context menu, and detail drawer action rail.

<img width="1120" height="591" alt="image" src="https://github.com/user-attachments/assets/34fd6788-790f-4a5f-9b1e-8d2858a6aaf9" />
