### PR TITLE
Support multi-select filters for status and project

### DIFF
--- a/src/__tests__/filter-sort.test.ts
+++ b/src/__tests__/filter-sort.test.ts
@@ -14,7 +14,12 @@ type AgentStatus =
   | 'disconnected'
   | 'stopping'
 
-type FilterValue = 'all' | 'blocked' | 'running' | 'idle' | 'completed' | string
+type StatusFilter = 'blocked' | 'running' | 'idle' | 'completed'
+
+interface FilterState {
+  statuses: Set<StatusFilter>
+  projects: Set<string>
+}
 
 interface AgentRow {
   id: string
@@ -29,21 +34,35 @@ interface AgentRow {
 
 // ── Logic extracted from src/renderer/src/components/FilterBar.tsx ──
 
-function matchesFilter(agent: { status: AgentStatus; projectName: string }, filter: FilterValue): boolean {
-  switch (filter) {
-    case 'all':
-      return true
-    case 'blocked':
-      return agent.status === 'needs_input' || agent.status === 'needs_approval'
-    case 'running':
-      return agent.status === 'running'
-    case 'idle':
-      return agent.status === 'idle'
-    case 'completed':
-      return agent.status === 'completed' || agent.status === 'completed_manual'
-    default:
-      return agent.projectName === filter
+const STATUS_MAP: Record<StatusFilter, AgentStatus[]> = {
+  blocked: ['needs_input', 'needs_approval'],
+  running: ['running'],
+  idle: ['idle'],
+  completed: ['completed', 'completed_manual']
+}
+
+function matchesFilter(
+  agent: { status: AgentStatus; projectName: string },
+  filter: FilterState
+): boolean {
+  const hasStatuses = filter.statuses.size > 0
+  const hasProjects = filter.projects.size > 0
+
+  if (!hasStatuses && !hasProjects) return true
+
+  if (hasStatuses) {
+    const allowedStatuses = new Set<AgentStatus>()
+    for (const sf of filter.statuses) {
+      for (const s of STATUS_MAP[sf]) allowedStatuses.add(s)
+    }
+    if (!allowedStatuses.has(agent.status)) return false
   }
+
+  if (hasProjects) {
+    if (!filter.projects.has(agent.projectName)) return false
+  }
+
+  return true
 }
 
 function canToggleManualComplete(status: AgentStatus): boolean {
@@ -124,53 +143,120 @@ function createAgent(overrides: Partial<AgentRow> = {}): AgentRow {
   }
 }
 
+const EMPTY: FilterState = { statuses: new Set(), projects: new Set() }
+
+function statusFilter(...statuses: StatusFilter[]): FilterState {
+  return { statuses: new Set(statuses), projects: new Set() }
+}
+
+function projectFilter(...projects: string[]): FilterState {
+  return { statuses: new Set(), projects: new Set(projects) }
+}
+
+function combinedFilter(statuses: StatusFilter[], projects: string[]): FilterState {
+  return { statuses: new Set(statuses), projects: new Set(projects) }
+}
+
 // ── Tests ──
 
 describe('matchesFilter', () => {
-  it('returns true for "all" filter regardless of status', () => {
+  it('returns true for empty filter (no statuses, no projects) regardless of status', () => {
     const statuses: AgentStatus[] = [
       'starting', 'running', 'needs_input', 'needs_approval',
       'idle', 'completed', 'completed_manual', 'errored', 'disconnected', 'stopping'
     ]
     for (const status of statuses) {
-      expect(matchesFilter({ status, projectName: 'proj' }, 'all')).toBe(true)
+      expect(matchesFilter({ status, projectName: 'proj' }, EMPTY)).toBe(true)
     }
   })
 
-  it('returns true for "blocked" filter only when needs_input or needs_approval', () => {
-    expect(matchesFilter({ status: 'needs_input', projectName: 'proj' }, 'blocked')).toBe(true)
-    expect(matchesFilter({ status: 'needs_approval', projectName: 'proj' }, 'blocked')).toBe(true)
-    expect(matchesFilter({ status: 'running', projectName: 'proj' }, 'blocked')).toBe(false)
-    expect(matchesFilter({ status: 'idle', projectName: 'proj' }, 'blocked')).toBe(false)
-    expect(matchesFilter({ status: 'errored', projectName: 'proj' }, 'blocked')).toBe(false)
-    expect(matchesFilter({ status: 'completed', projectName: 'proj' }, 'blocked')).toBe(false)
+  it('returns true for "blocked" status filter only when needs_input or needs_approval', () => {
+    const filter = statusFilter('blocked')
+    expect(matchesFilter({ status: 'needs_input', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'needs_approval', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'errored', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'completed', projectName: 'proj' }, filter)).toBe(false)
   })
 
-  it('returns true for "running" filter only when running', () => {
-    expect(matchesFilter({ status: 'running', projectName: 'proj' }, 'running')).toBe(true)
-    expect(matchesFilter({ status: 'idle', projectName: 'proj' }, 'running')).toBe(false)
-    expect(matchesFilter({ status: 'needs_input', projectName: 'proj' }, 'running')).toBe(false)
+  it('returns true for "running" status filter only when running', () => {
+    const filter = statusFilter('running')
+    expect(matchesFilter({ status: 'running', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'needs_input', projectName: 'proj' }, filter)).toBe(false)
   })
 
-  it('returns true for "idle" filter only when idle', () => {
-    expect(matchesFilter({ status: 'idle', projectName: 'proj' }, 'idle')).toBe(true)
-    expect(matchesFilter({ status: 'completed', projectName: 'proj' }, 'idle')).toBe(false)
-    expect(matchesFilter({ status: 'completed_manual', projectName: 'proj' }, 'idle')).toBe(false)
-    expect(matchesFilter({ status: 'running', projectName: 'proj' }, 'idle')).toBe(false)
-    expect(matchesFilter({ status: 'errored', projectName: 'proj' }, 'idle')).toBe(false)
+  it('returns true for "idle" status filter only when idle', () => {
+    const filter = statusFilter('idle')
+    expect(matchesFilter({ status: 'idle', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'completed_manual', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'errored', projectName: 'proj' }, filter)).toBe(false)
   })
 
-  it('returns true for "completed" filter when completed or completed_manual', () => {
-    expect(matchesFilter({ status: 'completed', projectName: 'proj' }, 'completed')).toBe(true)
-    expect(matchesFilter({ status: 'completed_manual', projectName: 'proj' }, 'completed')).toBe(true)
-    expect(matchesFilter({ status: 'idle', projectName: 'proj' }, 'completed')).toBe(false)
-    expect(matchesFilter({ status: 'running', projectName: 'proj' }, 'completed')).toBe(false)
-    expect(matchesFilter({ status: 'errored', projectName: 'proj' }, 'completed')).toBe(false)
+  it('returns true for "completed" status filter when completed or completed_manual', () => {
+    const filter = statusFilter('completed')
+    expect(matchesFilter({ status: 'completed', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed_manual', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'errored', projectName: 'proj' }, filter)).toBe(false)
   })
 
-  it('matches by project name for custom filter values', () => {
-    expect(matchesFilter({ status: 'running', projectName: 'my-app' }, 'my-app')).toBe(true)
-    expect(matchesFilter({ status: 'running', projectName: 'other-app' }, 'my-app')).toBe(false)
+  it('matches by project name when project filter is set', () => {
+    const filter = projectFilter('my-app')
+    expect(matchesFilter({ status: 'running', projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', projectName: 'other-app' }, filter)).toBe(false)
+  })
+
+  // ── Multi-select tests ──
+
+  it('allows multiple statuses to be selected simultaneously', () => {
+    const filter = statusFilter('running', 'idle')
+    expect(matchesFilter({ status: 'running', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'needs_input', projectName: 'proj' }, filter)).toBe(false)
+  })
+
+  it('allows multiple projects to be selected simultaneously', () => {
+    const filter = projectFilter('app-a', 'app-b')
+    expect(matchesFilter({ status: 'running', projectName: 'app-a' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', projectName: 'app-b' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', projectName: 'app-c' }, filter)).toBe(false)
+  })
+
+  it('combines status AND project filters (both must match)', () => {
+    const filter = combinedFilter(['running'], ['my-app'])
+    expect(matchesFilter({ status: 'running', projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', projectName: 'other-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', projectName: 'my-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', projectName: 'other-app' }, filter)).toBe(false)
+  })
+
+  it('combines multiple statuses AND multiple projects', () => {
+    const filter = combinedFilter(['running', 'blocked'], ['app-a', 'app-b'])
+    expect(matchesFilter({ status: 'running', projectName: 'app-a' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'needs_input', projectName: 'app-b' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'needs_approval', projectName: 'app-a' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', projectName: 'app-a' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', projectName: 'app-c' }, filter)).toBe(false)
+  })
+
+  it('status-only filter does not restrict by project', () => {
+    const filter = statusFilter('running')
+    expect(matchesFilter({ status: 'running', projectName: 'any-project' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', projectName: 'another-project' }, filter)).toBe(true)
+  })
+
+  it('project-only filter does not restrict by status', () => {
+    const filter = projectFilter('my-app')
+    expect(matchesFilter({ status: 'running', projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'errored', projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', projectName: 'my-app' }, filter)).toBe(true)
   })
 })
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import { TopBar } from './components/TopBar'
 import { InterruptBanner } from './components/InterruptBanner'
-import { FilterBar, matchesFilter, type FilterValue } from './components/FilterBar'
+import { FilterBar, matchesFilter, EMPTY_FILTER, type FilterState, type StatusFilter } from './components/FilterBar'
 import { FleetTable } from './components/FleetTable'
 import { StatusBar } from './components/StatusBar'
 import { DetailDrawer, type ChatCommand } from './components/DetailDrawer'
@@ -41,7 +41,7 @@ function mapToolState(toolState?: string): ToolCall['state'] {
 }
 
 export function App() {
-  const [filter, setFilter] = useState<FilterValue>('all')
+  const [filter, setFilter] = useState<FilterState>(EMPTY_FILTER)
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
   const [showLaunchModal, setShowLaunchModal] = useState(false)
@@ -145,7 +145,7 @@ export function App() {
   // ── Navigate to agent when desktop notification is clicked ──
   const navigateToAgent = useCallback((agentId: string) => {
     console.log('[App] Navigating to agent:', agentId)
-    setFilter('all')
+    setFilter(EMPTY_FILTER)
     setSearchQuery('')
     setSelectedAgentId(agentId)
   }, [])
@@ -902,13 +902,29 @@ export function App() {
       {displayInterrupts.length > 0 && (
         <InterruptBanner
           interrupts={displayInterrupts}
-          onReviewAll={() => setFilter('blocked')}
+          onReviewAll={() => setFilter({ statuses: new Set<StatusFilter>(['blocked']), projects: new Set() })}
         />
       )}
 
       <FilterBar
         filter={filter}
-        onFilterChange={setFilter}
+        onToggleStatus={(status) => {
+          setFilter((prev) => {
+            const next = new Set(prev.statuses)
+            if (next.has(status)) next.delete(status)
+            else next.add(status)
+            return { statuses: next, projects: new Set(prev.projects) }
+          })
+        }}
+        onToggleProject={(project) => {
+          setFilter((prev) => {
+            const next = new Set(prev.projects)
+            if (next.has(project)) next.delete(project)
+            else next.add(project)
+            return { statuses: new Set(prev.statuses), projects: next }
+          })
+        }}
+        onClearFilters={() => setFilter(EMPTY_FILTER)}
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
         counts={counts}

--- a/src/renderer/src/components/CommandPalette.tsx
+++ b/src/renderer/src/components/CommandPalette.tsx
@@ -11,6 +11,7 @@ import {
   Warning,
   CircleNotch
 } from '@phosphor-icons/react'
+import { EMPTY_FILTER, type FilterState, type StatusFilter } from './FilterBar'
 
 interface CommandPaletteProps {
   agents: Array<{ id: string; name: string; projectName: string; status: string }>
@@ -18,7 +19,7 @@ interface CommandPaletteProps {
   onSelectAgent: (id: string) => void
   onLaunchAgent: () => void
   onOpenSettings: () => void
-  onFilterChange: (filter: string) => void
+  onFilterChange: (filter: FilterState) => void
   onStopAll: () => void
   onApproveAll: () => void
 }
@@ -144,7 +145,7 @@ export function CommandPalette({
         category: 'navigation',
         action: () => {
           onClose()
-          onFilterChange('')
+          onFilterChange(EMPTY_FILTER)
         }
       },
       {
@@ -155,7 +156,7 @@ export function CommandPalette({
         category: 'navigation',
         action: () => {
           onClose()
-          onFilterChange('blocked')
+          onFilterChange({ statuses: new Set<StatusFilter>(['blocked']), projects: new Set() })
         }
       },
       {
@@ -166,7 +167,7 @@ export function CommandPalette({
         category: 'navigation',
         action: () => {
           onClose()
-          onFilterChange('running')
+          onFilterChange({ statuses: new Set<StatusFilter>(['running']), projects: new Set() })
         }
       }
     ]

--- a/src/renderer/src/components/FilterBar.tsx
+++ b/src/renderer/src/components/FilterBar.tsx
@@ -1,11 +1,27 @@
 import { MagnifyingGlass } from '@phosphor-icons/react'
 import type { AgentStatus } from '../types'
 
-export type FilterValue = 'all' | 'blocked' | 'running' | 'idle' | 'completed' | string
+export type StatusFilter = 'blocked' | 'running' | 'idle' | 'completed'
+
+export interface FilterState {
+  statuses: Set<StatusFilter>
+  projects: Set<string>
+}
+
+export const EMPTY_FILTER: FilterState = {
+  statuses: new Set(),
+  projects: new Set()
+}
+
+export function isFilterEmpty(filter: FilterState): boolean {
+  return filter.statuses.size === 0 && filter.projects.size === 0
+}
 
 interface FilterBarProps {
-  filter: FilterValue
-  onFilterChange: (filter: FilterValue) => void
+  filter: FilterState
+  onToggleStatus: (status: StatusFilter) => void
+  onToggleProject: (project: string) => void
+  onClearFilters: () => void
   searchQuery: string
   onSearchChange: (query: string) => void
   counts: {
@@ -20,12 +36,16 @@ interface FilterBarProps {
 
 export function FilterBar({
   filter,
-  onFilterChange,
+  onToggleStatus,
+  onToggleProject,
+  onClearFilters,
   searchQuery,
   onSearchChange,
   counts,
   projects
 }: FilterBarProps) {
+  const noFilters = isFilterEmpty(filter)
+
   return (
     <div className="flex items-center gap-2 px-4 py-2 bg-kumo-elevated border-b border-kumo-line shrink-0">
       {/* Search */}
@@ -44,11 +64,11 @@ export function FilterBar({
       <div className="w-px h-5 bg-kumo-line" />
 
       {/* Status filters */}
-      <FilterPill label={`All (${counts.all})`} active={filter === 'all'} onClick={() => onFilterChange('all')} />
-      <FilterPill label={`Blocked (${counts.blocked})`} active={filter === 'blocked'} onClick={() => onFilterChange('blocked')} />
-      <FilterPill label={`Running (${counts.running})`} active={filter === 'running'} onClick={() => onFilterChange('running')} />
-      <FilterPill label={`Idle (${counts.idle})`} active={filter === 'idle'} onClick={() => onFilterChange('idle')} />
-      <FilterPill label={`Completed (${counts.completed})`} active={filter === 'completed'} onClick={() => onFilterChange('completed')} />
+      <FilterPill label={`All (${counts.all})`} active={noFilters} onClick={onClearFilters} />
+      <FilterPill label={`Blocked (${counts.blocked})`} active={filter.statuses.has('blocked')} onClick={() => onToggleStatus('blocked')} />
+      <FilterPill label={`Running (${counts.running})`} active={filter.statuses.has('running')} onClick={() => onToggleStatus('running')} />
+      <FilterPill label={`Idle (${counts.idle})`} active={filter.statuses.has('idle')} onClick={() => onToggleStatus('idle')} />
+      <FilterPill label={`Completed (${counts.completed})`} active={filter.statuses.has('completed')} onClick={() => onToggleStatus('completed')} />
 
       <div className="w-px h-5 bg-kumo-line" />
 
@@ -57,8 +77,8 @@ export function FilterBar({
         <FilterPill
           key={project}
           label={project}
-          active={filter === project}
-          onClick={() => onFilterChange(filter === project ? 'all' : project)}
+          active={filter.projects.has(project)}
+          onClick={() => onToggleProject(project)}
         />
       ))}
     </div>
@@ -88,19 +108,33 @@ function FilterPill({
   )
 }
 
-export function matchesFilter(agent: { status: AgentStatus; projectName: string }, filter: FilterValue): boolean {
-  switch (filter) {
-    case 'all':
-      return true
-    case 'blocked':
-      return agent.status === 'needs_input' || agent.status === 'needs_approval'
-    case 'running':
-      return agent.status === 'running'
-    case 'idle':
-      return agent.status === 'idle'
-    case 'completed':
-      return agent.status === 'completed' || agent.status === 'completed_manual'
-    default:
-      return agent.projectName === filter
+const STATUS_MAP: Record<StatusFilter, AgentStatus[]> = {
+  blocked: ['needs_input', 'needs_approval'],
+  running: ['running'],
+  idle: ['idle'],
+  completed: ['completed', 'completed_manual']
+}
+
+export function matchesFilter(
+  agent: { status: AgentStatus; projectName: string },
+  filter: FilterState
+): boolean {
+  const hasStatuses = filter.statuses.size > 0
+  const hasProjects = filter.projects.size > 0
+
+  if (!hasStatuses && !hasProjects) return true
+
+  if (hasStatuses) {
+    const allowedStatuses = new Set<AgentStatus>()
+    for (const sf of filter.statuses) {
+      for (const s of STATUS_MAP[sf]) allowedStatuses.add(s)
+    }
+    if (!allowedStatuses.has(agent.status)) return false
   }
+
+  if (hasProjects) {
+    if (!filter.projects.has(agent.projectName)) return false
+  }
+
+  return true
 }


### PR DESCRIPTION
Replace single-select FilterValue with FilterState containing independent Sets for statuses and projects. Both dimensions AND together: an agent must match an active status AND an active project. When no filters are selected, all agents are shown.

Pills now toggle on/off independently, allowing combinations like 'Running + Idle in project-a' or excluding completed agents while viewing everything else.

<img width="1093" height="237" alt="Screenshot 2026-04-01 at 6 03 24 PM" src="https://github.com/user-attachments/assets/75d23dcb-6265-4a8d-bcc5-c50f83844077" />
