### PR TITLE
Fix agent name being slugified on launch but not on rename

### DIFF
--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -1005,14 +1005,14 @@ function upsertAgent(payload: AgentLaunchedPayload, initialStatus?: AgentStatus)
     !payload.title.match(/^.+-\d+$/) // matches pattern like "project-1" (auto-generated)
   const agentName = hasPrompt
     ? deriveNameFromPrompt(payload.prompt)
-    : payload.title.slice(0, 30).replace(/\s+/g, '-').toLowerCase()
+    : payload.title.slice(0, 30)
 
   const agent: LiveAgent = {
     id: payload.id,
     runtimeId: payload.runtimeId,
     sessionId: payload.sessionId,
     directory: payload.directory,
-    name: payload.displayName || existingAgent?.name || (hasExplicitTitle ? payload.title.slice(0, 30).replace(/\s+/g, '-').toLowerCase() : agentName),
+    name: payload.displayName || existingAgent?.name || (hasExplicitTitle ? payload.title.slice(0, 30) : agentName),
     projectName: payload.projectName || existingAgent?.projectName || payload.directory.split('/').pop() || payload.directory,
     branchName: existingAgent?.branchName ?? payload.branchName ?? '',
     isWorktree: payload.isWorktree ?? existingAgent?.isWorktree ?? false,


### PR DESCRIPTION
User-provided agent names were having spaces replaced with dashes and lowercased during launch, but rename preserved names as-is. Remove the slugification so launch and rename behave consistently.