### PR TITLE
Fix blocked banner persisting after responding to permission request

### DIFF
--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -1284,6 +1284,19 @@ export function useAgentStore() {
 
   const respondToPermission = useCallback(async (agentId: string, permissionId: string, response: 'once' | 'always' | 'reject') => {
     if (!window.api) return
+
+    // Optimistically clear permission and set running
+    state.permissions.delete(permissionId)
+    const agent = state.agents.get(agentId)
+    if (agent) {
+      if (agent.status !== 'stopping') {
+        agent.status = 'running'
+        agent.blockedSince = undefined
+      }
+      agent.lastActivityAt = Date.now()
+    }
+    emit()
+
     return window.api.respondToPermission(agentId, permissionId, response)
   }, [])
 


### PR DESCRIPTION
respondToPermission lacked optimistic state updates, unlike replyToQuestion and rejectQuestion. The UI waited for the SSE permission.replied event before clearing the blocked state, leaving the banner stale. Add optimistic updates matching the existing SSE handler behavior.