### PR TITLE
Fix crash from disposed render frame during dev hot-reload

### DIFF
--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -1062,7 +1062,9 @@ class AgentController {
 
   private broadcastToRenderer(channel: string, data: unknown): void {
     for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send(channel, data)
+      if (!win.isDestroyed() && !win.webContents.isDestroyed()) {
+        win.webContents.send(channel, data)
+      }
     }
   }
 }

--- a/src/main/services/event-bridge.ts
+++ b/src/main/services/event-bridge.ts
@@ -172,7 +172,9 @@ export class EventBridge {
 
   private broadcastToRenderer(channel: string, data: unknown): void {
     for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send(channel, data)
+      if (!win.isDestroyed() && !win.webContents.isDestroyed()) {
+        win.webContents.send(channel, data)
+      }
     }
   }
 }

--- a/src/main/services/runtime-manager.ts
+++ b/src/main/services/runtime-manager.ts
@@ -304,7 +304,9 @@ class RuntimeManager {
 
   private broadcastToRenderer(channel: string, data: unknown): void {
     for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send(channel, data)
+      if (!win.isDestroyed() && !win.webContents.isDestroyed()) {
+        win.webContents.send(channel, data)
+      }
     }
   }
 }


### PR DESCRIPTION
Guard broadcastToRenderer against destroyed windows and webContents. During long dev sessions, SSE events can arrive while the render frame is being disposed (e.g. hot-reload), causing an unhandled error that crashes the app.