### PR TITLE
Add status override dropdown with In Review, Blocked, and Completed statuses

### DIFF
--- a/src/__tests__/filter-sort.test.ts
+++ b/src/__tests__/filter-sort.test.ts
@@ -10,11 +10,15 @@ type AgentStatus =
   | 'idle'
   | 'completed'
   | 'completed_manual'
+  | 'in_review'
+  | 'blocked_manual'
   | 'errored'
   | 'disconnected'
   | 'stopping'
 
-type StatusFilter = 'blocked' | 'running' | 'idle' | 'completed'
+type StatusOverride = 'completed_manual' | 'in_review' | 'blocked_manual'
+
+type StatusFilter = 'blocked' | 'running' | 'idle' | 'in_review' | 'completed'
 
 interface FilterState {
   statuses: Set<StatusFilter>
@@ -35,9 +39,10 @@ interface AgentRow {
 // ── Logic extracted from src/renderer/src/components/FilterBar.tsx ──
 
 const STATUS_MAP: Record<StatusFilter, AgentStatus[]> = {
-  blocked: ['needs_input', 'needs_approval'],
+  blocked: ['needs_input', 'needs_approval', 'blocked_manual'],
   running: ['running'],
   idle: ['idle'],
+  in_review: ['in_review'],
   completed: ['completed', 'completed_manual']
 }
 
@@ -65,8 +70,8 @@ function matchesFilter(
   return true
 }
 
-function canToggleManualComplete(status: AgentStatus): boolean {
-  return status === 'idle' || status === 'completed' || status === 'completed_manual'
+function displayStatus(agent: { status: AgentStatus; statusOverride?: StatusOverride | null }): AgentStatus {
+  return agent.statusOverride ?? agent.status
 }
 
 // ── Sorting and search logic ──
@@ -79,7 +84,7 @@ function isBlocked(status: AgentStatus): boolean {
 }
 
 function isUrgent(agent: AgentRow): boolean {
-  return isBlocked(agent.status) || agent.status === 'errored'
+  return isBlocked(agent.status) || agent.status === 'errored' || agent.status === 'blocked_manual'
 }
 
 function compareAgents(
@@ -163,17 +168,18 @@ describe('matchesFilter', () => {
   it('returns true for empty filter (no statuses, no projects) regardless of status', () => {
     const statuses: AgentStatus[] = [
       'starting', 'running', 'needs_input', 'needs_approval',
-      'idle', 'completed', 'completed_manual', 'errored', 'disconnected', 'stopping'
+      'idle', 'completed', 'completed_manual', 'in_review', 'blocked_manual', 'errored', 'disconnected', 'stopping'
     ]
     for (const status of statuses) {
       expect(matchesFilter({ status, projectName: 'proj' }, EMPTY)).toBe(true)
     }
   })
 
-  it('returns true for "blocked" status filter only when needs_input or needs_approval', () => {
+  it('returns true for "blocked" status filter when needs_input, needs_approval, or blocked_manual', () => {
     const filter = statusFilter('blocked')
     expect(matchesFilter({ status: 'needs_input', projectName: 'proj' }, filter)).toBe(true)
     expect(matchesFilter({ status: 'needs_approval', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'blocked_manual', projectName: 'proj' }, filter)).toBe(true)
     expect(matchesFilter({ status: 'running', projectName: 'proj' }, filter)).toBe(false)
     expect(matchesFilter({ status: 'idle', projectName: 'proj' }, filter)).toBe(false)
     expect(matchesFilter({ status: 'errored', projectName: 'proj' }, filter)).toBe(false)
@@ -201,6 +207,15 @@ describe('matchesFilter', () => {
     expect(matchesFilter({ status: 'completed', projectName: 'proj' }, filter)).toBe(true)
     expect(matchesFilter({ status: 'completed_manual', projectName: 'proj' }, filter)).toBe(true)
     expect(matchesFilter({ status: 'idle', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'errored', projectName: 'proj' }, filter)).toBe(false)
+  })
+
+  it('returns true for "in_review" status filter only when in_review', () => {
+    const filter = statusFilter('in_review')
+    expect(matchesFilter({ status: 'in_review', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'completed', projectName: 'proj' }, filter)).toBe(false)
     expect(matchesFilter({ status: 'running', projectName: 'proj' }, filter)).toBe(false)
     expect(matchesFilter({ status: 'errored', projectName: 'proj' }, filter)).toBe(false)
   })
@@ -412,22 +427,57 @@ describe('sortUrgentFirst', () => {
     const sorted = sortUrgentFirst([manual, running, blocked])
     expect(sorted[0].id).toBe('b')
   })
-})
 
-describe('canToggleManualComplete', () => {
-  it('returns true for idle, completed, and completed_manual', () => {
-    expect(canToggleManualComplete('idle')).toBe(true)
-    expect(canToggleManualComplete('completed')).toBe(true)
-    expect(canToggleManualComplete('completed_manual')).toBe(true)
+  it('does not treat in_review as urgent', () => {
+    const running = createAgent({ id: 'r', status: 'running' })
+    const review = createAgent({ id: 'rv', status: 'in_review' })
+    const blocked = createAgent({ id: 'b', status: 'needs_input' })
+    const sorted = sortUrgentFirst([review, running, blocked])
+    expect(sorted[0].id).toBe('b')
   })
 
-  it('returns false for active/blocked statuses', () => {
-    expect(canToggleManualComplete('running')).toBe(false)
-    expect(canToggleManualComplete('starting')).toBe(false)
-    expect(canToggleManualComplete('needs_input')).toBe(false)
-    expect(canToggleManualComplete('needs_approval')).toBe(false)
-    expect(canToggleManualComplete('errored')).toBe(false)
-    expect(canToggleManualComplete('disconnected')).toBe(false)
-    expect(canToggleManualComplete('stopping')).toBe(false)
+  it('treats blocked_manual as urgent', () => {
+    const running = createAgent({ id: 'r', status: 'running' })
+    const blockedManual = createAgent({ id: 'bm', status: 'blocked_manual' })
+    const idle = createAgent({ id: 'i', status: 'idle' })
+    const sorted = sortUrgentFirst([idle, running, blockedManual])
+    expect(sorted[0].id).toBe('bm')
+  })
+})
+
+describe('displayStatus', () => {
+  it('returns the override when set', () => {
+    expect(displayStatus({ status: 'idle', statusOverride: 'completed_manual' })).toBe('completed_manual')
+    expect(displayStatus({ status: 'running', statusOverride: 'in_review' })).toBe('in_review')
+    expect(displayStatus({ status: 'completed', statusOverride: 'blocked_manual' })).toBe('blocked_manual')
+  })
+
+  it('returns the real status when override is null', () => {
+    expect(displayStatus({ status: 'idle', statusOverride: null })).toBe('idle')
+    expect(displayStatus({ status: 'running', statusOverride: null })).toBe('running')
+    expect(displayStatus({ status: 'errored', statusOverride: null })).toBe('errored')
+  })
+
+  it('returns the real status when override is undefined', () => {
+    expect(displayStatus({ status: 'idle' })).toBe('idle')
+    expect(displayStatus({ status: 'running' })).toBe('running')
+  })
+
+  it('override persists even when agent is running', () => {
+    expect(displayStatus({ status: 'running', statusOverride: 'in_review' })).toBe('in_review')
+    expect(displayStatus({ status: 'running', statusOverride: 'blocked_manual' })).toBe('blocked_manual')
+    expect(displayStatus({ status: 'running', statusOverride: 'completed_manual' })).toBe('completed_manual')
+  })
+})
+
+describe('blocked_manual in filters', () => {
+  it('blocked_manual matches the "blocked" filter', () => {
+    const filter = statusFilter('blocked')
+    expect(matchesFilter({ status: 'blocked_manual', projectName: 'proj' }, filter)).toBe(true)
+  })
+
+  it('blocked_manual does not match "running" or "idle" filters', () => {
+    expect(matchesFilter({ status: 'blocked_manual', projectName: 'proj' }, statusFilter('running'))).toBe(false)
+    expect(matchesFilter({ status: 'blocked_manual', projectName: 'proj' }, statusFilter('idle'))).toBe(false)
   })
 })

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -11,7 +11,7 @@ import { CommandPalette } from './components/CommandPalette'
 import { ModelPickerModal } from './components/ModelPickerModal'
 import { McpModal } from './components/McpModal'
 import { useAgentStore, setViewedAgentId, type LiveAgent } from './hooks/useAgentStore'
-import { type AgentRuntime, type Interrupt, type Message } from './types'
+import { type AgentRuntime, type Interrupt, type Message, type StatusOverride, displayStatus } from './types'
 import type { FileChange } from './components/FilesChanged'
 import type { ToolCall } from './components/ToolsUsage'
 import type { EventEntry } from './components/EventLog'
@@ -189,7 +189,8 @@ export function App() {
       isWorktree: agent.isWorktree,
       workspaceName: agent.workspaceName,
       taskSummary: agent.taskSummary,
-      status: agent.status,
+      status: displayStatus(agent),
+      statusOverride: agent.statusOverride,
       model: agent.model,
       lastActivityAt: formatTimeAgo(agent.lastActivityAt),
       lastActivityAtMs: agent.lastActivityAt,
@@ -472,9 +473,10 @@ export function App() {
   const counts = useMemo(
     () => ({
       all: displayAgents.length,
-      blocked: displayAgents.filter((agent) => agent.status === 'needs_input' || agent.status === 'needs_approval').length,
+      blocked: displayAgents.filter((agent) => agent.status === 'needs_input' || agent.status === 'needs_approval' || agent.status === 'blocked_manual').length,
       running: displayAgents.filter((agent) => agent.status === 'running').length,
       idle: displayAgents.filter((agent) => agent.status === 'idle').length,
+      in_review: displayAgents.filter((agent) => agent.status === 'in_review').length,
       completed: displayAgents.filter((agent) => agent.status === 'completed' || agent.status === 'completed_manual').length
     }),
     [displayAgents]
@@ -527,8 +529,8 @@ export function App() {
     setSelectedAgentId(agentId)
   }, [])
 
-  const handleToggleComplete = useCallback((agentId: string) => {
-    store.toggleManualComplete(agentId)
+  const handleSetStatusOverride = useCallback((agentId: string, override: StatusOverride | null) => {
+    store.setStatusOverride(agentId, override)
   }, [store])
 
   const handleRemoveAgent = useCallback(async (agentId: string) => {
@@ -958,7 +960,7 @@ export function App() {
           setModelPickerAgentId(agentId)
           setShowModelPicker(true)
         }}
-        onToggleComplete={handleToggleComplete}
+        onSetStatusOverride={handleSetStatusOverride}
       />
 
       <StatusBar
@@ -991,7 +993,7 @@ export function App() {
           onOpenInEditor={handleOpenInEditor}
           onChangeModel={() => { setModelPickerAgentId(selectedAgentId); setShowModelPicker(true) }}
           onOpenTerminal={handleOpenTerminalForDrawer}
-          onToggleComplete={() => handleToggleComplete(selectedAgent.id)}
+          onSetStatusOverride={(override) => handleSetStatusOverride(selectedAgent.id, override)}
         />
       )}
 

--- a/src/renderer/src/app.css
+++ b/src/renderer/src/app.css
@@ -38,6 +38,8 @@
   --color-status-idle-bg: rgba(234, 179, 8, 0.1);
   --color-status-completed: #86efac;
   --color-status-completed-bg: rgba(34, 197, 94, 0.06);
+  --color-status-in-review: #c084fc;
+  --color-status-in-review-bg: rgba(168, 85, 247, 0.1);
   --color-status-errored: #f87171;
   --color-status-errored-bg: rgba(239, 68, 68, 0.1);
 

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -3,10 +3,8 @@ import {
   X,
   Square,
   Check,
-  CheckCircle,
   XCircle,
   ArrowSquareOut,
-  ArrowCounterClockwise,
   GitPullRequest,
   Terminal,
   Wrench,
@@ -19,10 +17,11 @@ import {
   PaperPlaneTilt,
   Paperclip
 } from '@phosphor-icons/react'
-import type { AgentRuntime, Message } from '../types'
-import { formatBranchLabel, canToggleManualComplete } from '../types'
+import type { AgentRuntime, Message, StatusOverride } from '../types'
+import { formatBranchLabel } from '../types'
 import type { LivePermission, LiveQuestion } from '../hooks/useAgentStore'
 import { StatusBadge } from './StatusBadge'
+import { StatusDropdown } from './StatusDropdown'
 import { Markdown } from './Markdown'
 import { FilesChanged } from './FilesChanged'
 import { ToolsUsage } from './ToolsUsage'
@@ -84,7 +83,7 @@ interface DetailDrawerProps {
   onOpenInEditor?: () => void
   onChangeModel?: () => void
   onOpenTerminal?: () => void
-  onToggleComplete?: () => void
+  onSetStatusOverride?: (override: StatusOverride | null) => void
 }
 
 export function DetailDrawer({
@@ -110,7 +109,7 @@ export function DetailDrawer({
   onOpenInEditor,
   onChangeModel,
   onOpenTerminal,
-  onToggleComplete
+  onSetStatusOverride
 }: DetailDrawerProps) {
   const [inputText, setInputText] = useState('')
   const [activeTab, setActiveTab] = useState<TabKey>('transcript')
@@ -612,11 +611,11 @@ export function DetailDrawer({
           {onAbort && (agent.status === 'running' || agent.status === 'needs_approval' || agent.status === 'needs_input' || agent.status === 'stopping') && (
             <ActionButton icon={<Square size={12} weight="fill" />} label={agent.status === 'stopping' ? 'Stopping…' : 'Stop'} onClick={onAbort} disabled={agent.status === 'stopping'} />
           )}
-          {onToggleComplete && canToggleManualComplete(agent.status) && (
-            <ActionButton
-              icon={agent.status === 'completed_manual' ? <ArrowCounterClockwise size={12} /> : <CheckCircle size={12} />}
-              label={agent.status === 'completed_manual' ? 'Unmark' : 'Complete'}
-              onClick={onToggleComplete}
+          {onSetStatusOverride && (
+            <StatusDropdown
+              current={agent.statusOverride}
+              onSelect={onSetStatusOverride}
+              variant="action"
             />
           )}
           <div className="flex-1" />

--- a/src/renderer/src/components/FilterBar.tsx
+++ b/src/renderer/src/components/FilterBar.tsx
@@ -1,7 +1,7 @@
 import { MagnifyingGlass } from '@phosphor-icons/react'
 import type { AgentStatus } from '../types'
 
-export type StatusFilter = 'blocked' | 'running' | 'idle' | 'completed'
+export type StatusFilter = 'blocked' | 'running' | 'idle' | 'in_review' | 'completed'
 
 export interface FilterState {
   statuses: Set<StatusFilter>
@@ -29,6 +29,7 @@ interface FilterBarProps {
     blocked: number
     running: number
     idle: number
+    in_review: number
     completed: number
   }
   projects: string[]
@@ -68,6 +69,7 @@ export function FilterBar({
       <FilterPill label={`Blocked (${counts.blocked})`} active={filter.statuses.has('blocked')} onClick={() => onToggleStatus('blocked')} />
       <FilterPill label={`Running (${counts.running})`} active={filter.statuses.has('running')} onClick={() => onToggleStatus('running')} />
       <FilterPill label={`Idle (${counts.idle})`} active={filter.statuses.has('idle')} onClick={() => onToggleStatus('idle')} />
+      <FilterPill label={`In Review (${counts.in_review})`} active={filter.statuses.has('in_review')} onClick={() => onToggleStatus('in_review')} />
       <FilterPill label={`Completed (${counts.completed})`} active={filter.statuses.has('completed')} onClick={() => onToggleStatus('completed')} />
 
       <div className="w-px h-5 bg-kumo-line" />
@@ -109,9 +111,10 @@ function FilterPill({
 }
 
 const STATUS_MAP: Record<StatusFilter, AgentStatus[]> = {
-  blocked: ['needs_input', 'needs_approval'],
+  blocked: ['needs_input', 'needs_approval', 'blocked_manual'],
   running: ['running'],
   idle: ['idle'],
+  in_review: ['in_review'],
   completed: ['completed', 'completed_manual']
 }
 

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -4,7 +4,6 @@ import {
   CaretUp,
   CaretDown,
   Check,
-  CheckCircle,
   GearSix,
   Pause,
   PencilSimple,
@@ -13,12 +12,12 @@ import {
   Trash,
   Terminal,
   GitPullRequest,
-  ArrowSquareOut,
-  ArrowCounterClockwise
+  ArrowSquareOut
 } from '@phosphor-icons/react'
-import type { AgentRuntime } from '../types'
-import { formatBranchLabel, isUrgent, canToggleManualComplete } from '../types'
+import type { AgentRuntime, StatusOverride } from '../types'
+import { formatBranchLabel, isUrgent } from '../types'
 import { StatusBadge } from './StatusBadge'
+import { StatusDropdown } from './StatusDropdown'
 
 interface FleetTableProps {
   agents: AgentRuntime[]
@@ -35,7 +34,7 @@ interface FleetTableProps {
   onOpenInEditor?: (agentId: string) => void
   onCreatePr?: (agentId: string) => void
   onChangeModel?: (agentId: string) => void
-  onToggleComplete?: (agentId: string) => void
+  onSetStatusOverride?: (agentId: string, override: StatusOverride | null) => void
 }
 
 type SortColumn = 'agent' | 'status' | 'task' | 'branch' | 'model' | 'activity'
@@ -76,7 +75,7 @@ export function FleetTable({
   onOpenInEditor,
   onCreatePr,
   onChangeModel,
-  onToggleComplete
+  onSetStatusOverride
 }: FleetTableProps) {
   const [sortColumn, setSortColumn] = useState<SortColumn | null>(null)
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
@@ -197,7 +196,7 @@ export function FleetTable({
               onOpen={onOpen ? () => onOpen(agent.id) : () => onSelect(agent.id)}
               onRemove={onRemove ? () => onRemove(agent.id) : undefined}
               onChangeModel={onChangeModel ? () => onChangeModel(agent.id) : undefined}
-              onToggleComplete={onToggleComplete ? () => onToggleComplete(agent.id) : undefined}
+              onSetStatusOverride={onSetStatusOverride ? (override: StatusOverride | null) => onSetStatusOverride(agent.id, override) : undefined}
             />
           ))}
         </tbody>
@@ -242,8 +241,8 @@ export function FleetTable({
             onCreatePr?.(contextMenu.agentId)
             closeContextMenu()
           }}
-          onToggleComplete={() => {
-            onToggleComplete?.(contextMenu.agentId)
+          onSetStatusOverride={(override: StatusOverride | null) => {
+            onSetStatusOverride?.(contextMenu.agentId, override)
             closeContextMenu()
           }}
         />
@@ -347,7 +346,7 @@ function ContextMenu({
   onOpenTerminal,
   onOpenInEditor,
   onCreatePr,
-  onToggleComplete
+  onSetStatusOverride
 }: {
   agent: AgentRuntime
   posX: number
@@ -361,7 +360,7 @@ function ContextMenu({
   onOpenTerminal: () => void
   onOpenInEditor: () => void
   onCreatePr: () => void
-  onToggleComplete: () => void
+  onSetStatusOverride: (override: StatusOverride | null) => void
 }) {
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -427,14 +426,14 @@ function ContextMenu({
       <button className={itemClass} onClick={onCreatePr}>
         <GitPullRequest size={13} /> Create PR
       </button>
-      {canToggleManualComplete(agent.status) && (
-        <button className={itemClass} onClick={onToggleComplete}>
-          {agent.status === 'completed_manual'
-            ? <><ArrowCounterClockwise size={13} /> Unmark Completed</>
-            : <><CheckCircle size={13} /> Mark Completed</>
-          }
-        </button>
-      )}
+      <div className="px-2.5 py-1.5">
+        <div className="text-[10px] text-kumo-subtle uppercase tracking-wide mb-1">Status Override</div>
+        <StatusDropdown
+          current={agent.statusOverride}
+          onSelect={onSetStatusOverride}
+          variant="action"
+        />
+      </div>
 
       <div className="my-1 border-t border-kumo-line" />
 
@@ -465,7 +464,7 @@ function AgentRow({
   onOpen,
   onRemove,
   onChangeModel,
-  onToggleComplete
+  onSetStatusOverride
 }: {
   agent: AgentRuntime
   selected: boolean
@@ -477,7 +476,7 @@ function AgentRow({
   onOpen?: () => void
   onRemove?: () => void
   onChangeModel?: () => void
-  onToggleComplete?: () => void
+  onSetStatusOverride?: (override: StatusOverride | null) => void
 }) {
   const urgent = isUrgent(agent)
   const isStale = !!agent.blockedSince
@@ -539,7 +538,7 @@ function AgentRow({
             onStop={onStop}
             onOpen={onOpen}
             onRemove={onRemove}
-            onToggleComplete={onToggleComplete}
+            onSetStatusOverride={onSetStatusOverride}
           />
           <button
             onClick={(event) => { event.stopPropagation(); onContextMenu(event) }}
@@ -561,7 +560,7 @@ function RowActions({
   onStop,
   onOpen,
   onRemove,
-  onToggleComplete
+  onSetStatusOverride
 }: {
   agent: AgentRuntime
   onApprove?: () => void
@@ -569,7 +568,7 @@ function RowActions({
   onStop?: () => void
   onOpen?: () => void
   onRemove?: () => void
-  onToggleComplete?: () => void
+  onSetStatusOverride?: (override: StatusOverride | null) => void
 }) {
   const buttonBase = 'w-6 h-6 flex items-center justify-center bg-kumo-fill border border-kumo-line rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors cursor-pointer'
   const destructiveButton = 'w-6 h-6 flex items-center justify-center bg-kumo-danger/10 border border-kumo-danger/20 rounded text-kumo-danger hover:bg-kumo-danger/20 transition-colors cursor-pointer'
@@ -603,17 +602,12 @@ function RowActions({
           <Pause size={12} weight="bold" />
         </button>
       )}
-      {canToggleManualComplete(agent.status) && (
-        <button
-          className={buttonBase}
-          title={agent.status === 'completed_manual' ? 'Unmark Completed' : 'Mark Completed'}
-          onClick={(event) => { event.stopPropagation(); onToggleComplete?.() }}
-        >
-          {agent.status === 'completed_manual'
-            ? <ArrowCounterClockwise size={12} weight="bold" />
-            : <CheckCircle size={12} weight="bold" />
-          }
-        </button>
+      {onSetStatusOverride && (
+        <StatusDropdown
+          current={agent.statusOverride}
+          onSelect={onSetStatusOverride}
+          variant="row"
+        />
       )}
       <button
         className={buttonBase}

--- a/src/renderer/src/components/StatusBadge.tsx
+++ b/src/renderer/src/components/StatusBadge.tsx
@@ -12,13 +12,15 @@ const statusStyles: Record<string, string> = {
   idle: 'bg-status-idle-bg text-status-idle',
   completed: 'bg-status-completed-bg text-status-completed',
   completed_manual: 'bg-status-completed-bg text-status-completed',
+  in_review: 'bg-status-in-review-bg text-status-in-review',
+  blocked_manual: 'bg-status-errored-bg text-status-errored',
   errored: 'bg-status-errored-bg text-status-errored',
   starting: 'bg-kumo-fill text-kumo-subtle',
   stopping: 'bg-kumo-fill text-kumo-subtle',
   disconnected: 'bg-status-errored-bg text-status-errored'
 }
 
-const pulsing = new Set<AgentStatus>(['needs_input', 'needs_approval', 'errored'])
+const pulsing = new Set<AgentStatus>(['needs_input', 'needs_approval', 'errored', 'blocked_manual'])
 
 export function StatusBadge({ status }: StatusBadgeProps) {
   const style = statusStyles[status] ?? 'bg-kumo-fill text-kumo-subtle'

--- a/src/renderer/src/components/StatusDropdown.tsx
+++ b/src/renderer/src/components/StatusDropdown.tsx
@@ -1,0 +1,119 @@
+import { useState, useRef, useEffect } from 'react'
+import {
+  CaretDown,
+  CheckCircle,
+  Eye,
+  Warning,
+  ArrowsClockwise
+} from '@phosphor-icons/react'
+import type { StatusOverride } from '../types'
+import { statusOverrideLabel } from '../types'
+
+const OVERRIDE_OPTIONS: { value: StatusOverride | null; label: string; icon: React.ReactNode }[] = [
+  { value: null, label: 'Auto', icon: <ArrowsClockwise size={12} /> },
+  { value: 'completed_manual', label: 'Completed', icon: <CheckCircle size={12} /> },
+  { value: 'in_review', label: 'In Review', icon: <Eye size={12} /> },
+  { value: 'blocked_manual', label: 'Blocked', icon: <Warning size={12} /> }
+]
+
+interface StatusDropdownProps {
+  current: StatusOverride | null
+  onSelect: (override: StatusOverride | null) => void
+  variant?: 'row' | 'action'
+}
+
+export function StatusDropdown({ current, onSelect, variant = 'row' }: StatusDropdownProps) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleEscape)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleEscape)
+    }
+  }, [open])
+
+  const currentLabel = statusOverrideLabel(current)
+
+  if (variant === 'action') {
+    return (
+      <div ref={containerRef} className="relative">
+        <button
+          onClick={(event) => { event.stopPropagation(); setOpen(!open) }}
+          className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md border bg-kumo-control border-kumo-line text-kumo-default hover:bg-kumo-fill transition-colors"
+        >
+          {OVERRIDE_OPTIONS.find((o) => o.value === current)?.icon}
+          {currentLabel}
+          <CaretDown size={10} className="ml-0.5" />
+        </button>
+        {open && (
+          <div className="absolute bottom-full left-0 mb-1 z-[100] min-w-[140px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl">
+            {OVERRIDE_OPTIONS.map((option) => (
+              <button
+                key={option.label}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onSelect(option.value)
+                  setOpen(false)
+                }}
+                className={`flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] rounded transition-colors text-left ${
+                  option.value === current
+                    ? 'bg-kumo-interact/12 text-kumo-link'
+                    : 'text-kumo-default hover:bg-kumo-fill'
+                }`}
+              >
+                {option.icon}
+                {option.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        onClick={(event) => { event.stopPropagation(); setOpen(!open) }}
+        className="w-6 h-6 flex items-center justify-center bg-kumo-fill border border-kumo-line rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors cursor-pointer"
+        title={`Status: ${currentLabel}`}
+      >
+        <CaretDown size={10} />
+      </button>
+      {open && (
+        <div className="absolute top-full right-0 mt-1 z-[100] min-w-[140px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl">
+          {OVERRIDE_OPTIONS.map((option) => (
+            <button
+              key={option.label}
+              onClick={(event) => {
+                event.stopPropagation()
+                onSelect(option.value)
+                setOpen(false)
+              }}
+              className={`flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] rounded transition-colors text-left ${
+                option.value === current
+                  ? 'bg-kumo-interact/12 text-kumo-link'
+                  : 'text-kumo-default hover:bg-kumo-fill'
+              }`}
+            >
+              {option.icon}
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useSyncExternalStore } from 'react'
-import type { AgentStatus } from '../types'
+import type { AgentStatus, StatusOverride } from '../types'
 import type {
   OpenCodeEventPayload,
   AgentLaunchedPayload,
@@ -58,6 +58,7 @@ export interface LiveAgent {
   workspaceName: string
   taskSummary: string
   status: AgentStatus
+  statusOverride: StatusOverride | null
   model: string
   lastActivityAt: number
   blockedSince?: number
@@ -1003,6 +1004,7 @@ function upsertAgent(payload: AgentLaunchedPayload, initialStatus?: AgentStatus)
     workspaceName: payload.workspaceName ?? existingAgent?.workspaceName ?? payload.directory.split('/').pop() ?? payload.directory,
     taskSummary: payload.taskSummary || existingAgent?.taskSummary || (hasPrompt ? payload.prompt.slice(0, 120) : 'Waiting for prompt...'),
     status: initialStatus ?? existingAgent?.status ?? (hasPrompt ? 'running' : 'idle'),
+    statusOverride: existingAgent?.statusOverride ?? null,
     model: existingAgent?.model ?? 'starting...',
     lastActivityAt: existingAgent?.lastActivityAt ?? Date.now(),
     cost: existingAgent?.cost ?? 0,
@@ -1022,10 +1024,9 @@ function applyStatuses(statuses: AgentStatusesPayload): void {
     if (!agent) continue
 
     const nextStatus = mapSessionStatus(statusEntry.status.type)
-    // Don't let the server override a persisted completed/completed_manual status with idle.
-    // The server reports idle for finished sessions, but we want to preserve the user's
-    // manual completion or the previously-derived completed state across restarts.
-    if (nextStatus === 'idle' && (agent.status === 'completed' || agent.status === 'completed_manual')) {
+    // Don't let the server override a derived completed status with idle.
+    // The server reports idle for finished sessions, but we track completion separately.
+    if (nextStatus === 'idle' && agent.status === 'completed') {
       continue
     }
     agent.status = nextStatus
@@ -1145,10 +1146,14 @@ export function useAgentStore() {
 
       if (agentsResult.ok && agentsResult.data) {
         for (const agent of agentsResult.data) {
-          const restoredStatus = (agent.persistedStatus === 'completed' || agent.persistedStatus === 'completed_manual')
-            ? agent.persistedStatus as AgentStatus
-            : 'idle'
-          upsertAgent(agent, restoredStatus)
+          const restoredOverride = (agent.persistedStatus === 'completed_manual' || agent.persistedStatus === 'in_review' || agent.persistedStatus === 'blocked_manual')
+            ? agent.persistedStatus as StatusOverride
+            : null
+          upsertAgent(agent, restoredOverride ? undefined : 'idle')
+          const liveAgent = state.agents.get(agent.id)
+          if (liveAgent && restoredOverride) {
+            liveAgent.statusOverride = restoredOverride
+          }
           shouldEmit = true
         }
 
@@ -1471,16 +1476,12 @@ export function useAgentStore() {
     emit()
   }, [])
 
-  const toggleManualComplete = useCallback((agentId: string) => {
+  const setStatusOverride = useCallback((agentId: string, override: StatusOverride | null) => {
     const agent = state.agents.get(agentId)
     if (!agent) return
-    if (agent.status === 'completed_manual') {
-      agent.status = 'idle'
-    } else if (agent.status === 'idle' || agent.status === 'completed') {
-      agent.status = 'completed_manual'
-    }
+    agent.statusOverride = override
     agent.lastActivityAt = Date.now()
-    persistAgentMeta(agentId, { persistedStatus: agent.status })
+    persistAgentMeta(agentId, { persistedStatus: override ?? '' })
     emit()
   }, [])
 
@@ -1503,7 +1504,7 @@ export function useAgentStore() {
     removeAgent,
     renameAgent,
     setAgentModel,
-    toggleManualComplete,
+    setStatusOverride,
     selectDirectory,
     getMessagesForSession,
     getFileChangesForSession,

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -8,9 +8,13 @@ export type AgentStatus =
   | 'idle'
   | 'completed'
   | 'completed_manual'
+  | 'in_review'
+  | 'blocked_manual'
   | 'errored'
   | 'disconnected'
   | 'stopping'
+
+export type StatusOverride = 'completed_manual' | 'in_review' | 'blocked_manual'
 
 export type InterruptKind =
   | 'needs_input'
@@ -37,6 +41,7 @@ export interface AgentRuntime {
   workspaceName: string
   taskSummary: string
   status: AgentStatus
+  statusOverride: StatusOverride | null
   model: string
   lastActivityAt: string
   lastActivityAtMs: number
@@ -77,11 +82,11 @@ export function isBlocked(status: AgentStatus): boolean {
 }
 
 export function isUrgent(agent: AgentRuntime): boolean {
-  return isBlocked(agent.status) || agent.status === 'errored'
+  return isBlocked(agent.status) || agent.status === 'errored' || agent.status === 'blocked_manual'
 }
 
-export function canToggleManualComplete(status: AgentStatus): boolean {
-  return status === 'idle' || status === 'completed' || status === 'completed_manual'
+export function displayStatus(agent: { status: AgentStatus; statusOverride?: StatusOverride | null }): AgentStatus {
+  return agent.statusOverride ?? agent.status
 }
 
 export function formatBranchLabel(agent: Pick<AgentRuntime, 'branchName'>): string {
@@ -97,9 +102,21 @@ export function statusLabel(status: AgentStatus): string {
     idle: 'Idle',
     completed: 'Completed',
     completed_manual: 'Completed',
+    in_review: 'In Review',
+    blocked_manual: 'Blocked',
     errored: 'Errored',
     disconnected: 'Disconnected',
     stopping: 'Stopping'
   }
   return labels[status]
+}
+
+export function statusOverrideLabel(override: StatusOverride | null): string {
+  if (!override) return 'Auto'
+  const labels: Record<StatusOverride, string> = {
+    completed_manual: 'Completed',
+    in_review: 'In Review',
+    blocked_manual: 'Blocked'
+  }
+  return labels[override]
 }


### PR DESCRIPTION
Replace individual toggle buttons with a unified StatusDropdown component that lets users set a persistent status override (Auto, Completed, In Review, Blocked) on any agent. Overrides are stored separately from the server-driven status so they survive across agent runs - marking an agent 'In Review' keeps that status even when sending new commands.

Key changes:
- New StatusOverride type (completed_manual | in_review | blocked_manual)
- statusOverride field on LiveAgent, persisted via agent meta
- Displayed status derived as override ?? real status
- StatusDropdown component used in row actions, context menu, detail drawer
- In Review filter pill in FilterBar with purple badge
- Blocked manual treated as urgent (red badge, pulsing, sorts to top)

<img width="231" height="224" alt="Screenshot 2026-04-02 at 8 50 27 AM" src="https://github.com/user-attachments/assets/69af9dab-5258-420a-9514-c3a03ee90a60" />

<img width="822" height="354" alt="Screenshot 2026-04-02 at 8 50 41 AM" src="https://github.com/user-attachments/assets/839db8d4-1a9a-4a10-8203-32ad45e11ee4" />
