### PR TITLE
Add @ agent picker for invoking agents from the chat input

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -42,9 +42,9 @@ export function registerIpcHandlers(): void {
     }
   })
 
-  ipcMain.handle('agent:send-message', async (_event, agentId: string, text: string) => {
+  ipcMain.handle('agent:send-message', async (_event, agentId: string, text: string, agent?: string) => {
     try {
-      await agentController.sendMessage(agentId, text)
+      await agentController.sendMessage(agentId, text, agent)
       return { ok: true }
     } catch (error) {
       console.error('[IPC] agent:send-message failed:', error)

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -252,8 +252,9 @@ class AgentController {
 
   /**
    * Send a message to an existing agent session.
+   * Optionally invoke a specific agent config by name.
    */
-  async sendMessage(agentId: string, text: string): Promise<void> {
+  async sendMessage(agentId: string, text: string, agent?: string): Promise<void> {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
 
@@ -263,7 +264,8 @@ class AgentController {
     await runtime.client.session.promptAsync({
       sessionID: handle.sessionId,
       directory: handle.directory,
-      parts: [{ type: 'text', text }]
+      parts: [{ type: 'text', text }],
+      ...(agent ? { agent } : {})
     })
   }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,8 +11,8 @@ const api = {
   launchAgent: (options: { directory: string; prompt?: string; title?: string; model?: string }): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:launch', options),
 
-  sendMessage: (agentId: string, text: string): Promise<IpcResult> =>
-    ipcRenderer.invoke('agent:send-message', agentId, text),
+  sendMessage: (agentId: string, text: string, agent?: string): Promise<IpcResult> =>
+    ipcRenderer.invoke('agent:send-message', agentId, text, agent),
 
   respondToPermission: (agentId: string, permissionId: string, response: 'once' | 'always' | 'reject'): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:respond-permission', agentId, permissionId, response),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -21,6 +21,7 @@ type SortColumn = 'agent' | 'status' | 'task' | 'branch' | 'model' | 'activity'
 type SortDirection = 'asc' | 'desc'
 
 const NEW_AGENT_COMMAND = '/new'
+const AGENT_MENTION_REGEX = /@(\w+)/
 
 function sanitizeSlugSegment(value: string, fallback: string): string {
   const sanitized = value
@@ -51,6 +52,7 @@ export function App() {
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
   const [, setTick] = useState(0)
   const [agentCommands, setAgentCommands] = useState<ChatCommand[]>([])
+  const [agentConfigs, setAgentConfigs] = useState<Array<{ name: string; description?: string }>>([])
   const [showModelPicker, setShowModelPicker] = useState(false)
   const [showMcpModal, setShowMcpModal] = useState(false)
   const [updateInfo, setUpdateInfo] = useState<{ currentVersion: string; latestVersion: string } | null>(null)
@@ -58,10 +60,11 @@ export function App() {
 
   const store = useAgentStore()
 
-  // ── Fetch available commands when an agent is selected ──
+  // ── Fetch available commands and agent configs when an agent is selected ──
   useEffect(() => {
     if (!selectedAgentId) {
       setAgentCommands([])
+      setAgentConfigs([])
       return
     }
 
@@ -92,7 +95,14 @@ export function App() {
       setAgentCommands(builtInCommands)
     }
 
+    const fetchAgentConfigs = async (): Promise<void> => {
+      const configs = await store.listAgentConfigs(selectedAgentId)
+      if (cancelled) return
+      setAgentConfigs(configs ?? [])
+    }
+
     void fetchCommands()
+    void fetchAgentConfigs()
 
     return () => { cancelled = true }
   }, [selectedAgentId, store])
@@ -554,8 +564,20 @@ export function App() {
       if (handled) return
     }
 
+    // Check for @agentname mentions — extract agent name and strip from text
+    const agentMatch = trimmedText.match(AGENT_MENTION_REGEX)
+    if (agentMatch) {
+      const mentionedAgent = agentMatch[1]
+      const isKnownAgent = agentConfigs.some((cfg) => cfg.name === mentionedAgent)
+      if (isKnownAgent) {
+        const cleanText = trimmedText.replace(AGENT_MENTION_REGEX, '').trim()
+        await store.sendMessage(selectedAgentId, cleanText || trimmedText, mentionedAgent)
+        return
+      }
+    }
+
     await store.sendMessage(selectedAgentId, text)
-  }, [handleBuiltInCommand, selectedAgentId, store])
+  }, [agentConfigs, handleBuiltInCommand, selectedAgentId, store])
 
   const handleApprove = useCallback(async (permissionId: string) => {
     if (!selectedAgentId) return
@@ -875,6 +897,7 @@ export function App() {
           tools={selectedTools}
           events={selectedEvents}
           commands={agentCommands}
+          agentConfigs={agentConfigs}
           onClose={() => setSelectedAgentId(null)}
           onSendMessage={handleSendMessage}
           onApprove={selectedPermission ? () => handleApprove(selectedPermission.id) : undefined}

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -52,6 +52,11 @@ export interface ChatCommand {
   description: string
 }
 
+export interface AgentConfigItem {
+  name: string
+  description?: string
+}
+
 interface DetailDrawerProps {
   agent: AgentRuntime
   messages: Message[]
@@ -61,6 +66,7 @@ interface DetailDrawerProps {
   tools?: ToolCall[]
   events?: EventEntry[]
   commands?: ChatCommand[]
+  agentConfigs?: AgentConfigItem[]
   sessionNotice?: string
   onClose: () => void
   onSendMessage?: (text: string) => void
@@ -85,6 +91,7 @@ export function DetailDrawer({
   tools = [],
   events = [],
   commands = [],
+  agentConfigs = [],
   sessionNotice,
   onClose,
   onSendMessage,
@@ -104,9 +111,13 @@ export function DetailDrawer({
   const [isVisible, setIsVisible] = useState(false)
   const [showJumpToLatest, setShowJumpToLatest] = useState(false)
   const [drawerWidth, setDrawerWidth] = useState(loadDrawerWidth)
+  const [agentPickerDismissed, setAgentPickerDismissed] = useState(false)
+  const [agentPickerIndex, setAgentPickerIndex] = useState(0)
+  const [cursorPos, setCursorPos] = useState(0)
   const transcriptScrollRef = useRef<HTMLDivElement>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const overlayRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
   const shouldAutoScrollRef = useRef(true)
   const userScrolledRef = useRef(false)
   const isResizingRef = useRef(false)
@@ -146,6 +157,25 @@ export function DetailDrawer({
     : []
 
   const showCommandAutocomplete = matchingCommands.length > 0 && inputText.trim().length > 0
+
+  // ── @ Agent mention detection ──
+  // Find the @mention being typed at or before the cursor position.
+  // We look for "@" followed by optional word characters, where the cursor
+  // is within or right after this token.
+  const agentMentionResult = (() => {
+    if (agentConfigs.length === 0) return null
+    const textBeforeCursor = inputText.slice(0, cursorPos)
+    const match = textBeforeCursor.match(/@(\w*)$/)
+    if (!match) return null
+    const start = textBeforeCursor.length - match[0].length
+    return { query: match[1].toLowerCase(), start, end: cursorPos }
+  })()
+
+  const agentMention = !agentPickerDismissed ? agentMentionResult : null
+  const matchingAgents = agentMention
+    ? agentConfigs.filter((cfg) => cfg.name.toLowerCase().startsWith(agentMention.query))
+    : []
+  const showAgentPicker = matchingAgents.length > 0 && !showCommandAutocomplete
 
   // Slide-in animation on mount
   useEffect(() => {
@@ -200,6 +230,35 @@ export function DetailDrawer({
     messagesEndRef.current?.scrollIntoView({ behavior: 'instant' })
   }
 
+  const handleInputChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setInputText(event.target.value)
+    setCursorPos(event.target.selectionStart)
+    // Reset agent picker dismissed state when text changes
+    // so the picker can reappear on new @ triggers
+    setAgentPickerDismissed(false)
+    setAgentPickerIndex(0)
+  }
+
+  const insertAgentMention = (agentName: string) => {
+    if (!agentMention) return
+    const before = inputText.slice(0, agentMention.start)
+    const after = inputText.slice(agentMention.end)
+    const newText = `${before}@${agentName} ${after}`
+    setInputText(newText)
+    setAgentPickerDismissed(false)
+    setAgentPickerIndex(0)
+    // Move cursor to after the inserted mention
+    requestAnimationFrame(() => {
+      const textarea = textareaRef.current
+      if (textarea) {
+        const cursorPos = agentMention.start + agentName.length + 2 // @ + name + space
+        textarea.selectionStart = cursorPos
+        textarea.selectionEnd = cursorPos
+        textarea.focus()
+      }
+    })
+  }
+
   const handleSend = () => {
     if (!inputText.trim() || !onSendMessage) return
     onSendMessage(inputText.trim())
@@ -207,6 +266,32 @@ export function DetailDrawer({
   }
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
+    // ── Agent picker keyboard handling ──
+    if (showAgentPicker) {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setAgentPickerDismissed(true)
+        return
+      }
+      if (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey)) {
+        event.preventDefault()
+        const selected = matchingAgents[agentPickerIndex]
+        if (selected) insertAgentMention(selected.name)
+        return
+      }
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        setAgentPickerIndex((prev) => (prev + 1) % matchingAgents.length)
+        return
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        setAgentPickerIndex((prev) => (prev - 1 + matchingAgents.length) % matchingAgents.length)
+        return
+      }
+    }
+
+    // ── Command autocomplete ──
     if (event.key === 'Tab' && showCommandAutocomplete) {
       event.preventDefault()
       setInputText(`${matchingCommands[0].command} `)
@@ -506,16 +591,47 @@ export function DetailDrawer({
                 ))}
               </div>
             )}
+            {showAgentPicker && (
+              <div className="absolute bottom-full left-0 right-0 z-20 mb-2 rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl">
+                <div className="px-2.5 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wide">
+                  Agents
+                </div>
+                {matchingAgents.map((cfg, index) => (
+                  <button
+                    key={cfg.name}
+                    type="button"
+                    onMouseDown={(event) => {
+                      event.preventDefault()
+                      insertAgentMention(cfg.name)
+                    }}
+                    className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
+                      index === agentPickerIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
+                    }`}
+                  >
+                    <span className="font-mono text-[11px] text-kumo-brand">@{cfg.name}</span>
+                    {cfg.description && (
+                      <span className="text-[11px] text-kumo-subtle truncate">{cfg.description}</span>
+                    )}
+                  </button>
+                ))}
+                <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
+                  Tab/Enter to select · Arrow keys to navigate · Esc to dismiss
+                </div>
+              </div>
+            )}
             <textarea
+              ref={textareaRef}
               value={inputText}
-              onChange={(event) => setInputText(event.target.value)}
+              onChange={handleInputChange}
               onKeyDown={handleKeyDown}
-              placeholder="Send a message to this agent... Type / for commands."
+              onKeyUp={(e) => setCursorPos(e.currentTarget.selectionStart)}
+              onClick={(e) => setCursorPos(e.currentTarget.selectionStart)}
+              placeholder="Send a message to this agent... Type / for commands, @ for agents."
               rows={3}
               className="w-full px-3 py-2 bg-kumo-control border border-kumo-line rounded-md text-kumo-default text-sm outline-none focus:border-kumo-ring placeholder:text-kumo-subtle resize-none"
             />
             <div className="px-1 text-[10px] text-kumo-subtle">
-              Enter to send. Shift+Enter for a new line. Use Tab to autocomplete commands.
+              Enter to send. Shift+Enter for a new line. Tab to autocomplete / commands and @ agents.
             </div>
           </div>
           <button

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -1196,7 +1196,7 @@ export function useAgentStore() {
     return result
   }, [])
 
-  const sendMessage = useCallback(async (agentId: string, text: string) => {
+  const sendMessage = useCallback(async (agentId: string, text: string, agentConfig?: string) => {
     if (!window.api) return
 
     // Optimistically update task summary and status
@@ -1209,7 +1209,7 @@ export function useAgentStore() {
       emit()
     }
 
-    return window.api.sendMessage(agentId, text)
+    return window.api.sendMessage(agentId, text, agentConfig)
   }, [])
 
   const listCommands = useCallback(async (agentId: string) => {
@@ -1220,6 +1220,16 @@ export function useAgentStore() {
       return null
     }
     return result.data as Array<{ name: string; description?: string; template: string }> | null
+  }, [])
+
+  const listAgentConfigs = useCallback(async (agentId: string) => {
+    if (!window.api) return null
+    const result = await window.api.listAgentConfigs(agentId)
+    if (!result.ok) {
+      console.error('Failed to list agent configs:', result.error)
+      return null
+    }
+    return result.data as Array<{ name: string; description?: string }> | null
   }, [])
 
   const executeCommand = useCallback(async (agentId: string, command: string, args: string) => {
@@ -1352,6 +1362,7 @@ export function useAgentStore() {
     launchAgent,
     sendMessage,
     listCommands,
+    listAgentConfigs,
     executeCommand,
     prepareFreshAgent,
     resetSession,

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -6,7 +6,7 @@ export interface IpcResult<T = unknown> {
 
 export interface OrchestratorApi {
   launchAgent: (options: { directory: string; prompt?: string; title?: string; model?: string }) => Promise<IpcResult>
-  sendMessage: (agentId: string, text: string) => Promise<IpcResult>
+  sendMessage: (agentId: string, text: string, agent?: string) => Promise<IpcResult>
   respondToPermission: (agentId: string, permissionId: string, response: 'once' | 'always' | 'reject') => Promise<IpcResult>
   abortAgent: (agentId: string) => Promise<IpcResult>
   removeAgent: (agentId: string) => Promise<IpcResult>


### PR DESCRIPTION
Type @ anywhere in the textarea to trigger a picker of available agent configs (fetched via the existing listAgentConfigs IPC). Arrow keys navigate, Tab/Enter inserts @agentname, Escape dismisses. On send the @mention is parsed out and forwarded as the 'agent' param to the SDK's promptAsync, which routes the message to the selected agent.

<img width="593" height="844" alt="image" src="https://github.com/user-attachments/assets/25774416-9792-47f4-b156-f3bab4104a6f" />
