### PR TITLE
Replace freeform directory input with persistent saved project selector

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -403,6 +403,16 @@ export function registerIpcHandlers(): void {
     }
   })
 
+  ipcMain.handle('workspace:common-repo-root', async (_event, directory: string) => {
+    try {
+      const repoRoot = workspaceManager.getCommonRepoRoot(directory)
+      return { ok: true, data: repoRoot }
+    } catch (error) {
+      console.error('[IPC] workspace:common-repo-root failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
   ipcMain.handle('workspace:create', async (_event, options: {
     repoRoot: string
     projectSlug: string
@@ -485,6 +495,19 @@ export function registerIpcHandlers(): void {
       return { ok: true, data: project }
     } catch (error) {
       console.error('[IPC] db:projects:create failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  ipcMain.handle('db:projects:ensure', async (_event, options: {
+    name: string
+    repoRoot: string
+  }) => {
+    try {
+      const project = database.ensureProject(options.name, options.repoRoot)
+      return { ok: true, data: project }
+    } catch (error) {
+      console.error('[IPC] db:projects:ensure failed:', error)
       return { ok: false, error: String(error) }
     }
   })

--- a/src/main/services/database.ts
+++ b/src/main/services/database.ts
@@ -223,8 +223,25 @@ class Database {
     return this.queryOne<Project>('SELECT * FROM projects WHERE id = ?', [projectId])
   }
 
+  getProjectByRepoRoot(repoRoot: string): Project | undefined {
+    return this.queryOne<Project>('SELECT * FROM projects WHERE repo_root = ?', [repoRoot])
+  }
+
   getAllProjects(): Project[] {
     return this.queryAll<Project>('SELECT * FROM projects ORDER BY updated_at DESC')
+  }
+
+  ensureProject(name: string, repoRoot: string): Project {
+    const existing = this.getProjectByRepoRoot(repoRoot)
+    if (existing) {
+      const now = new Date().toISOString()
+      this.execute(
+        'UPDATE projects SET name = ?, updated_at = ? WHERE id = ?',
+        [name, now, existing.id]
+      )
+      return this.getProject(existing.id)!
+    }
+    return this.createProject(name, repoRoot)
   }
 
   deleteProject(projectId: string): boolean {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -113,6 +113,9 @@ const api = {
   getRepoRoot: (directory: string): Promise<IpcResult<string>> =>
     ipcRenderer.invoke('workspace:repo-root', directory),
 
+  getCommonRepoRoot: (directory: string): Promise<IpcResult<string>> =>
+    ipcRenderer.invoke('workspace:common-repo-root', directory),
+
   createWorktree: (options: { repoRoot: string; projectSlug: string; taskSlug: string }): Promise<IpcResult<{ worktreePath: string; branchName: string }>> =>
     ipcRenderer.invoke('workspace:create', options),
 
@@ -134,6 +137,9 @@ const api = {
 
   createProject: (options: { name: string; repoRoot: string }): Promise<IpcResult> =>
     ipcRenderer.invoke('db:projects:create', options),
+
+  ensureProject: (options: { name: string; repoRoot: string }): Promise<IpcResult> =>
+    ipcRenderer.invoke('db:projects:ensure', options),
 
   deleteProject: (projectId: string): Promise<IpcResult> =>
     ipcRenderer.invoke('db:projects:delete', projectId),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -714,8 +714,7 @@ export function App() {
     if (worktreeStrategy === 'new-worktree') {
       const repoRootResult = await window.api.getRepoRoot(directory)
       if (!repoRootResult.ok || !repoRootResult.data) {
-        console.error('Failed to resolve repo root for launch:', repoRootResult.error)
-        return
+        throw new Error(repoRootResult.error || 'Failed to resolve repo root')
       }
 
       const directoryParts = directory.replace(/\/$/, '').split('/').filter(Boolean)
@@ -729,8 +728,7 @@ export function App() {
       })
 
       if (!worktreeResult.ok || !worktreeResult.data) {
-        console.error('Failed to create worktree for launch:', worktreeResult.error)
-        return
+        throw new Error(worktreeResult.error || 'Failed to create worktree')
       }
 
       launchDirectory = worktreeResult.data.worktreePath
@@ -738,9 +736,13 @@ export function App() {
 
     const result = await store.launchAgent(launchDirectory, prompt || undefined, title, model)
 
+    if (!result?.ok) {
+      throw new Error('Failed to launch agent')
+    }
+
     // Auto-open the detail drawer for the newly launched agent
     // (especially useful when no prompt is given so the user can interact immediately)
-    if (result?.ok && result.data) {
+    if (result.data) {
       const data = result.data as { id: string }
       setSelectedAgentId(data.id)
 
@@ -1001,6 +1003,11 @@ export function App() {
           onLaunch={handleLaunch}
           onSelectDirectory={store.selectDirectory}
           onValidateDirectory={handleValidateDirectory}
+          knownDirectories={store.agents.map((a) => ({
+            name: a.projectName,
+            directory: a.directory,
+            isWorktree: a.isWorktree
+          }))}
         />
       )}
 

--- a/src/renderer/src/components/LaunchModal.tsx
+++ b/src/renderer/src/components/LaunchModal.tsx
@@ -1,32 +1,11 @@
-import { useState, useEffect, useMemo } from 'react'
-import { X, FolderOpen, Clock, Warning } from '@phosphor-icons/react'
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
+import { X, FolderOpen, CaretDown, Warning, Trash } from '@phosphor-icons/react'
 import { SelectField } from './SelectField'
 import { useModelOptions } from '../hooks/useModelOptions'
 import { loadSettings } from '../data/settings'
+import type { Project } from '../types/api'
 
 type WorktreeStrategy = 'new-worktree' | 'current-directory'
-
-const RECENT_DIRS_KEY = 'oc-orchestrator:recent-directories'
-const MAX_RECENT_DIRS = 5
-
-function loadRecentDirs(): string[] {
-  try {
-    const stored = localStorage.getItem(RECENT_DIRS_KEY)
-    if (stored) {
-      const parsed = JSON.parse(stored)
-      if (Array.isArray(parsed)) return parsed.slice(0, MAX_RECENT_DIRS)
-    }
-  } catch {
-    // ignore parse errors
-  }
-  return []
-}
-
-function saveRecentDir(dir: string): void {
-  const recent = loadRecentDirs().filter((entry) => entry !== dir)
-  recent.unshift(dir)
-  localStorage.setItem(RECENT_DIRS_KEY, JSON.stringify(recent.slice(0, MAX_RECENT_DIRS)))
-}
 
 function sanitizePathSegment(value: string, fallback: string): string {
   const sanitized = value
@@ -50,14 +29,26 @@ function computeWorktreePath(worktreeRoot: string, directory: string, title: str
   return `${worktreeRoot}/${projectSlug}/${taskSlug}-<timestamp>`
 }
 
+function dirDisplayName(path: string): string {
+  const parts = path.replace(/\/$/, '').split('/').filter(Boolean)
+  return parts.length > 0 ? parts[parts.length - 1] : path
+}
+
+interface KnownDirectory {
+  name: string
+  directory: string
+  isWorktree?: boolean
+}
+
 interface LaunchModalProps {
   onClose: () => void
   onLaunch: (directory: string, prompt?: string, title?: string, model?: string, worktreeStrategy?: string) => void
   onSelectDirectory: () => Promise<string | null>
   onValidateDirectory?: (dir: string) => Promise<boolean>
+  knownDirectories?: KnownDirectory[]
 }
 
-export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDirectory }: LaunchModalProps) {
+export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDirectory, knownDirectories }: LaunchModalProps) {
   const [directory, setDirectory] = useState('')
   const [prompt, setPrompt] = useState('')
   const [title, setTitle] = useState('')
@@ -65,16 +56,90 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
   const { options: modelOptions } = useModelOptions()
   const [worktreeStrategy, setWorktreeStrategy] = useState<WorktreeStrategy>('new-worktree')
   const [launching, setLaunching] = useState(false)
-  const [recentDirs] = useState<string[]>(loadRecentDirs)
-  const [showRecentDirs, setShowRecentDirs] = useState(false)
   const [dirError, setDirError] = useState<string | null>(null)
   const [validating, setValidating] = useState(false)
   const [worktreeRoot, setWorktreeRoot] = useState('')
+  const [savedProjects, setSavedProjects] = useState<Project[]>([])
+  const [showDropdown, setShowDropdown] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
 
   const estimatedWorktreePath = useMemo(() => {
     if (worktreeStrategy !== 'new-worktree') return ''
     return computeWorktreePath(worktreeRoot, directory, title)
   }, [directory, title, worktreeRoot, worktreeStrategy])
+
+  const loadProjects = useCallback(async () => {
+    try {
+      const result = await window.api.listProjects()
+      if (result.ok && result.data) {
+        setSavedProjects(result.data)
+      }
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  const saveProject = useCallback(async (dir: string) => {
+    const name = dirDisplayName(dir)
+    try {
+      await window.api.ensureProject({ name, repoRoot: dir })
+      await loadProjects()
+    } catch {
+      // ignore save failures
+    }
+  }, [loadProjects])
+
+  // Seed saved projects from existing agent directories
+  useEffect(() => {
+    if (!knownDirectories || knownDirectories.length === 0) return
+
+    const seedFromAgents = async () => {
+      const seen = new Set<string>()
+
+      for (const known of knownDirectories) {
+        try {
+          let dir = known.directory
+          // For worktree agents, resolve back to the actual repo root
+          if (known.isWorktree) {
+            const result = await window.api.getCommonRepoRoot(known.directory)
+            if (result.ok && result.data) {
+              dir = result.data
+            } else {
+              continue
+            }
+          }
+          if (seen.has(dir)) continue
+          seen.add(dir)
+          await window.api.ensureProject({ name: known.name, repoRoot: dir })
+        } catch {
+          // ignore
+        }
+      }
+      await loadProjects()
+    }
+
+    void seedFromAgents()
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const removeProject = useCallback(async (projectId: string, event: React.MouseEvent) => {
+    event.stopPropagation()
+    event.preventDefault()
+    try {
+      await window.api.deleteProject(projectId)
+      setSavedProjects((prev) => prev.filter((p) => p.id !== projectId))
+      // If the removed project was selected, clear the directory
+      const removed = savedProjects.find((p) => p.id === projectId)
+      if (removed && removed.repo_root === directory) {
+        setDirectory('')
+      }
+    } catch {
+      // ignore
+    }
+  }, [directory, savedProjects])
+
+  useEffect(() => {
+    void loadProjects()
+  }, [loadProjects])
 
   useEffect(() => {
     let isMounted = true
@@ -100,36 +165,59 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
   useEffect(() => {
     if (!directory.trim()) {
       setDirError(null)
+      setValidating(false)
       return
     }
 
+    const currentDir = directory.trim()
+    setValidating(true)
+
     const timer = setTimeout(async () => {
       if (onValidateDirectory) {
-        setValidating(true)
         try {
-          const isValid = await onValidateDirectory(directory.trim())
-          if (!isValid) {
-            setDirError('This directory is not a valid git repository.')
-          } else {
-            setDirError(null)
-          }
+          const isValid = await onValidateDirectory(currentDir)
+          // Only update state if the directory hasn't changed since we started
+          setDirectory((latest) => {
+            if (latest.trim() === currentDir) {
+              setDirError(isValid ? null : 'This directory is not a valid git repository.')
+              setValidating(false)
+            }
+            return latest
+          })
         } catch {
-          setDirError('Could not validate directory.')
-        } finally {
-          setValidating(false)
+          setDirectory((latest) => {
+            if (latest.trim() === currentDir) {
+              setDirError('Could not validate directory.')
+              setValidating(false)
+            }
+            return latest
+          })
         }
+      } else {
+        setValidating(false)
       }
     }, 500)
 
     return () => clearTimeout(timer)
   }, [directory, onValidateDirectory])
 
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setShowDropdown(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
   const handleLaunch = async () => {
-    if (!directory.trim() || dirError) return
+    if (!directory.trim() || dirError || validating) return
     setLaunching(true)
-    saveRecentDir(directory.trim())
     try {
       await onLaunch(directory, prompt || undefined, title || undefined, model, worktreeStrategy)
+      await saveProject(directory.trim())
       onClose()
     } catch (error) {
       console.error('Launch failed:', error)
@@ -139,12 +227,15 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
 
   const handleBrowse = async () => {
     const selected = await onSelectDirectory()
-    if (selected) setDirectory(selected)
+    if (selected) {
+      setDirectory(selected)
+      setShowDropdown(false)
+    }
   }
 
-  const handleSelectRecentDir = (dir: string) => {
-    setDirectory(dir)
-    setShowRecentDirs(false)
+  const handleSelectProject = (repoRoot: string) => {
+    setDirectory(repoRoot)
+    setShowDropdown(false)
   }
 
   const selectButtonClasses =
@@ -152,6 +243,9 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
 
   const selectMenuClasses =
     'absolute left-0 right-0 top-full z-20 mt-1 overflow-hidden rounded-md border border-kumo-line bg-kumo-overlay shadow-xl'
+
+  const selectedProject = savedProjects.find((p) => p.repo_root === directory)
+  const hasDirectory = directory.trim().length > 0
 
   return (
     <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/60" onClick={onClose}>
@@ -171,41 +265,80 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
         </div>
 
         {/* Body */}
-        <div className="px-5 py-4 flex flex-col gap-4 overflow-y-auto">
-          {/* Directory */}
+        <div className="px-5 py-4 flex flex-col gap-4 overflow-y-auto overflow-x-hidden">
+          {/* Directory Selector */}
           <div className="flex flex-col gap-1.5">
             <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
               Project Directory
             </label>
-            <div className="relative flex gap-2">
-              <div className="flex-1 relative">
-                <input
-                  type="text"
-                  value={directory}
-                  onChange={(event) => setDirectory(event.target.value)}
-                  onFocus={() => recentDirs.length > 0 && setShowRecentDirs(true)}
-                  onBlur={() => setTimeout(() => setShowRecentDirs(false), 200)}
-                  placeholder="/path/to/project"
-                  className={`w-full px-3 py-2 bg-kumo-control border rounded-md text-sm text-kumo-default font-mono outline-none focus:border-kumo-ring placeholder:text-kumo-subtle ${
+            <div className="relative flex gap-2" ref={dropdownRef}>
+              <div className="flex-1 min-w-0 relative">
+                {/* Selector button */}
+                <button
+                  type="button"
+                  onClick={() => setShowDropdown(!showDropdown)}
+                  className={`w-full flex items-center gap-2 px-3 py-2 bg-kumo-control border rounded-md text-sm outline-none transition-colors hover:bg-kumo-fill focus:border-kumo-ring ${
                     dirError ? 'border-kumo-danger' : 'border-kumo-line'
                   }`}
-                />
-                {/* Recent directories dropdown */}
-                {showRecentDirs && recentDirs.length > 0 && (
-                  <div className="absolute top-full left-0 right-0 mt-1 bg-kumo-overlay border border-kumo-line rounded-md shadow-xl z-10 overflow-hidden">
-                    <div className="px-3 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wider flex items-center gap-1.5">
-                      <Clock size={10} />
-                      Recent
-                    </div>
-                    {recentDirs.map((recentDir) => (
-                      <button
-                        key={recentDir}
-                        onMouseDown={() => handleSelectRecentDir(recentDir)}
-                        className="w-full px-3 py-1.5 text-left text-xs font-mono text-kumo-default hover:bg-kumo-fill transition-colors truncate"
-                      >
-                        {recentDir}
-                      </button>
-                    ))}
+                >
+                  <div className="min-w-0 flex-1 text-left truncate">
+                    {hasDirectory ? (
+                      <>
+                        <span className="text-kumo-default font-medium">
+                          {selectedProject?.name || dirDisplayName(directory)}
+                        </span>
+                        <span className="text-kumo-subtle font-mono text-xs ml-2">
+                          {directory}
+                        </span>
+                      </>
+                    ) : (
+                      <span className="text-kumo-subtle">Select a project directory...</span>
+                    )}
+                  </div>
+                  <CaretDown size={14} className="text-kumo-subtle shrink-0" />
+                </button>
+
+                {/* Dropdown */}
+                {showDropdown && (
+                  <div className="absolute top-full left-0 right-0 mt-1 bg-kumo-control border border-kumo-fill-hover rounded-md shadow-2xl z-10 max-h-[240px] overflow-y-auto overflow-x-hidden">
+                    {savedProjects.length > 0 && (
+                      <>
+                        <div className="px-3 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wider">
+                          Saved Projects
+                        </div>
+                        {savedProjects.map((project) => (
+                          <div
+                            key={project.id}
+                            className="group flex items-center px-3 py-1.5 hover:bg-kumo-fill-hover transition-colors cursor-pointer"
+                            onMouseDown={() => handleSelectProject(project.repo_root)}
+                          >
+                            <div className="min-w-0 flex-1">
+                              <div className="text-xs text-kumo-default font-medium truncate">
+                                {project.name}
+                              </div>
+                              <div className="text-[11px] text-kumo-subtle font-mono truncate">
+                                {project.repo_root}
+                              </div>
+                            </div>
+                            <button
+                              onMouseDown={(e) => void removeProject(project.id, e)}
+                              className="ml-2 p-1 rounded text-kumo-subtle/0 group-hover:text-kumo-subtle hover:!text-kumo-danger hover:bg-kumo-fill-hover transition-colors shrink-0"
+                              title="Remove from saved projects"
+                            >
+                              <Trash size={12} />
+                            </button>
+                          </div>
+                        ))}
+                        <div className="border-t border-kumo-fill-hover" />
+                      </>
+                    )}
+                    <button
+                      onMouseDown={() => void handleBrowse()}
+                      className="w-full px-3 py-2 text-left text-xs text-kumo-default hover:bg-kumo-fill-hover transition-colors flex items-center gap-2"
+                    >
+                      <FolderOpen size={14} className="text-kumo-subtle" />
+                      Browse for directory...
+                    </button>
                   </div>
                 )}
               </div>
@@ -304,7 +437,7 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
           </button>
           <button
             onClick={handleLaunch}
-            disabled={!directory.trim() || launching || !!dirError}
+            disabled={!directory.trim() || launching || validating || !!dirError}
             className="px-4 py-2 text-xs font-medium text-white bg-kumo-brand rounded-md hover:bg-kumo-brand-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
           >
             {launching ? 'Launching...' : 'Launch Agent'}

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -47,6 +47,7 @@ export interface OrchestratorApi {
   validateGitRepo: (directory: string) => Promise<IpcResult<boolean>>
   getWorktreeRoot: () => Promise<IpcResult<string>>
   getRepoRoot: (directory: string) => Promise<IpcResult<string>>
+  getCommonRepoRoot: (directory: string) => Promise<IpcResult<string>>
   createWorktree: (options: { repoRoot: string; projectSlug: string; taskSlug: string }) => Promise<IpcResult<{ worktreePath: string; branchName: string }>>
   createFreshWorktree: (options: { repoRoot: string; projectSlug: string; taskSlug: string }) => Promise<IpcResult<{ worktreePath: string; branchName: string; baseRef: string }>>
   removeWorktree: (options: { repoRoot: string; worktreePath: string }) => Promise<IpcResult>
@@ -56,6 +57,7 @@ export interface OrchestratorApi {
   // ── Database: Projects ──
   listProjects: () => Promise<IpcResult<Project[]>>
   createProject: (options: { name: string; repoRoot: string }) => Promise<IpcResult<Project>>
+  ensureProject: (options: { name: string; repoRoot: string }) => Promise<IpcResult<Project>>
   deleteProject: (projectId: string) => Promise<IpcResult<boolean>>
 
   // ── Database: Preferences ──


### PR DESCRIPTION
Replaces the text input + localStorage recent directories in LaunchModal with a dropdown selector backed by the SQLite projects table. Projects are automatically saved on successful launch, seeded from existing agent directories (resolving worktree paths to real repo roots), and can be removed via a trash button. Also fixes launch error handling so the modal stays open on failure and blocks launch while directory validation is in-flight.

<img width="676" height="557" alt="image" src="https://github.com/user-attachments/assets/580441fc-2212-4322-b3e2-40a4ad1bd043" />
