### PR TITLE
Show system default model name in model picker and wire up settings default

### DIFF
--- a/src/__tests__/model-options.test.ts
+++ b/src/__tests__/model-options.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildOptionsFromProviders,
+  resolveSystemDefaultLabel,
+  type ProviderData,
+} from '../renderer/src/hooks/useModelOptions'
+
+describe('buildOptionsFromProviders', () => {
+  it('always includes System Default as the first option', () => {
+    const data: ProviderData = { providers: [] }
+    const options = buildOptionsFromProviders(data)
+    expect(options).toHaveLength(1)
+    expect(options[0]).toEqual({ value: 'auto', label: 'System Default' })
+  })
+
+  it('builds provider/model options from provider data', () => {
+    const data: ProviderData = {
+      providers: [
+        {
+          id: 'anthropic',
+          name: 'Anthropic',
+          models: {
+            'claude-sonnet-4-20250514': { id: 'claude-sonnet-4-20250514', name: 'Claude Sonnet 4' },
+          },
+        },
+      ],
+    }
+
+    const options = buildOptionsFromProviders(data)
+    expect(options).toHaveLength(2)
+    expect(options[1]).toEqual({
+      value: 'anthropic/claude-sonnet-4-20250514',
+      label: 'Claude Sonnet 4  (Anthropic)',
+    })
+  })
+
+  it('sorts providers alphabetically', () => {
+    const data: ProviderData = {
+      providers: [
+        {
+          id: 'openai',
+          name: 'OpenAI',
+          models: { 'gpt-4o': { id: 'gpt-4o', name: 'GPT-4o' } },
+        },
+        {
+          id: 'anthropic',
+          name: 'Anthropic',
+          models: { 'claude-sonnet-4-20250514': { id: 'claude-sonnet-4-20250514', name: 'Claude Sonnet 4' } },
+        },
+      ],
+    }
+
+    const options = buildOptionsFromProviders(data)
+    // Anthropic sorts before OpenAI
+    expect(options[1].label).toContain('Anthropic')
+    expect(options[2].label).toContain('OpenAI')
+  })
+
+  it('filters out providers with no models', () => {
+    const data: ProviderData = {
+      providers: [
+        { id: 'empty', name: 'Empty Provider', models: {} },
+        {
+          id: 'anthropic',
+          name: 'Anthropic',
+          models: { 'claude-opus-4-20250515': { id: 'claude-opus-4-20250515', name: 'Claude Opus 4' } },
+        },
+      ],
+    }
+
+    const options = buildOptionsFromProviders(data)
+    expect(options).toHaveLength(2) // System Default + one model
+    expect(options.every((o) => !o.label.includes('Empty'))).toBe(true)
+  })
+})
+
+describe('resolveSystemDefaultLabel', () => {
+  const providers: ProviderData = {
+    providers: [
+      {
+        id: 'anthropic',
+        name: 'Anthropic',
+        models: {
+          'claude-sonnet-4-20250514': { id: 'claude-sonnet-4-20250514', name: 'Claude Sonnet 4' },
+          'claude-opus-4-20250515': { id: 'claude-opus-4-20250515', name: 'Claude Opus 4' },
+        },
+      },
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        models: {
+          'gpt-4o': { id: 'gpt-4o', name: 'GPT-4o' },
+        },
+      },
+    ],
+  }
+
+  it('returns plain label when config model is undefined', () => {
+    expect(resolveSystemDefaultLabel(undefined, providers)).toBe('System Default')
+  })
+
+  it('returns plain label when config model is undefined and no providers', () => {
+    expect(resolveSystemDefaultLabel(undefined, null)).toBe('System Default')
+  })
+
+  it('resolves provider/model format to friendly name from provider data', () => {
+    expect(resolveSystemDefaultLabel('anthropic/claude-sonnet-4-20250514', providers))
+      .toBe('System Default (Claude Sonnet 4)')
+  })
+
+  it('resolves bare model ID from provider data', () => {
+    expect(resolveSystemDefaultLabel('gpt-4o', providers))
+      .toBe('System Default (GPT-4o)')
+  })
+
+  it('falls back to formatModelName when model not found in providers', () => {
+    expect(resolveSystemDefaultLabel('anthropic/claude-haiku-3-20240307', providers))
+      .toBe('System Default (haiku-3)')
+  })
+
+  it('falls back to formatModelName when no providers available', () => {
+    expect(resolveSystemDefaultLabel('anthropic/claude-opus-4-5-20250630', null))
+      .toBe('System Default (opus-4.5)')
+  })
+
+  it('handles unknown model with no providers', () => {
+    expect(resolveSystemDefaultLabel('my-model', null))
+      .toBe('System Default (my-model)')
+  })
+
+  it('truncates long unknown model names via formatModelName', () => {
+    expect(resolveSystemDefaultLabel('very-long-unknown-model-name', null))
+      .toBe('System Default (very-long-unknow)')
+  })
+})

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -345,6 +345,16 @@ export function registerIpcHandlers(): void {
     }
   })
 
