### PR TITLE
Add image attachment support for agent messages

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -42,9 +42,9 @@ export function registerIpcHandlers(): void {
     }
   })
 
-  ipcMain.handle('agent:send-message', async (_event, agentId: string, text: string, agent?: string) => {
+  ipcMain.handle('agent:send-message', async (_event, agentId: string, text: string, agent?: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>) => {
     try {
-      await agentController.sendMessage(agentId, text, agent)
+      await agentController.sendMessage(agentId, text, agent, attachments)
       return { ok: true }
     } catch (error) {
       console.error('[IPC] agent:send-message failed:', error)
@@ -251,9 +251,9 @@ export function registerIpcHandlers(): void {
     }
   })
 
-  ipcMain.handle('agent:send-message-with-model', async (_event, agentId: string, text: string, providerID: string, modelID: string) => {
+  ipcMain.handle('agent:send-message-with-model', async (_event, agentId: string, text: string, providerID: string, modelID: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>) => {
     try {
-      await agentController.sendMessageWithModel(agentId, text, providerID, modelID)
+      await agentController.sendMessageWithModel(agentId, text, providerID, modelID, attachments)
       return { ok: true }
     } catch (error) {
       console.error('[IPC] agent:send-message-with-model failed:', error)

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -253,18 +253,26 @@ class AgentController {
   /**
    * Send a message to an existing agent session.
    * Optionally invoke a specific agent config by name.
+   * Optionally include file attachments (images, PDFs, etc.) as additional parts.
    */
-  async sendMessage(agentId: string, text: string, agent?: string): Promise<void> {
+  async sendMessage(agentId: string, text: string, agent?: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>): Promise<void> {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
 
     const runtime = await this.ensureRuntimeForAgent(handle)
     runtimeManager.touchRuntimeActivity(runtime.id)
 
+    const parts: Array<{ type: string; [key: string]: unknown }> = [{ type: 'text', text }]
+    if (attachments?.length) {
+      for (const att of attachments) {
+        parts.push({ type: 'file', mime: att.mime, url: att.dataUrl, ...(att.filename ? { filename: att.filename } : {}) })
+      }
+    }
+
     await runtime.client.session.promptAsync({
       sessionID: handle.sessionId,
       directory: handle.directory,
-      parts: [{ type: 'text', text }],
+      parts,
       ...(agent ? { agent } : {})
     })
   }
@@ -589,17 +597,24 @@ class AgentController {
   /**
    * Send a message with a model override.
    */
-  async sendMessageWithModel(agentId: string, text: string, providerID: string, modelID: string): Promise<void> {
+  async sendMessageWithModel(agentId: string, text: string, providerID: string, modelID: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>): Promise<void> {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
 
     const runtime = await this.ensureRuntimeForAgent(handle)
     runtimeManager.touchRuntimeActivity(runtime.id)
 
+    const parts: Array<{ type: string; [key: string]: unknown }> = [{ type: 'text', text }]
+    if (attachments?.length) {
+      for (const att of attachments) {
+        parts.push({ type: 'file', mime: att.mime, url: att.dataUrl, ...(att.filename ? { filename: att.filename } : {}) })
+      }
+    }
+
     await runtime.client.session.promptAsync({
       sessionID: handle.sessionId,
       directory: handle.directory,
-      parts: [{ type: 'text', text }],
+      parts,
       model: { providerID, modelID }
     })
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,8 +11,8 @@ const api = {
   launchAgent: (options: { directory: string; prompt?: string; title?: string; model?: string }): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:launch', options),
 
-  sendMessage: (agentId: string, text: string, agent?: string): Promise<IpcResult> =>
-    ipcRenderer.invoke('agent:send-message', agentId, text, agent),
+  sendMessage: (agentId: string, text: string, agent?: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>): Promise<IpcResult> =>
+    ipcRenderer.invoke('agent:send-message', agentId, text, agent, attachments),
 
   respondToPermission: (agentId: string, permissionId: string, response: 'once' | 'always' | 'reject'): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:respond-permission', agentId, permissionId, response),
@@ -65,8 +65,8 @@ const api = {
   listTools: (agentId: string): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:list-tools', agentId),
 
-  sendMessageWithModel: (agentId: string, text: string, providerID: string, modelID: string): Promise<IpcResult> =>
-    ipcRenderer.invoke('agent:send-message-with-model', agentId, text, providerID, modelID),
+  sendMessageWithModel: (agentId: string, text: string, providerID: string, modelID: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>): Promise<IpcResult> =>
+    ipcRenderer.invoke('agent:send-message-with-model', agentId, text, providerID, modelID, attachments),
 
   listAgents: (): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:list'),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -365,14 +365,23 @@ export function App() {
           timestamp: msg.createdAt
         }))
 
-      if (textContent.trim()) {
+      const images = msg.parts
+        .filter((part) => part.type === 'file' && part.fileUrl && part.fileMime?.startsWith('image/'))
+        .map((part) => ({
+          mime: part.fileMime!,
+          url: part.fileUrl!,
+          filename: part.fileName
+        }))
+
+      if (textContent.trim() || images.length > 0) {
         flushPendingToolCalls(msg.id, msg.createdAt)
 
         transcriptItems.push({
           id: msg.id,
           role: msg.role,
           content: textContent,
-          timestamp: formatTimeAgo(msg.createdAt)
+          timestamp: formatTimeAgo(msg.createdAt),
+          ...(images.length > 0 ? { images } : {})
         })
       }
 
@@ -584,7 +593,7 @@ export function App() {
   }, [agentCommands, store])
 
   // ── Detail drawer actions ──
-  const handleSendMessage = useCallback(async (text: string) => {
+  const handleSendMessage = useCallback(async (text: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>) => {
     if (!selectedAgentId) return
     const trimmedText = text.trim()
 
@@ -611,12 +620,12 @@ export function App() {
       const isKnownAgent = agentConfigs.some((cfg) => cfg.name === mentionedAgent)
       if (isKnownAgent) {
         const cleanText = trimmedText.replace(AGENT_MENTION_REGEX, '').trim()
-        await store.sendMessage(selectedAgentId, cleanText || trimmedText, mentionedAgent)
+        await store.sendMessage(selectedAgentId, cleanText || trimmedText, mentionedAgent, attachments)
         return
       }
     }
 
-    await store.sendMessage(selectedAgentId, text)
+    await store.sendMessage(selectedAgentId, text, undefined, attachments)
   }, [agentConfigs, handleBuiltInCommand, selectedAgentId, store])
 
   const handleApprove = useCallback(async (permissionId: string) => {

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -16,7 +16,8 @@ import {
   Trash,
   ChatCircleDots,
   Brain,
-  PaperPlaneTilt
+  PaperPlaneTilt,
+  Paperclip
 } from '@phosphor-icons/react'
 import type { AgentRuntime, Message } from '../types'
 import { formatBranchLabel, canToggleManualComplete } from '../types'
@@ -72,7 +73,7 @@ interface DetailDrawerProps {
   agentConfigs?: AgentConfigItem[]
   sessionNotice?: string
   onClose: () => void
-  onSendMessage?: (text: string) => void
+  onSendMessage?: (text: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>) => void
   onApprove?: () => void
   onDeny?: () => void
   onReplyQuestion?: (answers: string[][]) => void
@@ -119,13 +120,93 @@ export function DetailDrawer({
   const [agentPickerDismissed, setAgentPickerDismissed] = useState(false)
   const [agentPickerIndex, setAgentPickerIndex] = useState(0)
   const [cursorPos, setCursorPos] = useState(0)
+  const [attachments, setAttachments] = useState<Array<{ mime: string; dataUrl: string; filename?: string }>>([])
+  const [isDragOver, setIsDragOver] = useState(false)
   const transcriptScrollRef = useRef<HTMLDivElement>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const overlayRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const shouldAutoScrollRef = useRef(true)
   const userScrolledRef = useRef(false)
   const isResizingRef = useRef(false)
+
+  const ACCEPTED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
+  const MAX_ATTACHMENT_SIZE = 20 * 1024 * 1024 // 20 MB
+
+  const readFileAsDataUrl = useCallback((file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => resolve(reader.result as string)
+      reader.onerror = () => reject(reader.error)
+      reader.readAsDataURL(file)
+    })
+  }, [])
+
+  const addImageFiles = useCallback(async (files: FileList | File[]) => {
+    const imageFiles = Array.from(files).filter(
+      (f) => ACCEPTED_IMAGE_TYPES.includes(f.type) && f.size <= MAX_ATTACHMENT_SIZE
+    )
+    if (imageFiles.length === 0) return
+
+    const newAttachments = await Promise.all(
+      imageFiles.map(async (f) => ({
+        mime: f.type,
+        dataUrl: await readFileAsDataUrl(f),
+        filename: f.name
+      }))
+    )
+    setAttachments((prev) => [...prev, ...newAttachments])
+  }, [readFileAsDataUrl])
+
+  const removeAttachment = useCallback((index: number) => {
+    setAttachments((prev) => prev.filter((_, i) => i !== index))
+  }, [])
+
+  const handlePaste = useCallback((event: React.ClipboardEvent) => {
+    const items = event.clipboardData?.items
+    if (!items) return
+
+    const imageFiles: File[] = []
+    for (const item of items) {
+      if (ACCEPTED_IMAGE_TYPES.includes(item.type)) {
+        const file = item.getAsFile()
+        if (file) imageFiles.push(file)
+      }
+    }
+    if (imageFiles.length > 0) {
+      event.preventDefault()
+      void addImageFiles(imageFiles)
+    }
+  }, [addImageFiles])
+
+  const handleDragOver = useCallback((event: React.DragEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setIsDragOver(true)
+  }, [])
+
+  const handleDragLeave = useCallback((event: React.DragEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setIsDragOver(false)
+  }, [])
+
+  const handleDrop = useCallback((event: React.DragEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setIsDragOver(false)
+    if (event.dataTransfer?.files?.length) {
+      void addImageFiles(event.dataTransfer.files)
+    }
+  }, [addImageFiles])
+
+  const handleFileInputChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files?.length) {
+      void addImageFiles(event.target.files)
+      event.target.value = ''
+    }
+  }, [addImageFiles])
 
   const handleResizeStart = useCallback((event: React.MouseEvent) => {
     event.preventDefault()
@@ -265,9 +346,10 @@ export function DetailDrawer({
   }
 
   const handleSend = () => {
-    if (!inputText.trim() || !onSendMessage) return
-    onSendMessage(inputText.trim())
+    if ((!inputText.trim() && attachments.length === 0) || !onSendMessage) return
+    onSendMessage(inputText.trim(), attachments.length > 0 ? attachments : undefined)
     setInputText('')
+    setAttachments([])
   }
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
@@ -549,76 +631,134 @@ export function DetailDrawer({
         </div>
 
         {/* Input */}
-        <div className="flex gap-2 px-3 py-2 border-t border-kumo-line shrink-0">
-          <div className="relative flex-1 flex flex-col gap-1">
-            {showCommandAutocomplete && (
-              <div className="absolute bottom-full left-0 right-0 z-20 mb-2 rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl">
-                {matchingCommands.map((item) => (
+        <div
+          className={`flex flex-col gap-0 px-3 py-2 border-t shrink-0 transition-colors ${
+            isDragOver ? 'border-kumo-brand bg-kumo-brand/[0.04]' : 'border-kumo-line'
+          }`}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          {/* Attachment thumbnails */}
+          {attachments.length > 0 && (
+            <div className="flex gap-2 px-1 py-1.5 overflow-x-auto">
+              {attachments.map((att, index) => (
+                <div key={index} className="relative group shrink-0">
+                  <img
+                    src={att.dataUrl}
+                    alt={att.filename ?? 'attachment'}
+                    className="h-16 w-16 rounded-md border border-kumo-line object-cover"
+                  />
                   <button
-                    key={item.command}
                     type="button"
-                    onMouseDown={(event) => {
-                      event.preventDefault()
-                      setInputText(`${item.command} `)
-                    }}
-                    className="flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left hover:bg-kumo-fill transition-colors"
+                    onClick={() => removeAttachment(index)}
+                    className="absolute -top-1.5 -right-1.5 w-4 h-4 flex items-center justify-center rounded-full bg-kumo-danger text-white text-[9px] font-bold opacity-0 group-hover:opacity-100 transition-opacity"
                   >
-                    <span className="font-mono text-[11px] text-kumo-default">{item.command}</span>
-                    <span className="text-[11px] text-kumo-subtle">{item.description}</span>
+                    <X size={8} weight="bold" />
                   </button>
-                ))}
-              </div>
-            )}
-            {showAgentPicker && (
-              <div className="absolute bottom-full left-0 right-0 z-20 mb-2 rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl">
-                <div className="px-2.5 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wide">
-                  Agents
+                  {att.filename && (
+                    <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white text-[8px] px-1 py-0.5 rounded-b-md truncate">
+                      {att.filename}
+                    </div>
+                  )}
                 </div>
-                {matchingAgents.map((cfg, index) => (
-                  <button
-                    key={cfg.name}
-                    type="button"
-                    onMouseDown={(event) => {
-                      event.preventDefault()
-                      insertAgentMention(cfg.name)
-                    }}
-                    className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
-                      index === agentPickerIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
-                    }`}
-                  >
-                    <span className="font-mono text-[11px] text-kumo-brand">@{cfg.name}</span>
-                    {cfg.description && (
-                      <span className="text-[11px] text-kumo-subtle truncate">{cfg.description}</span>
-                    )}
-                  </button>
-                ))}
-                <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
-                  Tab/Enter to select · Arrow keys to navigate · Esc to dismiss
-                </div>
-              </div>
-            )}
-            <textarea
-              ref={textareaRef}
-              value={inputText}
-              onChange={handleInputChange}
-              onKeyDown={handleKeyDown}
-              onKeyUp={(e) => setCursorPos(e.currentTarget.selectionStart)}
-              onClick={(e) => setCursorPos(e.currentTarget.selectionStart)}
-              placeholder="Send a message to this agent... Type / for commands, @ for agents."
-              rows={3}
-              className="w-full px-3 py-2 bg-kumo-control border border-kumo-line rounded-md text-kumo-default text-sm outline-none focus:border-kumo-ring placeholder:text-kumo-subtle resize-none"
-            />
-            <div className="px-1 text-[10px] text-kumo-subtle">
-              Enter to send. Shift+Enter for a new line. Tab to autocomplete / commands and @ agents.
+              ))}
             </div>
+          )}
+
+          <div className="flex gap-2">
+            <div className="relative flex-1 flex flex-col gap-1">
+              {showCommandAutocomplete && (
+                <div className="absolute bottom-full left-0 right-0 z-20 mb-2 rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl">
+                  {matchingCommands.map((item) => (
+                    <button
+                      key={item.command}
+                      type="button"
+                      onMouseDown={(event) => {
+                        event.preventDefault()
+                        setInputText(`${item.command} `)
+                      }}
+                      className="flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left hover:bg-kumo-fill transition-colors"
+                    >
+                      <span className="font-mono text-[11px] text-kumo-default">{item.command}</span>
+                      <span className="text-[11px] text-kumo-subtle">{item.description}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+              {showAgentPicker && (
+                <div className="absolute bottom-full left-0 right-0 z-20 mb-2 rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl">
+                  <div className="px-2.5 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wide">
+                    Agents
+                  </div>
+                  {matchingAgents.map((cfg, index) => (
+                    <button
+                      key={cfg.name}
+                      type="button"
+                      onMouseDown={(event) => {
+                        event.preventDefault()
+                        insertAgentMention(cfg.name)
+                      }}
+                      className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
+                        index === agentPickerIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
+                      }`}
+                    >
+                      <span className="font-mono text-[11px] text-kumo-brand">@{cfg.name}</span>
+                      {cfg.description && (
+                        <span className="text-[11px] text-kumo-subtle truncate">{cfg.description}</span>
+                      )}
+                    </button>
+                  ))}
+                  <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
+                    Tab/Enter to select · Arrow keys to navigate · Esc to dismiss
+                  </div>
+                </div>
+              )}
+              <textarea
+                ref={textareaRef}
+                value={inputText}
+                onChange={handleInputChange}
+                onKeyDown={handleKeyDown}
+                onKeyUp={(e) => setCursorPos(e.currentTarget.selectionStart)}
+                onClick={(e) => setCursorPos(e.currentTarget.selectionStart)}
+                onPaste={handlePaste}
+                placeholder={isDragOver ? 'Drop image here...' : 'Send a message to this agent... Type / for commands, @ for agents.'}
+                rows={3}
+                className={`w-full px-3 py-2 bg-kumo-control border rounded-md text-kumo-default text-sm outline-none placeholder:text-kumo-subtle resize-none transition-colors ${
+                  isDragOver ? 'border-kumo-brand' : 'border-kumo-line focus:border-kumo-ring'
+                }`}
+              />
+              <div className="flex items-center gap-2 px-1">
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  className="flex items-center gap-1 text-[10px] text-kumo-subtle hover:text-kumo-default transition-colors"
+                  title="Attach image"
+                >
+                  <Paperclip size={11} />
+                  <span>Attach image</span>
+                </button>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/png,image/jpeg,image/gif,image/webp"
+                  multiple
+                  className="hidden"
+                  onChange={handleFileInputChange}
+                />
+                <span className="text-[10px] text-kumo-subtle">
+                  Enter to send. Shift+Enter for new line. Paste or drag images.
+                </span>
+              </div>
+            </div>
+            <button
+              onClick={handleSend}
+              disabled={!inputText.trim() && attachments.length === 0}
+              className="self-start px-3 py-2 bg-kumo-brand text-white text-xs font-medium rounded-md hover:bg-kumo-brand-hover transition-colors disabled:opacity-40"
+            >
+              Send
+            </button>
           </div>
-          <button
-            onClick={handleSend}
-            disabled={!inputText.trim()}
-            className="self-start px-3 py-2 bg-kumo-brand text-white text-xs font-medium rounded-md hover:bg-kumo-brand-hover transition-colors disabled:opacity-40"
-          >
-            Send
-          </button>
         </div>
       </div>
     </div>
@@ -928,10 +1068,30 @@ function MessageBubble({ message }: { message: Message }) {
       <div className="text-[10px] font-semibold uppercase tracking-wide text-kumo-subtle mb-1">
         {isUser ? 'You' : 'Agent'}
       </div>
-      {isUser
-        ? <div className="whitespace-pre-wrap">{message.content}</div>
-        : <Markdown>{message.content}</Markdown>
-      }
+      {message.images && message.images.length > 0 && (
+        <div className="flex flex-wrap gap-2 mb-2">
+          {message.images.map((img, index) => (
+            <div key={index} className="relative group">
+              <img
+                src={img.url}
+                alt={img.filename ?? 'attached image'}
+                className="max-h-48 max-w-full rounded-md border border-kumo-line object-contain cursor-pointer"
+                onClick={() => window.open(img.url, '_blank')}
+              />
+              {img.filename && (
+                <div className="text-[9px] text-kumo-subtle mt-0.5 truncate max-w-[200px]">
+                  {img.filename}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      {message.content && (
+        isUser
+          ? <div className="whitespace-pre-wrap">{message.content}</div>
+          : <Markdown>{message.content}</Markdown>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -108,11 +108,14 @@ export interface LiveMessage {
 
 export interface LiveMessagePart {
   id: string
-  type: 'text' | 'tool' | 'reasoning' | 'step-start' | 'step-finish' | string
+  type: 'text' | 'tool' | 'reasoning' | 'step-start' | 'step-finish' | 'file' | string
   text?: string
   toolName?: string
   toolState?: string
   toolInput?: string
+  fileMime?: string
+  fileUrl?: string
+  fileName?: string
 }
 
 export interface FileChangeRecord {
@@ -391,6 +394,13 @@ function mapHistoricalPart(part: HistoricalMessagePart): LiveMessagePart {
     nextPart.text = part.text ?? part.state?.output ?? part.state?.error ?? part.state?.title ?? part.state?.raw
   }
 
+  if (part.type === 'file') {
+    const filePart = part as unknown as Record<string, unknown>
+    nextPart.fileMime = filePart.mime as string | undefined
+    nextPart.fileUrl = filePart.url as string | undefined
+    nextPart.fileName = filePart.filename as string | undefined
+  }
+
   return nextPart
 }
 
@@ -634,6 +644,11 @@ function processEvent(payload: OpenCodeEventPayload): void {
             existingPart.toolState = getToolState(toolState)
             existingPart.toolInput = stringifyToolInput(toolState?.input)
           }
+          if (partType === 'file') {
+            existingPart.fileMime = part.mime as string | undefined
+            existingPart.fileUrl = part.url as string | undefined
+            existingPart.fileName = part.filename as string | undefined
+          }
         } else {
           const newPart: LiveMessagePart = {
             id: partId,
@@ -644,6 +659,11 @@ function processEvent(payload: OpenCodeEventPayload): void {
             newPart.toolName = part.tool as string | undefined
             newPart.toolState = getToolState(toolState)
             newPart.toolInput = stringifyToolInput(toolState?.input)
+          }
+          if (partType === 'file') {
+            newPart.fileMime = part.mime as string | undefined
+            newPart.fileUrl = part.url as string | undefined
+            newPart.fileName = part.filename as string | undefined
           }
           message.parts.push(newPart)
         }
@@ -1214,7 +1234,7 @@ export function useAgentStore() {
     return result
   }, [])
 
-  const sendMessage = useCallback(async (agentId: string, text: string, agentConfig?: string) => {
+  const sendMessage = useCallback(async (agentId: string, text: string, agentConfig?: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>) => {
     if (!window.api) return
 
     // Don't allow sending while agent is stopping
@@ -1230,7 +1250,7 @@ export function useAgentStore() {
       emit()
     }
 
-    return window.api.sendMessage(agentId, text, agentConfig)
+    return window.api.sendMessage(agentId, text, agentConfig, attachments)
   }, [])
 
   const listCommands = useCallback(async (agentId: string) => {

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -4,9 +4,15 @@ export interface IpcResult<T = unknown> {
   error?: string
 }
 
+export interface MessageAttachment {
+  mime: string
+  dataUrl: string
+  filename?: string
+}
+
 export interface OrchestratorApi {
   launchAgent: (options: { directory: string; prompt?: string; title?: string; model?: string }) => Promise<IpcResult>
-  sendMessage: (agentId: string, text: string, agent?: string) => Promise<IpcResult>
+  sendMessage: (agentId: string, text: string, agent?: string, attachments?: MessageAttachment[]) => Promise<IpcResult>
   respondToPermission: (agentId: string, permissionId: string, response: 'once' | 'always' | 'reject') => Promise<IpcResult>
   abortAgent: (agentId: string) => Promise<IpcResult>
   removeAgent: (agentId: string) => Promise<IpcResult>
@@ -24,7 +30,7 @@ export interface OrchestratorApi {
   shareSession: (agentId: string) => Promise<IpcResult>
   listAgentConfigs: (agentId: string) => Promise<IpcResult>
   listTools: (agentId: string) => Promise<IpcResult>
-  sendMessageWithModel: (agentId: string, text: string, providerID: string, modelID: string) => Promise<IpcResult>
+  sendMessageWithModel: (agentId: string, text: string, providerID: string, modelID: string, attachments?: MessageAttachment[]) => Promise<IpcResult>
   listAgents: () => Promise<IpcResult<ListAgentsPayload>>
   updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string }) => Promise<IpcResult>
   getStatuses: () => Promise<IpcResult<AgentStatusesPayload>>

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -55,6 +55,12 @@ export interface Interrupt {
   resolvedAt?: string
 }
 
+export interface MessageImage {
+  mime: string
+  url: string
+  filename?: string
+}
+
 export interface Message {
   id: string
   role: 'user' | 'assistant' | 'tool' | 'tool-group'
@@ -63,6 +69,7 @@ export interface Message {
   toolName?: string
   toolState?: 'running' | 'completed' | 'failed'
   toolCalls?: ToolCall[]
+  images?: MessageImage[]
 }
 
 export function isBlocked(status: AgentStatus): boolean {


### PR DESCRIPTION
Wire screenshot/image support through the full stack — from the DetailDrawer UI (paste, drag-drop, file picker with thumbnails) through IPC and AgentController to the OpenCode SDK's FilePartInput. Images in both sent and received messages render inline in the transcript.

<img width="556" height="845" alt="Screenshot 2026-04-01 at 4 24 54 PM" src="https://github.com/user-attachments/assets/8bd16e94-575f-440e-ba6b-745e87f7d348" />
