### PR TITLE
Fix model selector click in fleet table opening the detail drawer

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -54,6 +54,7 @@ export function App() {
   const [agentCommands, setAgentCommands] = useState<ChatCommand[]>([])
   const [agentConfigs, setAgentConfigs] = useState<Array<{ name: string; description?: string }>>([])
   const [showModelPicker, setShowModelPicker] = useState(false)
+  const [modelPickerAgentId, setModelPickerAgentId] = useState<string | null>(null)
   const [showMcpModal, setShowMcpModal] = useState(false)
   const [updateInfo, setUpdateInfo] = useState<{ currentVersion: string; latestVersion: string } | null>(null)
   const [appVersion, setAppVersion] = useState('')
@@ -920,7 +921,7 @@ export function App() {
         onOpenInEditor={handleOpenInEditorForAgent}
         onCreatePr={handleCreatePrForAgent}
         onChangeModel={(agentId) => {
-          setSelectedAgentId(agentId)
+          setModelPickerAgentId(agentId)
           setShowModelPicker(true)
         }}
         onToggleComplete={handleToggleComplete}
@@ -954,7 +955,7 @@ export function App() {
           onRemove={() => void handleRemoveAgent(selectedAgent.id)}
           onCreatePr={handleCreatePr}
           onOpenInEditor={handleOpenInEditor}
-          onChangeModel={() => setShowModelPicker(true)}
+          onChangeModel={() => { setModelPickerAgentId(selectedAgentId); setShowModelPicker(true) }}
           onOpenTerminal={handleOpenTerminalForDrawer}
           onToggleComplete={() => handleToggleComplete(selectedAgent.id)}
         />
@@ -973,17 +974,19 @@ export function App() {
         <SettingsModal onClose={() => setShowSettings(false)} />
       )}
 
-      {showModelPicker && selectedAgentId && (
+      {showModelPicker && modelPickerAgentId && (
         <ModelPickerModal
-          agentId={selectedAgentId}
-          currentModel={selectedAgent?.model}
-          onClose={() => setShowModelPicker(false)}
+          agentId={modelPickerAgentId}
+          currentModel={displayAgents.find((a) => a.id === modelPickerAgentId)?.model
+            ?? liveAgentsAsRuntimes.find((a) => a.id === modelPickerAgentId)?.model}
+          onClose={() => { setShowModelPicker(false); setModelPickerAgentId(null) }}
           onSelect={async (modelPath) => {
-            if (!selectedAgentId) return
-            const result = await window.api.updateConfig(selectedAgentId, { model: modelPath })
+            if (!modelPickerAgentId) return
+            const result = await window.api.updateConfig(modelPickerAgentId, { model: modelPath })
             if (result.ok) {
-              store.setAgentModel(selectedAgentId, modelPath)
+              store.setAgentModel(modelPickerAgentId, modelPath)
               setShowModelPicker(false)
+              setModelPickerAgentId(null)
             } else {
               console.error('Failed to set model:', result.error)
             }

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -486,7 +486,7 @@ function AgentRow({
     <tr
       onClick={onSelect}
       onContextMenu={onContextMenu}
-      className={`group cursor-pointer transition-colors border-b border-kumo-line ${
+      className={`group cursor-default transition-colors border-b border-kumo-line ${
         selected
           ? 'bg-kumo-control'
           : urgent
@@ -518,7 +518,7 @@ function AgentRow({
         {agent.model && agent.model !== 'starting...' && (
           <button
             onClick={(event) => { event.stopPropagation(); onChangeModel?.() }}
-            className="font-mono text-[10px] px-1.5 py-0.5 bg-kumo-fill rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors max-w-full truncate block"
+            className="font-mono text-[10px] px-1.5 py-0.5 bg-kumo-fill rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors max-w-full truncate block cursor-pointer"
             title={agent.model}
           >
             {agent.model}
@@ -543,7 +543,7 @@ function AgentRow({
           />
           <button
             onClick={(event) => { event.stopPropagation(); onContextMenu(event) }}
-            className="w-6 h-6 flex items-center justify-center rounded text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill transition-colors"
+            className="w-6 h-6 flex items-center justify-center rounded text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill transition-colors cursor-pointer"
             title="Agent actions"
           >
             <GearSix size={13} />
@@ -571,8 +571,8 @@ function RowActions({
   onRemove?: () => void
   onToggleComplete?: () => void
 }) {
-  const buttonBase = 'w-6 h-6 flex items-center justify-center bg-kumo-fill border border-kumo-line rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors'
-  const destructiveButton = 'w-6 h-6 flex items-center justify-center bg-kumo-danger/10 border border-kumo-danger/20 rounded text-kumo-danger hover:bg-kumo-danger/20 transition-colors'
+  const buttonBase = 'w-6 h-6 flex items-center justify-center bg-kumo-fill border border-kumo-line rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors cursor-pointer'
+  const destructiveButton = 'w-6 h-6 flex items-center justify-center bg-kumo-danger/10 border border-kumo-danger/20 rounded text-kumo-danger hover:bg-kumo-danger/20 transition-colors cursor-pointer'
 
   return (
     <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">


### PR DESCRIPTION
Decouple model picker from drawer selection by introducing a separate modelPickerAgentId state, so clicking the model button only opens the picker without side-effecting the drawer. Use default cursor on table rows and cursor-pointer only on interactive elements (model button, action buttons, gear icon).