+  ipcMain.handle('runtime:config', async () => {
+    try {
+      const data = await agentController.getConfigFromAnyRuntime()
+      return { ok: true, data }
+    } catch (error) {
+      console.error('[IPC] runtime:config failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
   // ── Dialog ──
 
   ipcMain.handle('dialog:select-directory', async () => {

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -464,6 +464,26 @@ class AgentController {
   }
 
   /**
+   * Get config from any available runtime.
+   * Useful for inferring the system default model on launch screens.
+   */
+  async getConfigFromAnyRuntime(): Promise<unknown> {
+    for (const handle of this.agents.values()) {
+      try {
+        const runtime = await this.ensureRuntimeForAgent(handle)
+        const result = await runtime.client.config.get({
+          directory: handle.directory
+        })
+        return result.data
+      } catch {
+        continue
+      }
+    }
+
+    return null
+  }
+
+  /**
    * Get MCP server status for an agent's runtime.
    */
   async getMcpStatus(agentId: string): Promise<unknown> {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -96,6 +96,9 @@ const api = {
   listAllProviders: (): Promise<IpcResult> =>
     ipcRenderer.invoke('runtime:providers'),
 
+  getSystemConfig: (): Promise<IpcResult> =>
+    ipcRenderer.invoke('runtime:config'),
+
   // ── Dialog ──
   selectDirectory: (): Promise<IpcResult<string>> =>
     ipcRenderer.invoke('dialog:select-directory'),

--- a/src/renderer/src/components/LaunchModal.tsx
+++ b/src/renderer/src/components/LaunchModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { X, FolderOpen, Clock, Warning } from '@phosphor-icons/react'
 import { SelectField } from './SelectField'
 import { useModelOptions } from '../hooks/useModelOptions'
+import { loadSettings } from '../data/settings'
 
 type WorktreeStrategy = 'new-worktree' | 'current-directory'
 
@@ -60,7 +61,7 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
   const [directory, setDirectory] = useState('')
   const [prompt, setPrompt] = useState('')
   const [title, setTitle] = useState('')
-  const [model, setModel] = useState('auto')
+  const [model, setModel] = useState(() => loadSettings().model)
   const { options: modelOptions } = useModelOptions()
   const [worktreeStrategy, setWorktreeStrategy] = useState<WorktreeStrategy>('new-worktree')
   const [launching, setLaunching] = useState(false)

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -144,6 +144,9 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                     menuClassName={selectMenuClasses}
                   />
                 </div>
+                <p className="text-[11px] text-kumo-subtle">
+                  Pre-selected model when launching new agents. &quot;System Default&quot; uses the model from the project&apos;s opencode config.
+                </p>
               </div>
 
               {/* Default Editor */}

--- a/src/renderer/src/hooks/useModelOptions.ts
+++ b/src/renderer/src/hooks/useModelOptions.ts
@@ -1,18 +1,12 @@
 import { useState, useEffect } from 'react'
+import { formatModelName } from './useAgentStore'
 
 export interface ModelOption {
   value: string
   label: string
 }
 
-const STATIC_MODEL_OPTIONS: ModelOption[] = [
-  { value: 'auto', label: 'Auto (recommended)' },
-  { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4' },
-  { value: 'claude-opus-4-20250515', label: 'Claude Opus 4' },
-  { value: 'claude-haiku-3-20240307', label: 'Claude Haiku 3' },
-]
-
-interface ProviderData {
+export interface ProviderData {
   providers: Array<{
     id: string
     name: string
@@ -20,8 +14,15 @@ interface ProviderData {
   }>
 }
 
-function buildOptionsFromProviders(data: ProviderData): ModelOption[] {
-  const options: ModelOption[] = [{ value: 'auto', label: 'Auto (recommended)' }]
+export const STATIC_MODEL_OPTIONS: ModelOption[] = [
+  { value: 'auto', label: 'System Default' },
+  { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4' },
+  { value: 'claude-opus-4-20250515', label: 'Claude Opus 4' },
+  { value: 'claude-haiku-3-20240307', label: 'Claude Haiku 3' },
+]
+
+export function buildOptionsFromProviders(data: ProviderData): ModelOption[] {
+  const options: ModelOption[] = [{ value: 'auto', label: 'System Default' }]
 
   const providers = [...data.providers]
     .filter((p) => Object.keys(p.models).length > 0)
@@ -40,8 +41,40 @@ function buildOptionsFromProviders(data: ProviderData): ModelOption[] {
 }
 
 /**
+ * Resolves the system default model name from the config and provider data,
+ * returning a label like "System Default (sonnet-4)" or just "System Default".
+ */
+export function resolveSystemDefaultLabel(
+  configModel: string | undefined,
+  providers: ProviderData | null
+): string {
+  if (!configModel) return 'System Default'
+
+  // Try to find a friendly name from provider data first
+  if (providers) {
+    const [providerId, modelId] = configModel.includes('/')
+      ? configModel.split('/', 2)
+      : [null, configModel]
+
+    for (const provider of providers.providers) {
+      if (providerId && provider.id !== providerId) continue
+      for (const model of Object.values(provider.models)) {
+        if (model.id === modelId || model.id === configModel) {
+          return `System Default (${model.name})`
+        }
+      }
+    }
+  }
+
+  // Fall back to formatModelName for a shorter display
+  const shortName = formatModelName(configModel)
+  return `System Default (${shortName})`
+}
+
+/**
  * Fetches model options dynamically from any active runtime.
  * Falls back to a static list if no runtimes are available.
+ * Resolves the system default model name from the opencode config.
  */
 export function useModelOptions(): { options: ModelOption[]; loading: boolean } {
   const [options, setOptions] = useState<ModelOption[]>(STATIC_MODEL_OPTIONS)
@@ -50,17 +83,35 @@ export function useModelOptions(): { options: ModelOption[]; loading: boolean } 
   useEffect(() => {
     let cancelled = false
 
-    const fetchProviders = async (): Promise<void> => {
+    const fetchData = async (): Promise<void> => {
       try {
-        const result = await window.api.listAllProviders()
+        const [providersResult, configResult] = await Promise.all([
+          window.api.listAllProviders(),
+          window.api.getSystemConfig(),
+        ])
         if (cancelled) return
 
-        if (result.ok && result.data) {
-          const dynamicOptions = buildOptionsFromProviders(result.data as ProviderData)
-          if (dynamicOptions.length > 1) {
-            setOptions(dynamicOptions)
-          }
+        const providerData = providersResult.ok && providersResult.data
+          ? providersResult.data as ProviderData
+          : null
+
+        const configModel = configResult.ok && configResult.data
+          ? (configResult.data as { model?: string }).model
+          : undefined
+
+        let opts: ModelOption[]
+        if (providerData) {
+          const dynamicOptions = buildOptionsFromProviders(providerData)
+          opts = dynamicOptions.length > 1 ? dynamicOptions : [...STATIC_MODEL_OPTIONS]
+        } else {
+          opts = [...STATIC_MODEL_OPTIONS]
         }
+
+        // Resolve the system default label
+        const defaultLabel = resolveSystemDefaultLabel(configModel, providerData)
+        opts[0] = { value: 'auto', label: defaultLabel }
+
+        setOptions(opts)
       } catch {
         // Fall back to static list silently
       } finally {
@@ -68,7 +119,7 @@ export function useModelOptions(): { options: ModelOption[]; loading: boolean } 
       }
     }
 
-    void fetchProviders()
+    void fetchData()
     return () => { cancelled = true }
   }, [])
 

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -34,6 +34,7 @@ export interface OrchestratorApi {
   listRuntimes: () => Promise<IpcResult>
   stopRuntime: (runtimeId: string) => Promise<IpcResult>
   listAllProviders: () => Promise<IpcResult>
+  getSystemConfig: () => Promise<IpcResult>
   selectDirectory: () => Promise<IpcResult<string>>
 
   // ── Workspace Operations ──


### PR DESCRIPTION
Rename 'Auto (recommended)' to 'System Default' and infer the configured model from the OpenCode runtime config so the dropdown shows e.g. 'System Default (Claude Sonnet 4)'. LaunchModal now reads the default model from Settings instead of hardcoding 'auto'.

<img width="584" height="566" alt="image" src="https://github.com/user-attachments/assets/95371029-1c5b-41d6-a085-066784e17645" />
