### PR TITLE
Truncate slug segments to 50 chars to prevent file-name-too-long errors

### DIFF
--- a/src/main/services/workspace-manager.ts
+++ b/src/main/services/workspace-manager.ts
@@ -58,9 +58,11 @@ class WorkspaceManager {
    */
   createWorktree(repoRoot: string, projectSlug: string, taskSlug: string): WorktreeInfo {
     const timestamp = Date.now()
-    const branchName = `${projectSlug}/${taskSlug}-${timestamp}`
+    const safeProjSlug = projectSlug.slice(0, 50)
+    const safeTaskSlug = taskSlug.slice(0, 50)
+    const branchName = `${safeProjSlug}/${safeTaskSlug}-${timestamp}`
     const worktreeRoot = this.getWorktreeRoot()
-    const worktreePath = path.join(worktreeRoot, projectSlug, `${taskSlug}-${timestamp}`)
+    const worktreePath = path.join(worktreeRoot, safeProjSlug, `${safeTaskSlug}-${timestamp}`)
 
     try {
       // Ensure the parent directory exists
@@ -92,9 +94,11 @@ class WorkspaceManager {
    */
   createFreshWorktree(repoRoot: string, projectSlug: string, taskSlug: string): FreshWorktreeInfo {
     const timestamp = Date.now()
-    const branchName = `${projectSlug}/${taskSlug}-${timestamp}`
+    const safeProjSlug = projectSlug.slice(0, 50)
+    const safeTaskSlug = taskSlug.slice(0, 50)
+    const branchName = `${safeProjSlug}/${safeTaskSlug}-${timestamp}`
     const worktreeRoot = this.getWorktreeRoot()
-    const worktreePath = path.join(worktreeRoot, projectSlug, `${taskSlug}-${timestamp}`)
+    const worktreePath = path.join(worktreeRoot, safeProjSlug, `${safeTaskSlug}-${timestamp}`)
 
     try {
       const parentDir = path.dirname(worktreePath)
@@ -327,7 +331,9 @@ class WorkspaceManager {
 
     const baseRef = this.getDefaultBaseRef(repoRoot)
     const timestamp = Date.now()
-    const branchName = `${projectSlug}/${taskSlug}-${timestamp}`
+    const safeProjSlug = projectSlug.slice(0, 50)
+    const safeTaskSlug = taskSlug.slice(0, 50)
+    const branchName = `${safeProjSlug}/${safeTaskSlug}-${timestamp}`
 
     // Discard uncommitted changes, create a fresh branch off the default branch
     execSync('git clean -fd', {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -30,6 +30,7 @@ function sanitizeSlugSegment(value: string, fallback: string): string {
     .replace(/[^a-z0-9-]/g, '-')
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '')
+    .slice(0, 50)
 
   return sanitized || fallback
 }

--- a/src/renderer/src/components/LaunchModal.tsx
+++ b/src/renderer/src/components/LaunchModal.tsx
@@ -35,6 +35,7 @@ function sanitizePathSegment(value: string, fallback: string): string {
     .replace(/[^a-z0-9-]/g, '-')
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '')
+    .slice(0, 50)
 
   return sanitized || fallback
 }


### PR DESCRIPTION
When agent name is omitted, the full prompt text becomes the worktree slug, which can exceed filesystem path limits. Add .slice(0, 50) to the two renderer-side sanitization functions (matching the existing limit in agent-controller.ts) and add defensive truncation in all three WorkspaceManager worktree creation methods.