### PR TITLE
Add screenshot/image attachment support to agent launch modal

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -7,6 +7,13 @@ import { database } from './services/database'
 import { notificationService, type NotifiableEventType } from './services/notification-service'
 import { getAppVersion } from './version'
 
+interface Attachment {
+  id?: string
+  mime: string
+  dataUrl: string
+  filename?: string
+}
+
 /**
  * Register all IPC handlers for renderer <-> main communication.
  */
@@ -18,6 +25,7 @@ export function registerIpcHandlers(): void {
     prompt?: string
     title?: string
     model?: string
+    attachments?: Attachment[]
   }) => {
     try {
       const handle = await agentController.launchAgent(options)
@@ -42,7 +50,7 @@ export function registerIpcHandlers(): void {
     }
   })
 
-  ipcMain.handle('agent:send-message', async (_event, agentId: string, text: string, agent?: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>) => {
+  ipcMain.handle('agent:send-message', async (_event, agentId: string, text: string, agent?: string, attachments?: Attachment[]) => {
     try {
       await agentController.sendMessage(agentId, text, agent, attachments)
       return { ok: true }
@@ -251,7 +259,7 @@ export function registerIpcHandlers(): void {
     }
   })
 
-  ipcMain.handle('agent:send-message-with-model', async (_event, agentId: string, text: string, providerID: string, modelID: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>) => {
+  ipcMain.handle('agent:send-message-with-model', async (_event, agentId: string, text: string, providerID: string, modelID: string, attachments?: Attachment[]) => {
     try {
       await agentController.sendMessageWithModel(agentId, text, providerID, modelID, attachments)
       return { ok: true }

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -6,6 +6,50 @@ import { notificationService, type NotifiableEventType } from './notification-se
 import { database } from './database'
 import { workspaceManager } from './workspace-manager'
 
+interface Attachment {
+  id?: string
+  mime: string
+  dataUrl: string
+  filename?: string
+}
+
+const ALLOWED_MIME_TYPES = new Set([
+  'image/png', 'image/jpeg', 'image/gif', 'image/webp',
+  'application/pdf'
+])
+const MAX_ATTACHMENTS = 10
+const MAX_TOTAL_PAYLOAD_BYTES = 50 * 1024 * 1024 // 50 MB
+
+function validateAttachments(attachments: Attachment[]): Attachment[] {
+  let totalSize = 0
+  const valid: Attachment[] = []
+
+  for (const att of attachments.slice(0, MAX_ATTACHMENTS)) {
+    if (!ALLOWED_MIME_TYPES.has(att.mime)) continue
+    if (!att.dataUrl.startsWith('data:')) continue
+    totalSize += att.dataUrl.length
+    if (totalSize > MAX_TOTAL_PAYLOAD_BYTES) break
+    valid.push(att)
+  }
+
+  return valid
+}
+
+function buildMessageParts(text: string, attachments?: Attachment[]): Array<TextPartInput | FilePartInput> {
+  const parts: Array<TextPartInput | FilePartInput> = [{ type: 'text', text }]
+  if (attachments?.length) {
+    for (const att of validateAttachments(attachments)) {
+      parts.push({
+        type: 'file',
+        mime: att.mime,
+        url: att.dataUrl,
+        ...(att.filename ? { filename: att.filename } : {})
+      })
+    }
+  }
+  return parts
+}
+
 function sanitizeSlug(value: string, fallback: string): string {
   const sanitized = value
     .trim()
@@ -106,8 +150,9 @@ class AgentController {
     prompt?: string
     title?: string
     model?: string
+    attachments?: Attachment[]
   }): Promise<AgentHandle> {
-    const { directory, prompt, title, model } = options
+    const { directory, prompt, title, model, attachments } = options
 
     // Ensure we have a runtime for this directory
     const runtime = await this.ensureBridgeForDirectory(directory)
@@ -163,7 +208,7 @@ class AgentController {
       await client.session.promptAsync({
         sessionID: session.id,
         directory,
-        parts: [{ type: 'text', text: prompt }]
+        parts: buildMessageParts(prompt, attachments)
       })
     }
 
@@ -259,24 +304,17 @@ class AgentController {
    * Optionally invoke a specific agent config by name.
    * Optionally include file attachments (images, PDFs, etc.) as additional parts.
    */
-  async sendMessage(agentId: string, text: string, agent?: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>): Promise<void> {
+  async sendMessage(agentId: string, text: string, agent?: string, attachments?: Attachment[]): Promise<void> {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
 
     const runtime = await this.ensureRuntimeForAgent(handle)
     runtimeManager.touchRuntimeActivity(runtime.id)
 
-    const parts: Array<TextPartInput | FilePartInput> = [{ type: 'text', text }]
-    if (attachments?.length) {
-      for (const att of attachments) {
-        parts.push({ type: 'file', mime: att.mime, url: att.dataUrl, ...(att.filename ? { filename: att.filename } : {}) })
-      }
-    }
-
     await runtime.client.session.promptAsync({
       sessionID: handle.sessionId,
       directory: handle.directory,
-      parts,
+      parts: buildMessageParts(text, attachments),
       ...(agent ? { agent } : {})
     })
   }
@@ -621,24 +659,17 @@ class AgentController {
   /**
    * Send a message with a model override.
    */
-  async sendMessageWithModel(agentId: string, text: string, providerID: string, modelID: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>): Promise<void> {
+  async sendMessageWithModel(agentId: string, text: string, providerID: string, modelID: string, attachments?: Attachment[]): Promise<void> {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
 
     const runtime = await this.ensureRuntimeForAgent(handle)
     runtimeManager.touchRuntimeActivity(runtime.id)
 
-    const parts: Array<TextPartInput | FilePartInput> = [{ type: 'text', text }]
-    if (attachments?.length) {
-      for (const att of attachments) {
-        parts.push({ type: 'file', mime: att.mime, url: att.dataUrl, ...(att.filename ? { filename: att.filename } : {}) })
-      }
-    }
-
     await runtime.client.session.promptAsync({
       sessionID: handle.sessionId,
       directory: handle.directory,
-      parts,
+      parts: buildMessageParts(text, attachments),
       model: { providerID, modelID }
     })
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -6,12 +6,19 @@ export interface IpcResult<T = unknown> {
   error?: string
 }
 
+interface Attachment {
+  id?: string
+  mime: string
+  dataUrl: string
+  filename?: string
+}
+
 const api = {
   // ── Agent Operations ──
-  launchAgent: (options: { directory: string; prompt?: string; title?: string; model?: string }): Promise<IpcResult> =>
+  launchAgent: (options: { directory: string; prompt?: string; title?: string; model?: string; attachments?: Attachment[] }): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:launch', options),
 
-  sendMessage: (agentId: string, text: string, agent?: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>): Promise<IpcResult> =>
+  sendMessage: (agentId: string, text: string, agent?: string, attachments?: Attachment[]): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:send-message', agentId, text, agent, attachments),
 
   respondToPermission: (agentId: string, permissionId: string, response: 'once' | 'always' | 'reject'): Promise<IpcResult> =>
@@ -65,7 +72,7 @@ const api = {
   listTools: (agentId: string): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:list-tools', agentId),
 
-  sendMessageWithModel: (agentId: string, text: string, providerID: string, modelID: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>): Promise<IpcResult> =>
+  sendMessageWithModel: (agentId: string, text: string, providerID: string, modelID: string, attachments?: Attachment[]): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:send-message-with-model', agentId, text, providerID, modelID, attachments),
 
   listSessions: (directory: string): Promise<IpcResult<Array<{ id: string; title: string; createdAt: number; updatedAt: number }>>> =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -716,7 +716,8 @@ export function App() {
     prompt?: string,
     title?: string,
     model?: string,
-    worktreeStrategy?: string
+    worktreeStrategy?: string,
+    attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>
   ) => {
     let launchDirectory = directory
 
@@ -743,7 +744,7 @@ export function App() {
       launchDirectory = worktreeResult.data.worktreePath
     }
 
-    const result = await store.launchAgent(launchDirectory, prompt || undefined, title, model)
+    const result = await store.launchAgent(launchDirectory, prompt || undefined, title, model, attachments)
 
     if (!result?.ok) {
       throw new Error('Failed to launch agent')

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -20,6 +20,7 @@ import {
 import type { AgentRuntime, Message, StatusOverride } from '../types'
 import { formatBranchLabel } from '../types'
 import type { LivePermission, LiveQuestion } from '../hooks/useAgentStore'
+import { useImageAttachments } from '../hooks/useImageAttachments'
 import { StatusBadge } from './StatusBadge'
 import { StatusDropdown } from './StatusDropdown'
 import { Markdown } from './Markdown'
@@ -119,93 +120,18 @@ export function DetailDrawer({
   const [agentPickerDismissed, setAgentPickerDismissed] = useState(false)
   const [agentPickerIndex, setAgentPickerIndex] = useState(0)
   const [cursorPos, setCursorPos] = useState(0)
-  const [attachments, setAttachments] = useState<Array<{ mime: string; dataUrl: string; filename?: string }>>([])
-  const [isDragOver, setIsDragOver] = useState(false)
+  const {
+    attachments, isDragOver, fileInputRef,
+    removeAttachment, clearAttachments,
+    handlePaste, handleDragOver, handleDragEnter, handleDragLeave, handleDrop, handleFileInputChange
+  } = useImageAttachments()
   const transcriptScrollRef = useRef<HTMLDivElement>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const overlayRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const fileInputRef = useRef<HTMLInputElement>(null)
   const shouldAutoScrollRef = useRef(true)
   const userScrolledRef = useRef(false)
   const isResizingRef = useRef(false)
-
-  const ACCEPTED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
-  const MAX_ATTACHMENT_SIZE = 20 * 1024 * 1024 // 20 MB
-
-  const readFileAsDataUrl = useCallback((file: File): Promise<string> => {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onload = () => resolve(reader.result as string)
-      reader.onerror = () => reject(reader.error)
-      reader.readAsDataURL(file)
-    })
-  }, [])
-
-  const addImageFiles = useCallback(async (files: FileList | File[]) => {
-    const imageFiles = Array.from(files).filter(
-      (f) => ACCEPTED_IMAGE_TYPES.includes(f.type) && f.size <= MAX_ATTACHMENT_SIZE
-    )
-    if (imageFiles.length === 0) return
-
-    const newAttachments = await Promise.all(
-      imageFiles.map(async (f) => ({
-        mime: f.type,
-        dataUrl: await readFileAsDataUrl(f),
-        filename: f.name
-      }))
-    )
-    setAttachments((prev) => [...prev, ...newAttachments])
-  }, [readFileAsDataUrl])
-
-  const removeAttachment = useCallback((index: number) => {
-    setAttachments((prev) => prev.filter((_, i) => i !== index))
-  }, [])
-
-  const handlePaste = useCallback((event: React.ClipboardEvent) => {
-    const items = event.clipboardData?.items
-    if (!items) return
-
-    const imageFiles: File[] = []
-    for (const item of items) {
-      if (ACCEPTED_IMAGE_TYPES.includes(item.type)) {
-        const file = item.getAsFile()
-        if (file) imageFiles.push(file)
-      }
-    }
-    if (imageFiles.length > 0) {
-      event.preventDefault()
-      void addImageFiles(imageFiles)
-    }
-  }, [addImageFiles])
-
-  const handleDragOver = useCallback((event: React.DragEvent) => {
-    event.preventDefault()
-    event.stopPropagation()
-    setIsDragOver(true)
-  }, [])
-
-  const handleDragLeave = useCallback((event: React.DragEvent) => {
-    event.preventDefault()
-    event.stopPropagation()
-    setIsDragOver(false)
-  }, [])
-
-  const handleDrop = useCallback((event: React.DragEvent) => {
-    event.preventDefault()
-    event.stopPropagation()
-    setIsDragOver(false)
-    if (event.dataTransfer?.files?.length) {
-      void addImageFiles(event.dataTransfer.files)
-    }
-  }, [addImageFiles])
-
-  const handleFileInputChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    if (event.target.files?.length) {
-      void addImageFiles(event.target.files)
-      event.target.value = ''
-    }
-  }, [addImageFiles])
 
   const handleResizeStart = useCallback((event: React.MouseEvent) => {
     event.preventDefault()
@@ -348,7 +274,7 @@ export function DetailDrawer({
     if ((!inputText.trim() && attachments.length === 0) || !onSendMessage) return
     onSendMessage(inputText.trim(), attachments.length > 0 ? attachments : undefined)
     setInputText('')
-    setAttachments([])
+    clearAttachments()
   }
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
@@ -635,14 +561,14 @@ export function DetailDrawer({
             isDragOver ? 'border-kumo-brand bg-kumo-brand/[0.04]' : 'border-kumo-line'
           }`}
           onDragOver={handleDragOver}
+          onDragEnter={handleDragEnter}
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
         >
-          {/* Attachment thumbnails */}
           {attachments.length > 0 && (
             <div className="flex gap-2 px-1 py-1.5 overflow-x-auto">
-              {attachments.map((att, index) => (
-                <div key={index} className="relative group shrink-0">
+              {attachments.map((att) => (
+                <div key={att.id} className="relative group shrink-0">
                   <img
                     src={att.dataUrl}
                     alt={att.filename ?? 'attachment'}
@@ -650,7 +576,7 @@ export function DetailDrawer({
                   />
                   <button
                     type="button"
-                    onClick={() => removeAttachment(index)}
+                    onClick={() => removeAttachment(att.id!)}
                     className="absolute -top-1.5 -right-1.5 w-4 h-4 flex items-center justify-center rounded-full bg-kumo-danger text-white text-[9px] font-bold opacity-0 group-hover:opacity-100 transition-opacity"
                   >
                     <X size={8} weight="bold" />

--- a/src/renderer/src/components/LaunchModal.tsx
+++ b/src/renderer/src/components/LaunchModal.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
-import { X, FolderOpen, CaretDown, Warning, Trash } from '@phosphor-icons/react'
+import { X, FolderOpen, CaretDown, Warning, Trash, Paperclip } from '@phosphor-icons/react'
 import { SelectField } from './SelectField'
 import { useModelOptions } from '../hooks/useModelOptions'
+import { useImageAttachments } from '../hooks/useImageAttachments'
 import { loadSettings } from '../data/settings'
-import type { Project } from '../types/api'
+import type { Project, MessageAttachment } from '../types/api'
 
 type WorktreeStrategy = 'new-worktree' | 'current-directory'
 
@@ -43,7 +44,7 @@ interface KnownDirectory {
 
 interface LaunchModalProps {
   onClose: () => void
-  onLaunch: (directory: string, prompt?: string, title?: string, model?: string, worktreeStrategy?: string) => void
+  onLaunch: (directory: string, prompt?: string, title?: string, model?: string, worktreeStrategy?: string, attachments?: MessageAttachment[]) => void
   onSelectDirectory: () => Promise<string | null>
   onValidateDirectory?: (dir: string) => Promise<boolean>
   knownDirectories?: KnownDirectory[]
@@ -62,6 +63,11 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
   const [worktreeRoot, setWorktreeRoot] = useState('')
   const [savedProjects, setSavedProjects] = useState<Project[]>([])
   const [showDropdown, setShowDropdown] = useState(false)
+  const {
+    attachments, isDragOver, fileInputRef,
+    removeAttachment, clearAttachments,
+    handlePaste, handleDragOver, handleDragEnter, handleDragLeave, handleDrop, handleFileInputChange
+  } = useImageAttachments()
   const dropdownRef = useRef<HTMLDivElement>(null)
 
   const estimatedWorktreePath = useMemo(() => {
@@ -217,8 +223,9 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
     if (!directory.trim() || dirError || validating) return
     setLaunching(true)
     try {
-      await onLaunch(directory, prompt || undefined, title || undefined, model, worktreeStrategy)
+      await onLaunch(directory, prompt || undefined, title || undefined, model, worktreeStrategy, attachments.length > 0 ? attachments : undefined)
       await saveProject(directory.trim())
+      clearAttachments()
       onClose()
     } catch (error) {
       console.error('Launch failed:', error)
@@ -418,13 +425,71 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
             <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
               Initial Prompt <span className="text-kumo-subtle/60">(optional — you can prompt from the session)</span>
             </label>
-            <textarea
-              value={prompt}
-              onChange={(event) => setPrompt(event.target.value)}
-              placeholder="Leave empty to start an interactive session..."
-              rows={3}
-              className="px-3 py-2 bg-kumo-control border border-kumo-line rounded-md text-sm text-kumo-default outline-none focus:border-kumo-ring placeholder:text-kumo-subtle resize-none"
-            />
+            <div
+              className={`flex flex-col gap-0 rounded-md border transition-colors ${
+                isDragOver ? 'border-kumo-brand bg-kumo-brand/[0.04]' : 'border-kumo-line focus-within:border-kumo-ring'
+              }`}
+              onDragOver={handleDragOver}
+              onDragEnter={handleDragEnter}
+              onDragLeave={handleDragLeave}
+              onDrop={handleDrop}
+            >
+              {attachments.length > 0 && (
+                <div className="flex gap-2 px-3 py-2 overflow-x-auto">
+                  {attachments.map((att) => (
+                    <div key={att.id} className="relative group shrink-0">
+                      <img
+                        src={att.dataUrl}
+                        alt={att.filename ?? 'attachment'}
+                        className="h-16 w-16 rounded-md border border-kumo-line object-cover"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => removeAttachment(att.id!)}
+                        className="absolute -top-1.5 -right-1.5 w-4 h-4 flex items-center justify-center rounded-full bg-kumo-danger text-white text-[9px] font-bold opacity-0 group-hover:opacity-100 transition-opacity"
+                      >
+                        <X size={8} weight="bold" />
+                      </button>
+                      {att.filename && (
+                        <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white text-[8px] px-1 py-0.5 rounded-b-md truncate">
+                          {att.filename}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+              <textarea
+                value={prompt}
+                onChange={(event) => setPrompt(event.target.value)}
+                onPaste={handlePaste}
+                placeholder={isDragOver ? 'Drop image here...' : 'Leave empty to start an interactive session...'}
+                rows={3}
+                className="px-3 py-2 bg-kumo-control rounded-md text-sm text-kumo-default outline-none placeholder:text-kumo-subtle resize-none border-0 focus:ring-0"
+              />
+              <div className="flex items-center gap-2 px-3 pb-2">
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  className="flex items-center gap-1 text-[10px] text-kumo-subtle hover:text-kumo-default transition-colors"
+                  title="Attach image"
+                >
+                  <Paperclip size={11} />
+                  <span>Attach image</span>
+                </button>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/png,image/jpeg,image/gif,image/webp"
+                  multiple
+                  className="hidden"
+                  onChange={handleFileInputChange}
+                />
+                <span className="text-[10px] text-kumo-subtle">
+                  Paste or drag images to attach.
+                </span>
+              </div>
+            </div>
           </div>
         </div>
 

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -3,7 +3,8 @@ import type { AgentStatus, StatusOverride } from '../types'
 import type {
   OpenCodeEventPayload,
   AgentLaunchedPayload,
-  AgentStatusesPayload
+  AgentStatusesPayload,
+  MessageAttachment
 } from '../types/api'
 
 interface HistoricalMessageInfo {
@@ -1303,9 +1304,9 @@ export function useAgentStore() {
   const permissions = Array.from(storeState.permissions.values())
   const questions = Array.from(storeState.questions.values())
 
-  const launchAgent = useCallback(async (directory: string, prompt?: string, title?: string, model?: string) => {
+  const launchAgent = useCallback(async (directory: string, prompt?: string, title?: string, model?: string, attachments?: MessageAttachment[]) => {
     if (!window.api) return
-    const result = await window.api.launchAgent({ directory, prompt, title, model })
+    const result = await window.api.launchAgent({ directory, prompt, title, model, attachments })
     if (!result.ok) {
       console.error('Failed to launch agent:', result.error)
     } else if (result.data) {
@@ -1331,7 +1332,7 @@ export function useAgentStore() {
     return result
   }, [])
 
-  const sendMessage = useCallback(async (agentId: string, text: string, agentConfig?: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>) => {
+  const sendMessage = useCallback(async (agentId: string, text: string, agentConfig?: string, attachments?: MessageAttachment[]) => {
     if (!window.api) return
 
     // Don't allow sending while agent is stopping

--- a/src/renderer/src/hooks/useImageAttachments.ts
+++ b/src/renderer/src/hooks/useImageAttachments.ts
@@ -1,0 +1,134 @@
+import { useState, useCallback, useRef } from 'react'
+import type { MessageAttachment } from '../types/api'
+
+const ACCEPTED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
+const MAX_ATTACHMENT_SIZE = 20 * 1024 * 1024 // 20 MB
+const MAX_ATTACHMENT_COUNT = 10
+
+let nextAttachmentId = 0
+function generateAttachmentId(): string {
+  return `att-${Date.now()}-${nextAttachmentId++}`
+}
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = () => reject(reader.error)
+    reader.readAsDataURL(file)
+  })
+}
+
+export function useImageAttachments() {
+  const [attachments, setAttachments] = useState<MessageAttachment[]>([])
+  const [isDragOver, setIsDragOver] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const dragCounterRef = useRef(0)
+
+  const addImageFiles = useCallback(async (files: FileList | File[]) => {
+    const imageFiles = Array.from(files).filter(
+      (f) => ACCEPTED_IMAGE_TYPES.includes(f.type) && f.size <= MAX_ATTACHMENT_SIZE
+    )
+    if (imageFiles.length === 0) return
+
+    const results = await Promise.allSettled(
+      imageFiles.map(async (f): Promise<MessageAttachment> => ({
+        id: generateAttachmentId(),
+        mime: f.type,
+        dataUrl: await readFileAsDataUrl(f),
+        filename: f.name
+      }))
+    )
+
+    const succeeded = results
+      .filter((r): r is PromiseFulfilledResult<MessageAttachment> => r.status === 'fulfilled')
+      .map((r) => r.value)
+
+    if (succeeded.length === 0) return
+
+    setAttachments((prev) => {
+      const remaining = MAX_ATTACHMENT_COUNT - prev.length
+      if (remaining <= 0) return prev
+      return [...prev, ...succeeded.slice(0, remaining)]
+    })
+  }, [])
+
+  const removeAttachment = useCallback((id: string) => {
+    setAttachments((prev) => prev.filter((att) => att.id !== id))
+  }, [])
+
+  const clearAttachments = useCallback(() => {
+    setAttachments([])
+  }, [])
+
+  const handlePaste = useCallback((event: React.ClipboardEvent) => {
+    const items = event.clipboardData?.items
+    if (!items) return
+
+    const imageFiles: File[] = []
+    for (const item of items) {
+      if (ACCEPTED_IMAGE_TYPES.includes(item.type)) {
+        const file = item.getAsFile()
+        if (file) imageFiles.push(file)
+      }
+    }
+    if (imageFiles.length > 0) {
+      event.preventDefault()
+      void addImageFiles(imageFiles)
+    }
+  }, [addImageFiles])
+
+  const handleDragOver = useCallback((event: React.DragEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+  }, [])
+
+  const handleDragEnter = useCallback((event: React.DragEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    dragCounterRef.current++
+    if (dragCounterRef.current === 1) {
+      setIsDragOver(true)
+    }
+  }, [])
+
+  const handleDragLeave = useCallback((event: React.DragEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    dragCounterRef.current--
+    if (dragCounterRef.current === 0) {
+      setIsDragOver(false)
+    }
+  }, [])
+
+  const handleDrop = useCallback((event: React.DragEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    dragCounterRef.current = 0
+    setIsDragOver(false)
+    if (event.dataTransfer?.files?.length) {
+      void addImageFiles(event.dataTransfer.files)
+    }
+  }, [addImageFiles])
+
+  const handleFileInputChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files?.length) {
+      void addImageFiles(event.target.files)
+      event.target.value = ''
+    }
+  }, [addImageFiles])
+
+  return {
+    attachments,
+    isDragOver,
+    fileInputRef,
+    removeAttachment,
+    clearAttachments,
+    handlePaste,
+    handleDragOver,
+    handleDragEnter,
+    handleDragLeave,
+    handleDrop,
+    handleFileInputChange
+  }
+}

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -5,13 +5,14 @@ export interface IpcResult<T = unknown> {
 }
 
 export interface MessageAttachment {
+  id?: string
   mime: string
   dataUrl: string
   filename?: string
 }
 
 export interface OrchestratorApi {
-  launchAgent: (options: { directory: string; prompt?: string; title?: string; model?: string }) => Promise<IpcResult>
+  launchAgent: (options: { directory: string; prompt?: string; title?: string; model?: string; attachments?: MessageAttachment[] }) => Promise<IpcResult>
   sendMessage: (agentId: string, text: string, agent?: string, attachments?: MessageAttachment[]) => Promise<IpcResult>
   respondToPermission: (agentId: string, permissionId: string, response: 'once' | 'always' | 'reject') => Promise<IpcResult>
   abortAgent: (agentId: string) => Promise<IpcResult>


### PR DESCRIPTION
Thread image attachment support through the full stack so users can paste, drag-drop, or pick images when launching a new agent — matching the existing capability in the detail drawer.

Extract shared useImageAttachments hook to deduplicate ~85 lines of identical attachment logic between LaunchModal and DetailDrawer. Add server-side MIME validation, attachment count/size limits, stable React keys, and resilient file reads via Promise.allSettled.