### PR TITLE
Fix completed status not persisting across sessions

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -287,12 +287,13 @@ export function registerIpcHandlers(): void {
         prompt: agent.prompt,
         title: agent.title,
         displayName: agent.displayName,
-        taskSummary: agent.taskSummary
+        taskSummary: agent.taskSummary,
+        persistedStatus: agent.persistedStatus
       }))
     }
   })
 
-  ipcMain.handle('agent:update-meta', async (_event, agentId: string, meta: { displayName?: string; taskSummary?: string }) => {
+  ipcMain.handle('agent:update-meta', async (_event, agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string }) => {
     try {
       agentController.updateAgentMeta(agentId, meta)
       return { ok: true }

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -31,6 +31,7 @@ export interface AgentHandle {
   title: string
   displayName: string
   taskSummary: string
+  persistedStatus?: string
   bridge: EventBridge
 }
 
@@ -42,6 +43,7 @@ interface PersistedAgentHandle {
   title: string
   displayName?: string
   taskSummary?: string
+  persistedStatus?: string
 }
 
 const ACTIVE_AGENTS_PREFERENCE_KEY = 'active_agents'
@@ -80,6 +82,7 @@ class AgentController {
           title: persistedAgent.title,
           displayName: persistedAgent.displayName ?? '',
           taskSummary: persistedAgent.taskSummary ?? '',
+          persistedStatus: persistedAgent.persistedStatus,
           bridge: this.bridges.get(runtime.id)!
         }
 
@@ -239,14 +242,15 @@ class AgentController {
   }
 
   /**
-   * Update the persisted display name and task summary for an agent.
+   * Update the persisted display name, task summary, and/or status for an agent.
    */
-  updateAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string }): void {
+  updateAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string }): void {
     const handle = this.agents.get(agentId)
     if (!handle) return
 
     if (meta.displayName !== undefined) handle.displayName = meta.displayName
     if (meta.taskSummary !== undefined) handle.taskSummary = meta.taskSummary
+    if (meta.persistedStatus !== undefined) handle.persistedStatus = meta.persistedStatus
     this.persistAgents()
   }
 
@@ -945,7 +949,8 @@ class AgentController {
       prompt: agent.prompt,
       title: agent.title,
       displayName: agent.displayName,
-      taskSummary: agent.taskSummary
+      taskSummary: agent.taskSummary,
+      persistedStatus: agent.persistedStatus
     }))
 
     database.setPreference(ACTIVE_AGENTS_PREFERENCE_KEY, JSON.stringify(persistedAgents))

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -71,7 +71,7 @@ const api = {
   listAgents: (): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:list'),
 
-  updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string }): Promise<IpcResult> =>
+  updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string }): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:update-meta', agentId, meta),
 
   getStatuses: (): Promise<IpcResult> =>

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -166,7 +166,7 @@ function emit(): void {
   }
 }
 
-function persistAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string }): void {
+function persistAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string }): void {
   window.api?.updateAgentMeta(agentId, meta)
 }
 
@@ -506,6 +506,9 @@ function processEvent(payload: OpenCodeEventPayload): void {
           } else {
             agent.blockedSince = undefined
           }
+          if (newStatus === 'completed') {
+            persistAgentMeta(agent.id, { persistedStatus: 'completed' })
+          }
           emit()
         }
       }
@@ -545,6 +548,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
         agent.status = 'completed'
         agent.lastActivityAt = Date.now()
         agent.blockedSince = undefined
+        persistAgentMeta(agent.id, { persistedStatus: 'completed' })
         emit()
       }
       break
@@ -1018,6 +1022,12 @@ function applyStatuses(statuses: AgentStatusesPayload): void {
     if (!agent) continue
 
     const nextStatus = mapSessionStatus(statusEntry.status.type)
+    // Don't let the server override a persisted completed/completed_manual status with idle.
+    // The server reports idle for finished sessions, but we want to preserve the user's
+    // manual completion or the previously-derived completed state across restarts.
+    if (nextStatus === 'idle' && (agent.status === 'completed' || agent.status === 'completed_manual')) {
+      continue
+    }
     agent.status = nextStatus
     if (nextStatus === 'needs_input' || nextStatus === 'needs_approval') {
       agent.blockedSince = agent.blockedSince ?? Date.now()
@@ -1135,7 +1145,10 @@ export function useAgentStore() {
 
       if (agentsResult.ok && agentsResult.data) {
         for (const agent of agentsResult.data) {
-          upsertAgent(agent, 'idle')
+          const restoredStatus = (agent.persistedStatus === 'completed' || agent.persistedStatus === 'completed_manual')
+            ? agent.persistedStatus as AgentStatus
+            : 'idle'
+          upsertAgent(agent, restoredStatus)
           shouldEmit = true
         }
 
@@ -1247,7 +1260,7 @@ export function useAgentStore() {
       agent.status = 'running'
       agent.lastActivityAt = Date.now()
       agent.blockedSince = undefined
-      persistAgentMeta(agentId, { taskSummary: agent.taskSummary })
+      persistAgentMeta(agentId, { taskSummary: agent.taskSummary, persistedStatus: 'running' })
     }
 
     // Optimistically clear any pending questions for this agent
@@ -1467,6 +1480,7 @@ export function useAgentStore() {
       agent.status = 'completed_manual'
     }
     agent.lastActivityAt = Date.now()
+    persistAgentMeta(agentId, { persistedStatus: agent.status })
     emit()
   }, [])
 

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -32,7 +32,7 @@ export interface OrchestratorApi {
   listTools: (agentId: string) => Promise<IpcResult>
   sendMessageWithModel: (agentId: string, text: string, providerID: string, modelID: string, attachments?: MessageAttachment[]) => Promise<IpcResult>
   listAgents: () => Promise<IpcResult<ListAgentsPayload>>
-  updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string }) => Promise<IpcResult>
+  updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string }) => Promise<IpcResult>
   getStatuses: () => Promise<IpcResult<AgentStatusesPayload>>
   replyToQuestion: (agentId: string, requestId: string, answers: string[][]) => Promise<IpcResult>
   rejectQuestion: (agentId: string, requestId: string) => Promise<IpcResult>
@@ -142,6 +142,7 @@ export interface AgentLaunchedPayload {
   title: string
   displayName?: string
   taskSummary?: string
+  persistedStatus?: string
 }
 
 export interface SessionResetPayload {


### PR DESCRIPTION
Agent status (completed, completed_manual) was never included in the persisted agent data, so all agents reverted to idle on app restart. Add persistedStatus to the persistence pipeline and restore it on session resume, guarding against the server downgrading completed agents back to idle.