### PR TITLE
Make agent deletion non-blocking with optimistic UI removal

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -443,7 +443,7 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle('workspace:common-repo-root', async (_event, directory: string) => {
     try {
-      const repoRoot = workspaceManager.getCommonRepoRoot(directory)
+      const repoRoot = await workspaceManager.getCommonRepoRoot(directory)
       return { ok: true, data: repoRoot }
     } catch (error) {
       console.error('[IPC] workspace:common-repo-root failed:', error)
@@ -484,7 +484,7 @@ export function registerIpcHandlers(): void {
     worktreePath: string
   }) => {
     try {
-      workspaceManager.removeWorktree(options.repoRoot, options.worktreePath)
+      await workspaceManager.removeWorktree(options.repoRoot, options.worktreePath)
       return { ok: true }
     } catch (error) {
       console.error('[IPC] workspace:remove failed:', error)

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -200,7 +200,7 @@ class AgentController {
     // Reset the working directory to a fresh branch off the default branch
     const projectSlug = sanitizeSlug(handle.projectName, 'project')
     const taskSlug = prompt ? sanitizeSlug(prompt, 'next-feature') : 'next-feature'
-    const newBranch = workspaceManager.resetToDefaultBranch(handle.directory, projectSlug, taskSlug)
+    const newBranch = await workspaceManager.resetToDefaultBranch(handle.directory, projectSlug, taskSlug)
     handle.branchName = newBranch
 
     const sessionTitle = prompt ? prompt.slice(0, 80) : `${projectSlug}-${Date.now()}`
@@ -860,27 +860,47 @@ class AgentController {
   }
 
   /**
-   * Remove an agent from orchestration and clean up its worktree when possible.
+   * Remove an agent from orchestration and clean up its resources.
+   *
+   * Bookkeeping (map removal + persist) is synchronous so the IPC response
+   * is fast.  Expensive cleanup (runtime stop, worktree removal) runs in
+   * the background and never blocks the caller.
    */
-  async removeAgent(agentId: string): Promise<void> {
+  removeAgent(agentId: string): void {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
 
     const otherAgents = Array.from(this.agents.values()).filter((agent) => agent.id !== agentId)
-    const hasRuntimePeers = otherAgents.some((agent) => agent.runtimeId === handle.runtimeId)
-    const hasDirectoryPeers = otherAgents.some((agent) => agent.directory === handle.directory)
-
-    if (!hasRuntimePeers) {
-      await this.stopRuntime(handle.runtimeId)
-    }
-
-    if (handle.isWorktree && !hasDirectoryPeers) {
-      const repoRoot = workspaceManager.getCommonRepoRoot(handle.directory)
-      workspaceManager.removeWorktree(repoRoot, handle.directory)
-    }
+    const shouldStopRuntime = !otherAgents.some((agent) => agent.runtimeId === handle.runtimeId)
+    const shouldRemoveWorktree = handle.isWorktree && !otherAgents.some((agent) => agent.directory === handle.directory)
 
     this.agents.delete(agentId)
     this.persistAgents()
+
+    void this.backgroundCleanup(handle, shouldStopRuntime, shouldRemoveWorktree)
+  }
+
+  private async backgroundCleanup(
+    handle: AgentHandle,
+    shouldStopRuntime: boolean,
+    shouldRemoveWorktree: boolean
+  ): Promise<void> {
+    try {
+      if (shouldStopRuntime) {
+        await this.stopRuntime(handle.runtimeId)
+      }
+    } catch (error) {
+      console.error(`[AgentController] Background runtime cleanup failed for ${handle.id}:`, error)
+    }
+
+    try {
+      if (shouldRemoveWorktree) {
+        const repoRoot = await workspaceManager.getCommonRepoRoot(handle.directory)
+        await workspaceManager.removeWorktree(repoRoot, handle.directory)
+      }
+    } catch (error) {
+      console.error(`[AgentController] Background worktree cleanup failed for ${handle.id}:`, error)
+    }
   }
 
   startIdleRuntimeChecks(): void {

--- a/src/main/services/workspace-manager.ts
+++ b/src/main/services/workspace-manager.ts
@@ -1,7 +1,10 @@
-import { execSync } from 'child_process'
+import { execSync, exec } from 'child_process'
+import { promisify } from 'util'
 import path from 'path'
 import fs from 'fs'
 import os from 'os'
+
+const execAsync = promisify(exec)
 
 export interface WorktreeInfo {
   worktreePath: string
@@ -135,20 +138,18 @@ class WorkspaceManager {
   /**
    * Removes a worktree and prunes stale worktree references.
    */
-  removeWorktree(repoRoot: string, worktreePath: string): void {
+  async removeWorktree(repoRoot: string, worktreePath: string): Promise<void> {
     try {
       console.log(`[WorkspaceManager] Removing worktree at ${worktreePath}`)
 
-      execSync(`git worktree remove "${worktreePath}" --force`, {
+      await execAsync(`git worktree remove "${worktreePath}" --force`, {
         cwd: repoRoot,
-        encoding: 'utf-8',
-        stdio: 'pipe'
+        encoding: 'utf-8'
       })
 
-      execSync('git worktree prune', {
+      await execAsync('git worktree prune', {
         cwd: repoRoot,
-        encoding: 'utf-8',
-        stdio: 'pipe'
+        encoding: 'utf-8'
       })
 
       // Release the claim if it was claimed
@@ -241,15 +242,14 @@ class WorkspaceManager {
     }
   }
 
-  getCommonRepoRoot(directory: string): string {
+  async getCommonRepoRoot(directory: string): Promise<string> {
     try {
-      const gitCommonDir = execSync('git rev-parse --path-format=absolute --git-common-dir', {
+      const { stdout } = await execAsync('git rev-parse --path-format=absolute --git-common-dir', {
         cwd: directory,
-        encoding: 'utf-8',
-        stdio: 'pipe'
-      }).trim()
+        encoding: 'utf-8'
+      })
 
-      return path.dirname(gitCommonDir)
+      return path.dirname(stdout.trim())
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       console.error(`[WorkspaceManager] Failed to get common repo root: ${message}`)
@@ -320,8 +320,8 @@ class WorkspaceManager {
    * Fetches origin, creates a new branch off the default branch, and checks
    * it out in the given directory.  Returns the new branch name.
    */
-  resetToDefaultBranch(directory: string, projectSlug: string, taskSlug: string): string {
-    const repoRoot = this.getCommonRepoRoot(directory)
+  async resetToDefaultBranch(directory: string, projectSlug: string, taskSlug: string): Promise<string> {
+    const repoRoot = await this.getCommonRepoRoot(directory)
 
     execSync('git fetch origin --prune', {
       cwd: directory,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -537,7 +537,7 @@ export function App() {
     store.setStatusOverride(agentId, override)
   }, [store])
 
-  const handleRemoveAgent = useCallback(async (agentId: string) => {
+  const handleRemoveAgent = useCallback((agentId: string) => {
     const liveAgent = findLiveAgent(agentId)
     if (!liveAgent) return
 
@@ -547,9 +547,7 @@ export function App() {
 
     if (!window.confirm(confirmMessage)) return
 
-    const result = await store.removeAgent(agentId)
-    if (!result?.ok) return
-
+    store.removeAgent(agentId)
 
     if (selectedAgentId === agentId) {
       setSelectedAgentId(null)

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -1555,17 +1555,20 @@ export function useAgentStore() {
     return window.api.resetSession(agentId, prompt)
   }, [])
 
-  const removeAgent = useCallback(async (agentId: string) => {
+  const removeAgent = useCallback((agentId: string) => {
     if (!window.api) return
-    const result = await window.api.removeAgent(agentId)
-    if (!result.ok) {
-      console.error('Failed to remove agent:', result.error)
-      return result
-    }
 
     removeAgentState(agentId)
     emit()
-    return result
+
+    // Background cleanup (runtime stop, worktree removal) in main process
+    window.api.removeAgent(agentId).then((result) => {
+      if (!result.ok) {
+        console.error('Failed to remove agent (background cleanup):', result.error)
+      }
+    })
+
+    return { ok: true }
   }, [])
 
   const selectDirectory = useCallback(async () => {


### PR DESCRIPTION
Agent removal previously blocked the UI for seconds while awaiting runtime shutdown (up to 5s) and synchronous git worktree commands that froze the Electron main process. Now the agent disappears from the dashboard immediately and all expensive cleanup runs in the background.