### PR TITLE
Prevent message.part.updated from overriding completed/idle status

### DIFF
--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -673,11 +673,11 @@ function processEvent(payload: OpenCodeEventPayload): void {
           message.parts.push(newPart)
         }
 
-        // Update agent activity (but don't clobber blocked/stopping states)
+        // Update agent activity (but don't clobber blocked/stopping/terminal states)
         const agent = findAgentBySession(sessionId)
         if (agent) {
           agent.lastActivityAt = Date.now()
-          if (agent.status !== 'needs_input' && agent.status !== 'needs_approval' && agent.status !== 'stopping' && agent.status !== 'completed_manual') {
+          if (agent.status !== 'needs_input' && agent.status !== 'needs_approval' && agent.status !== 'stopping' && agent.status !== 'completed_manual' && agent.status !== 'completed' && agent.status !== 'idle') {
             agent.status = 'running'
             agent.blockedSince = undefined
           }


### PR DESCRIPTION
The message.part.updated handler was forcing status back to 'running' even after session.completed/session.idle had been processed. This race condition was the primary cause of agents appearing stuck after PR generation — the tool result event would arrive after the terminal event and reset the status.