### PR TITLE
Fix interrupt banner persisting after input and add dismiss button

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -58,6 +58,7 @@ export function App() {
   const [showMcpModal, setShowMcpModal] = useState(false)
   const [updateInfo, setUpdateInfo] = useState<{ currentVersion: string; latestVersion: string } | null>(null)
   const [appVersion, setAppVersion] = useState('')
+  const [dismissedInterruptIds, setDismissedInterruptIds] = useState<Set<string> | null>(null)
 
   const store = useAgentStore()
 
@@ -246,6 +247,13 @@ export function App() {
   // ── Display data: always live (no mock fallback) ──
   const displayAgents = liveAgentsAsRuntimes
   const displayInterrupts = liveInterrupts
+
+  // Re-show banner if new interrupts appear that weren't in the dismissed set
+  const isBannerDismissed = dismissedInterruptIds !== null &&
+    liveInterrupts.length > 0 &&
+    liveInterrupts.every((interrupt) => dismissedInterruptIds.has(interrupt.id))
+
+  const showInterruptBanner = displayInterrupts.length > 0 && !isBannerDismissed
 
   // ── Filtered + sorted agents ──
   const filteredAgents = useMemo(() => {
@@ -899,10 +907,11 @@ export function App() {
         </div>
       )}
 
-      {displayInterrupts.length > 0 && (
+      {showInterruptBanner && (
         <InterruptBanner
           interrupts={displayInterrupts}
           onReviewAll={() => setFilter({ statuses: new Set<StatusFilter>(['blocked']), projects: new Set() })}
+          onDismiss={() => setDismissedInterruptIds(new Set(displayInterrupts.map((i) => i.id)))}
         />
       )}
 

--- a/src/renderer/src/components/InterruptBanner.tsx
+++ b/src/renderer/src/components/InterruptBanner.tsx
@@ -3,9 +3,10 @@ import type { Interrupt } from '../types'
 interface InterruptBannerProps {
   interrupts: Interrupt[]
   onReviewAll: () => void
+  onDismiss: () => void
 }
 
-export function InterruptBanner({ interrupts, onReviewAll }: InterruptBannerProps) {
+export function InterruptBanner({ interrupts, onReviewAll, onDismiss }: InterruptBannerProps) {
   if (interrupts.length === 0) return null
 
   const approvalCount = interrupts.filter((interrupt) => interrupt.kind === 'needs_approval').length
@@ -33,6 +34,15 @@ export function InterruptBanner({ interrupts, onReviewAll }: InterruptBannerProp
         className="px-2.5 py-1 text-[11px] font-medium bg-kumo-danger/15 text-kumo-danger border border-kumo-danger/25 rounded-md hover:bg-kumo-danger/25 transition-colors"
       >
         Review All &rarr;
+      </button>
+      <button
+        onClick={onDismiss}
+        className="ml-1 p-0.5 text-kumo-danger/60 hover:text-kumo-danger transition-colors rounded"
+        title="Dismiss banner"
+      >
+        <svg className="w-3.5 h-3.5" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+          <path d="M4 4l8 8M12 4l-8 8" />
+        </svg>
       </button>
     </div>
   )

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -1246,9 +1246,17 @@ export function useAgentStore() {
       agent.taskSummary = text.trim().slice(0, 120)
       agent.status = 'running'
       agent.lastActivityAt = Date.now()
+      agent.blockedSince = undefined
       persistAgentMeta(agentId, { taskSummary: agent.taskSummary })
-      emit()
     }
+
+    // Optimistically clear any pending questions for this agent
+    // (sending a message is the response to a needs_input state)
+    for (const [qId, q] of state.questions) {
+      if (q.agentId === agentId) state.questions.delete(qId)
+    }
+
+    emit()
 
     return window.api.sendMessage(agentId, text, agentConfig, attachments)
   }, [])


### PR DESCRIPTION
The agent blocked banner stayed visible after sending a message because sendMessage didn't optimistically clear pending questions or blockedSince. Now it clears both immediately.

Also adds an X button to manually dismiss the banner. The banner automatically re-appears if new interrupts arrive that weren't in the dismissed set.