### PR TITLE
Add session resume feature to import existing OpenCode sessions

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -271,6 +271,44 @@ export function registerIpcHandlers(): void {
     }
   })
 
+  ipcMain.handle('session:list', async (_event, directory: string) => {
+    try {
+      const sessions = await agentController.listSessions(directory)
+      return { ok: true, data: sessions }
+    } catch (error) {
+      console.error('[IPC] session:list failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  ipcMain.handle('agent:resume', async (_event, options: {
+    directory: string
+    sessionId: string
+    title?: string
+  }) => {
+    try {
+      const handle = await agentController.resumeAgent(options)
+      return {
+        ok: true,
+        data: {
+          id: handle.id,
+          runtimeId: handle.runtimeId,
+          sessionId: handle.sessionId,
+          directory: handle.directory,
+          projectName: handle.projectName,
+          branchName: handle.branchName,
+          isWorktree: handle.isWorktree,
+          workspaceName: handle.workspaceName,
+          prompt: handle.prompt,
+          title: handle.title
+        }
+      }
+    } catch (error) {
+      console.error('[IPC] agent:resume failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
   ipcMain.handle('agent:list', async () => {
     const agents = agentController.getAllAgents()
     return {

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -755,6 +755,102 @@ class AgentController {
     return result.data
   }
 
+  /**
+   * List existing OpenCode sessions for a directory.
+   * Spins up a temporary runtime if needed, then queries the SDK.
+   */
+  async listSessions(directory: string): Promise<Array<{
+    id: string
+    title: string
+    createdAt: number
+    updatedAt: number
+  }>> {
+    const runtime = await this.ensureBridgeForDirectory(directory)
+    runtimeManager.touchRuntimeActivity(runtime.id)
+
+    const result = await runtime.client.session.list({
+      directory
+    })
+
+    if (!result.data) return []
+
+    const sessions = result.data as Array<{
+      id: string
+      title?: string
+      time?: { created?: number; updated?: number }
+    }>
+
+    // Filter out sessions that are already managed by an active agent
+    const activeSessionIds = new Set(
+      Array.from(this.agents.values()).map((agent) => agent.sessionId)
+    )
+
+    return sessions
+      .filter((session) => !activeSessionIds.has(session.id))
+      .map((session) => ({
+        id: session.id,
+        title: session.title ?? session.id,
+        createdAt: session.time?.created ?? 0,
+        updatedAt: session.time?.updated ?? 0
+      }))
+  }
+
+  /**
+   * Resume an existing OpenCode session by importing it into orchestration.
+   * Unlike launchAgent, this does NOT call session.create — it attaches
+   * to an existing sessionId.
+   */
+  async resumeAgent(options: {
+    directory: string
+    sessionId: string
+    title?: string
+  }): Promise<AgentHandle> {
+    const { directory, sessionId, title } = options
+
+    const runtime = await this.ensureBridgeForDirectory(directory)
+    const directoryContext = workspaceManager.getDirectoryContext(directory)
+    runtimeManager.touchRuntimeActivity(runtime.id)
+
+    const sessionTitle = title ?? `resumed-${this.nextId}`
+
+    const agentId = `agent-${this.nextId++}`
+    const handle: AgentHandle = {
+      id: agentId,
+      runtimeId: runtime.id,
+      sessionId,
+      directory,
+      projectName: directoryContext.repoName,
+      branchName: directoryContext.branchName,
+      isWorktree: directoryContext.isWorktree,
+      workspaceName: directoryContext.workspaceName,
+      prompt: '',
+      title: sessionTitle,
+      displayName: '',
+      taskSummary: '',
+      bridge: this.bridges.get(runtime.id)!
+    }
+
+    this.agents.set(agentId, handle)
+    this.persistAgents()
+
+    this.broadcastToRenderer('agent:launched', {
+      id: agentId,
+      runtimeId: runtime.id,
+      sessionId,
+      directory,
+      projectName: handle.projectName,
+      branchName: handle.branchName,
+      isWorktree: handle.isWorktree,
+      workspaceName: handle.workspaceName,
+      prompt: '',
+      title: sessionTitle
+    })
+
+    console.log(`[AgentController] Resumed agent ${agentId} (session ${sessionId}) in ${directory}`)
+
+    return handle
+  }
+
   getAgent(agentId: string): AgentHandle | undefined {
     return this.agents.get(agentId)
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -68,6 +68,12 @@ const api = {
   sendMessageWithModel: (agentId: string, text: string, providerID: string, modelID: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:send-message-with-model', agentId, text, providerID, modelID, attachments),
 
+  listSessions: (directory: string): Promise<IpcResult<Array<{ id: string; title: string; createdAt: number; updatedAt: number }>>> =>
+    ipcRenderer.invoke('session:list', directory),
+
+  resumeAgent: (options: { directory: string; sessionId: string; title?: string }): Promise<IpcResult> =>
+    ipcRenderer.invoke('agent:resume', options),
+
   listAgents: (): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:list'),
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -6,6 +6,7 @@ import { FleetTable } from './components/FleetTable'
 import { StatusBar } from './components/StatusBar'
 import { DetailDrawer, type ChatCommand } from './components/DetailDrawer'
 import { LaunchModal } from './components/LaunchModal'
+import { SessionBrowser } from './components/SessionBrowser'
 import { SettingsModal } from './components/SettingsModal'
 import { CommandPalette } from './components/CommandPalette'
 import { ModelPickerModal } from './components/ModelPickerModal'
@@ -48,6 +49,7 @@ export function App() {
   const [showLaunchModal, setShowLaunchModal] = useState(false)
   const [showSettings, setShowSettings] = useState(false)
   const [showCommandPalette, setShowCommandPalette] = useState(false)
+  const [showSessionBrowser, setShowSessionBrowser] = useState(false)
 
   const [sortColumn, setSortColumn] = useState<SortColumn | null>(null)
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
@@ -82,7 +84,8 @@ export function App() {
         { command: '/model', description: 'Open model picker or set model — /model [provider/model-id]' },
         { command: '/compact', description: 'Compact conversation to reduce context usage' },
         { command: '/share', description: 'Share this session' },
-        { command: '/mcp', description: 'Open MCP server manager' }
+        { command: '/mcp', description: 'Open MCP server manager' },
+        { command: '/sessions', description: 'Browse and resume existing sessions from a project' }
       ]
 
       if (commands && Array.isArray(commands)) {
@@ -592,6 +595,11 @@ export function App() {
         return true
       }
 
+      case 'sessions': {
+        setShowSessionBrowser(true)
+        return true
+      }
+
       default: {
         // Check if it's a custom command from the API (skills, /init, /review, etc.)
         const isKnownCommand = agentCommands.some((cmd) => cmd.command === `/${commandName}`)
@@ -756,6 +764,17 @@ export function App() {
     }
   }, [store])
 
+  const handleResumeSession = useCallback(async (directory: string, sessionId: string, title: string) => {
+    const result = await window.api.resumeAgent({ directory, sessionId, title })
+    if (!result?.ok) {
+      throw new Error('Failed to resume session')
+    }
+    if (result.data) {
+      const data = result.data as { id: string }
+      setSelectedAgentId(data.id)
+    }
+  }, [])
+
   const handleValidateDirectory = useCallback(async (dir: string): Promise<boolean> => {
     if (!dir.trim() || dir.trim().length < 2) return false
     try {
@@ -786,6 +805,10 @@ export function App() {
           setShowCommandPalette(false)
           return
         }
+        if (showSessionBrowser) {
+          setShowSessionBrowser(false)
+          return
+        }
         if (showSettings) {
           setShowSettings(false)
           return
@@ -810,8 +833,16 @@ export function App() {
 
       // L -> open launch modal
       if (event.key === 'l' || event.key === 'L') {
-        if (!showLaunchModal && !showSettings) {
+        if (!showLaunchModal && !showSettings && !showSessionBrowser) {
           setShowLaunchModal(true)
+        }
+        return
+      }
+
+      // R -> open session browser (resume)
+      if (event.key === 'r' || event.key === 'R') {
+        if (!showLaunchModal && !showSettings && !showSessionBrowser) {
+          setShowSessionBrowser(true)
         }
         return
       }
@@ -877,7 +908,7 @@ export function App() {
         return
       }
     },
-    [filteredAgents, selectedAgentId, showLaunchModal, showSettings, showCommandPalette, findPermissionForAgent, store]
+    [filteredAgents, selectedAgentId, showLaunchModal, showSettings, showCommandPalette, showSessionBrowser, findPermissionForAgent, store]
   )
 
   useEffect(() => {
@@ -1014,6 +1045,20 @@ export function App() {
         />
       )}
 
+      {showSessionBrowser && (
+        <SessionBrowser
+          onClose={() => setShowSessionBrowser(false)}
+          onResume={handleResumeSession}
+          onSelectDirectory={store.selectDirectory}
+          onValidateDirectory={handleValidateDirectory}
+          knownDirectories={store.agents.map((a) => ({
+            name: a.projectName,
+            directory: a.directory,
+            isWorktree: a.isWorktree
+          }))}
+        />
+      )}
+
       {showSettings && (
         <SettingsModal onClose={() => setShowSettings(false)} />
       )}
@@ -1061,6 +1106,10 @@ export function App() {
           onLaunchAgent={() => {
             setShowCommandPalette(false)
             setShowLaunchModal(true)
+          }}
+          onResumeSession={() => {
+            setShowCommandPalette(false)
+            setShowSessionBrowser(true)
           }}
           onOpenSettings={() => {
             setShowCommandPalette(false)

--- a/src/renderer/src/components/CommandPalette.tsx
+++ b/src/renderer/src/components/CommandPalette.tsx
@@ -9,7 +9,8 @@ import {
   Robot,
   SquaresFour,
   Warning,
-  CircleNotch
+  CircleNotch,
+  ClockCounterClockwise
 } from '@phosphor-icons/react'
 import { EMPTY_FILTER, type FilterState, type StatusFilter } from './FilterBar'
 
@@ -18,6 +19,7 @@ interface CommandPaletteProps {
   onClose: () => void
   onSelectAgent: (id: string) => void
   onLaunchAgent: () => void
+  onResumeSession: () => void
   onOpenSettings: () => void
   onFilterChange: (filter: FilterState) => void
   onStopAll: () => void
@@ -60,6 +62,7 @@ export function CommandPalette({
   onClose,
   onSelectAgent,
   onLaunchAgent,
+  onResumeSession,
   onOpenSettings,
   onFilterChange,
   onStopAll,
@@ -98,6 +101,18 @@ export function CommandPalette({
         action: () => {
           onClose()
           onLaunchAgent()
+        }
+      },
+      {
+        id: 'action-resume',
+        label: 'Resume Session',
+        description: 'Import an existing session from a project',
+        icon: <ClockCounterClockwise size={16} weight="bold" className="text-kumo-link" />,
+        category: 'actions',
+        shortcut: 'R',
+        action: () => {
+          onClose()
+          onResumeSession()
         }
       },
       {
@@ -185,7 +200,7 @@ export function CommandPalette({
     }))
 
     return [...actionCommands, ...navigationCommands, ...agentCommands]
-  }, [agents, onClose, onSelectAgent, onLaunchAgent, onOpenSettings, onFilterChange, onStopAll, onApproveAll])
+  }, [agents, onClose, onSelectAgent, onLaunchAgent, onResumeSession, onOpenSettings, onFilterChange, onStopAll, onApproveAll])
 
   // Filter commands based on debounced query
   const filteredCommands = useMemo(() => {

--- a/src/renderer/src/components/SessionBrowser.tsx
+++ b/src/renderer/src/components/SessionBrowser.tsx
@@ -1,0 +1,425 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { X, FolderOpen, CaretDown, Trash, ClockCounterClockwise, CircleNotch, ChatCircleDots } from '@phosphor-icons/react'
+import type { Project } from '../types/api'
+
+interface SessionInfo {
+  id: string
+  title: string
+  createdAt: number
+  updatedAt: number
+}
+
+interface KnownDirectory {
+  name: string
+  directory: string
+  isWorktree?: boolean
+}
+
+interface SessionBrowserProps {
+  onClose: () => void
+  onResume: (directory: string, sessionId: string, title: string) => void
+  onSelectDirectory: () => Promise<string | null>
+  onValidateDirectory?: (dir: string) => Promise<boolean>
+  knownDirectories?: KnownDirectory[]
+}
+
+function dirDisplayName(path: string): string {
+  const parts = path.replace(/\/$/, '').split('/').filter(Boolean)
+  return parts.length > 0 ? parts[parts.length - 1] : path
+}
+
+function formatTimestamp(ms: number): string {
+  if (!ms) return 'unknown'
+  const date = new Date(ms)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / 60_000)
+  const diffHours = Math.floor(diffMins / 60)
+  const diffDays = Math.floor(diffHours / 24)
+
+  if (diffMins < 1) return 'just now'
+  if (diffMins < 60) return `${diffMins}m ago`
+  if (diffHours < 24) return `${diffHours}h ago`
+  if (diffDays < 7) return `${diffDays}d ago`
+  return date.toLocaleDateString()
+}
+
+export function SessionBrowser({
+  onClose,
+  onResume,
+  onSelectDirectory,
+  onValidateDirectory,
+  knownDirectories
+}: SessionBrowserProps) {
+  const [directory, setDirectory] = useState('')
+  const [sessions, setSessions] = useState<SessionInfo[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [resuming, setResuming] = useState<string | null>(null)
+  const [savedProjects, setSavedProjects] = useState<Project[]>([])
+  const [showDropdown, setShowDropdown] = useState(false)
+  const [validating, setValidating] = useState(false)
+  const [dirError, setDirError] = useState<string | null>(null)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  // Load saved projects
+  useEffect(() => {
+    const loadProjects = async () => {
+      try {
+        const result = await window.api.listProjects()
+        if (result.ok && result.data) {
+          setSavedProjects(result.data)
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    // Seed saved projects from existing agent directories
+    const seedFromAgents = async () => {
+      if (!knownDirectories || knownDirectories.length === 0) {
+        await loadProjects()
+        return
+      }
+
+      const seen = new Set<string>()
+      for (const known of knownDirectories) {
+        try {
+          let dir = known.directory
+          if (known.isWorktree) {
+            const result = await window.api.getCommonRepoRoot(known.directory)
+            if (result.ok && result.data) {
+              dir = result.data
+            } else {
+              continue
+            }
+          }
+          if (seen.has(dir)) continue
+          seen.add(dir)
+          await window.api.ensureProject({ name: known.name, repoRoot: dir })
+        } catch {
+          // ignore
+        }
+      }
+      await loadProjects()
+    }
+
+    void seedFromAgents()
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Validate directory
+  useEffect(() => {
+    if (!directory.trim()) {
+      setDirError(null)
+      setValidating(false)
+      return
+    }
+
+    const currentDir = directory.trim()
+    setValidating(true)
+
+    const timer = setTimeout(async () => {
+      if (onValidateDirectory) {
+        try {
+          const isValid = await onValidateDirectory(currentDir)
+          setDirectory((latest) => {
+            if (latest.trim() === currentDir) {
+              setDirError(isValid ? null : 'This directory is not a valid git repository.')
+              setValidating(false)
+            }
+            return latest
+          })
+        } catch {
+          setDirectory((latest) => {
+            if (latest.trim() === currentDir) {
+              setDirError('Could not validate directory.')
+              setValidating(false)
+            }
+            return latest
+          })
+        }
+      } else {
+        setValidating(false)
+      }
+    }, 500)
+
+    return () => clearTimeout(timer)
+  }, [directory, onValidateDirectory])
+
+  // Fetch sessions when directory changes and is valid
+  useEffect(() => {
+    if (!directory.trim() || dirError || validating) {
+      setSessions([])
+      setError(null)
+      return
+    }
+
+    let cancelled = false
+    const fetchSessions = async () => {
+      setLoading(true)
+      setError(null)
+      setSessions([])
+
+      try {
+        const result = await window.api.listSessions(directory.trim())
+        if (cancelled) return
+
+        if (result.ok && result.data) {
+          const sorted = [...result.data].sort((a, b) => b.updatedAt - a.updatedAt)
+          setSessions(sorted)
+          if (sorted.length === 0) {
+            setError('No existing sessions found in this directory.')
+          }
+        } else {
+          setError(result.error ?? 'Failed to list sessions.')
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(String(err))
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    void fetchSessions()
+    return () => { cancelled = true }
+  }, [directory, dirError, validating])
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setShowDropdown(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const handleBrowse = async () => {
+    const selected = await onSelectDirectory()
+    if (selected) {
+      setDirectory(selected)
+      setShowDropdown(false)
+    }
+  }
+
+  const handleSelectProject = (repoRoot: string) => {
+    setDirectory(repoRoot)
+    setShowDropdown(false)
+  }
+
+  const handleResume = useCallback(async (session: SessionInfo) => {
+    setResuming(session.id)
+    try {
+      await onResume(directory.trim(), session.id, session.title)
+      onClose()
+    } catch (err) {
+      console.error('Resume failed:', err)
+      setResuming(null)
+    }
+  }, [directory, onResume, onClose])
+
+  const removeProject = useCallback(async (projectId: string, event: React.MouseEvent) => {
+    event.stopPropagation()
+    event.preventDefault()
+    try {
+      await window.api.deleteProject(projectId)
+      setSavedProjects((prev) => prev.filter((p) => p.id !== projectId))
+      const removed = savedProjects.find((p) => p.id === projectId)
+      if (removed && removed.repo_root === directory) {
+        setDirectory('')
+      }
+    } catch {
+      // ignore
+    }
+  }, [directory, savedProjects])
+
+  const selectedProject = savedProjects.find((p) => p.repo_root === directory)
+  const hasDirectory = directory.trim().length > 0
+
+  return (
+    <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/60" onClick={onClose}>
+      <div
+        className="w-[560px] max-h-[85vh] bg-kumo-elevated border border-kumo-line rounded-xl shadow-2xl flex flex-col"
+        onClick={(event) => event.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-kumo-line">
+          <div className="flex items-center gap-2.5">
+            <ClockCounterClockwise size={18} className="text-kumo-brand" />
+            <h2 className="text-base font-semibold text-kumo-strong">Resume Session</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-7 h-7 flex items-center justify-center rounded-md border border-kumo-line text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill transition-colors"
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-4 flex flex-col gap-4 overflow-y-auto overflow-x-hidden">
+          {/* Directory Selector */}
+          <div className="flex flex-col gap-1.5">
+            <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
+              Project Directory
+            </label>
+            <p className="text-[11px] text-kumo-subtle -mt-0.5">
+              Select the original project directory (not a worktree) to browse its sessions.
+            </p>
+            <div className="relative flex gap-2" ref={dropdownRef}>
+              <div className="flex-1 min-w-0 relative">
+                <button
+                  type="button"
+                  onClick={() => setShowDropdown(!showDropdown)}
+                  className={`w-full flex items-center gap-2 px-3 py-2 bg-kumo-control border rounded-md text-sm outline-none transition-colors hover:bg-kumo-fill focus:border-kumo-ring ${
+                    dirError ? 'border-kumo-danger' : 'border-kumo-line'
+                  }`}
+                >
+                  <div className="min-w-0 flex-1 text-left truncate">
+                    {hasDirectory ? (
+                      <>
+                        <span className="text-kumo-default font-medium">
+                          {selectedProject?.name || dirDisplayName(directory)}
+                        </span>
+                        <span className="text-kumo-subtle font-mono text-xs ml-2">
+                          {directory}
+                        </span>
+                      </>
+                    ) : (
+                      <span className="text-kumo-subtle">Select a project directory...</span>
+                    )}
+                  </div>
+                  <CaretDown size={14} className="text-kumo-subtle shrink-0" />
+                </button>
+
+                {showDropdown && (
+                  <div className="absolute top-full left-0 right-0 mt-1 bg-kumo-control border border-kumo-fill-hover rounded-md shadow-2xl z-10 max-h-[240px] overflow-y-auto overflow-x-hidden">
+                    {savedProjects.length > 0 && (
+                      <>
+                        <div className="px-3 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wider">
+                          Saved Projects
+                        </div>
+                        {savedProjects.map((project) => (
+                          <div
+                            key={project.id}
+                            className="group flex items-center px-3 py-1.5 hover:bg-kumo-fill-hover transition-colors cursor-pointer"
+                            onMouseDown={() => handleSelectProject(project.repo_root)}
+                          >
+                            <div className="min-w-0 flex-1">
+                              <div className="text-xs text-kumo-default font-medium truncate">
+                                {project.name}
+                              </div>
+                              <div className="text-[11px] text-kumo-subtle font-mono truncate">
+                                {project.repo_root}
+                              </div>
+                            </div>
+                            <button
+                              onMouseDown={(e) => void removeProject(project.id, e)}
+                              className="ml-2 p-1 rounded text-kumo-subtle/0 group-hover:text-kumo-subtle hover:!text-kumo-danger hover:bg-kumo-fill-hover transition-colors shrink-0"
+                              title="Remove from saved projects"
+                            >
+                              <Trash size={12} />
+                            </button>
+                          </div>
+                        ))}
+                        <div className="border-t border-kumo-fill-hover" />
+                      </>
+                    )}
+                    <button
+                      onMouseDown={() => void handleBrowse()}
+                      className="w-full px-3 py-2 text-left text-xs text-kumo-default hover:bg-kumo-fill-hover transition-colors flex items-center gap-2"
+                    >
+                      <FolderOpen size={14} className="text-kumo-subtle" />
+                      Browse for directory...
+                    </button>
+                  </div>
+                )}
+              </div>
+              <button
+                onClick={handleBrowse}
+                className="px-3 py-2 bg-kumo-control border border-kumo-line rounded-md text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill transition-colors"
+              >
+                <FolderOpen size={16} />
+              </button>
+            </div>
+            {validating && (
+              <p className="text-[11px] text-kumo-subtle">Validating directory...</p>
+            )}
+            {dirError && (
+              <p className="text-[11px] text-kumo-danger">{dirError}</p>
+            )}
+          </div>
+
+          {/* Sessions List */}
+          {hasDirectory && !dirError && !validating && (
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
+                Available Sessions
+              </label>
+
+              {loading && (
+                <div className="flex items-center gap-2 py-6 justify-center text-sm text-kumo-subtle">
+                  <CircleNotch size={16} className="animate-spin" />
+                  Loading sessions...
+                </div>
+              )}
+
+              {!loading && error && (
+                <div className="flex items-center gap-2 py-6 justify-center text-sm text-kumo-subtle">
+                  <ChatCircleDots size={16} />
+                  {error}
+                </div>
+              )}
+
+              {!loading && !error && sessions.length > 0 && (
+                <div className="border border-kumo-line rounded-md overflow-hidden max-h-[300px] overflow-y-auto">
+                  {sessions.map((session) => (
+                    <div
+                      key={session.id}
+                      className="flex items-center gap-3 px-3 py-2.5 border-b border-kumo-line last:border-b-0 hover:bg-kumo-fill transition-colors group"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm text-kumo-default font-medium truncate">
+                          {session.title}
+                        </div>
+                        <div className="flex items-center gap-2 text-[11px] text-kumo-subtle">
+                          <span>Updated {formatTimestamp(session.updatedAt)}</span>
+                          <span className="text-kumo-line">|</span>
+                          <span className="font-mono truncate">{session.id.slice(0, 12)}...</span>
+                        </div>
+                      </div>
+                      <button
+                        onClick={() => void handleResume(session)}
+                        disabled={resuming !== null}
+                        className="shrink-0 px-3 py-1.5 text-xs font-medium text-kumo-brand border border-kumo-brand/30 rounded-md hover:bg-kumo-brand/10 transition-colors disabled:opacity-40 disabled:cursor-not-allowed opacity-0 group-hover:opacity-100 focus:opacity-100"
+                      >
+                        {resuming === session.id ? (
+                          <CircleNotch size={12} className="animate-spin" />
+                        ) : (
+                          'Resume'
+                        )}
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 px-5 py-3 border-t border-kumo-line">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-xs font-medium text-kumo-subtle border border-kumo-line rounded-md hover:bg-kumo-fill transition-colors"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Allow users to browse and resume sessions created outside the orchestrator (e.g. from the terminal opencode CLI). Sessions are discovered via the SDK's session.list API and imported into orchestration without creating a new session. Accessible via /sessions command, R keyboard shortcut, and the command palette.

<img width="1022" height="780" alt="image" src="https://github.com/user-attachments/assets/e0cce718-624a-4f9f-947e-4e325f7c2d34" />

(Also totally AI generated, but did as much testing as I could in a dev session)