### PR TITLE
Add agent response preview to desktop notifications

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -592,11 +592,11 @@ export function registerIpcHandlers(): void {
 
   // ── Notifications ──
 
-  ipcMain.handle('agent:notify-status', async (_event, agentId: string, status: string, agentName: string, projectName?: string) => {
+  ipcMain.handle('agent:notify-status', async (_event, agentId: string, status: string, agentName: string, projectName?: string, preview?: string) => {
     try {
       const notifiable = ['needs_approval', 'needs_input', 'errored', 'completed', 'disconnected']
       if (notifiable.includes(status)) {
-        agentController.checkAndNotify(agentId, status as NotifiableEventType, agentName, projectName)
+        agentController.checkAndNotify(agentId, status as NotifiableEventType, agentName, projectName, preview)
       }
       return { ok: true }
     } catch (error) {

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -962,8 +962,8 @@ class AgentController {
   /**
    * Check agent status and send desktop notification if appropriate.
    */
-  checkAndNotify(agentId: string, status: NotifiableEventType, agentName: string, projectName?: string): void {
-    notificationService.checkAndNotify(agentId, status, agentName, projectName)
+  checkAndNotify(agentId: string, status: NotifiableEventType, agentName: string, projectName?: string, preview?: string): void {
+    notificationService.checkAndNotify(agentId, status, agentName, projectName, preview)
 
     // Update badge count with number of blocked agents (needs_approval + needs_input)
     const blockedStatuses: NotifiableEventType[] = ['needs_approval', 'needs_input']

--- a/src/main/services/notification-service.ts
+++ b/src/main/services/notification-service.ts
@@ -75,7 +75,8 @@ class NotificationService {
     agentId: string,
     status: NotifiableEventType,
     agentName: string,
-    projectName?: string
+    projectName?: string,
+    preview?: string
   ): void {
     if (!this.preferences[status]) {
       return
@@ -86,7 +87,7 @@ class NotificationService {
     }
 
     this.recordNotification(agentId, status)
-    this.sendNotification(agentId, status, agentName, projectName)
+    this.sendNotification(agentId, status, agentName, projectName, preview)
   }
 
   private isDuplicate(agentId: string, eventType: NotifiableEventType): boolean {
@@ -127,7 +128,8 @@ class NotificationService {
     agentId: string,
     eventType: NotifiableEventType,
     agentName: string,
-    projectName?: string
+    projectName?: string,
+    preview?: string
   ): void {
     if (!Notification.isSupported()) {
       console.warn('[NotificationService] Notifications not supported on this platform')
@@ -135,7 +137,15 @@ class NotificationService {
     }
 
     const title = NOTIFICATION_TITLES[eventType](agentName)
-    const body = NOTIFICATION_BODIES[eventType](projectName)
+    const defaultBody = NOTIFICATION_BODIES[eventType](projectName)
+
+    // Only show preview for terminal statuses where "what did the agent say?" is relevant.
+    // For blocked statuses (needs_approval, needs_input, disconnected) the generic body
+    // ("Action requires your approval") is more useful than unrelated assistant text.
+    const usePreview = preview && (eventType === 'completed' || eventType === 'errored')
+    const body = usePreview
+      ? (projectName ? `${projectName}: ${preview}` : preview)
+      : defaultBody
 
     const notification = new Notification({
       title,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -179,8 +179,8 @@ const api = {
     ipcRenderer.invoke('app:version'),
 
   // ── Shell Integration ──
-  notifyAgentStatus: (agentId: string, status: string, agentName: string, projectName?: string): Promise<IpcResult> =>
-    ipcRenderer.invoke('agent:notify-status', agentId, status, agentName, projectName),
+  notifyAgentStatus: (agentId: string, status: string, agentName: string, projectName?: string, preview?: string): Promise<IpcResult> =>
+    ipcRenderer.invoke('agent:notify-status', agentId, status, agentName, projectName, preview),
 
   openInEditor: (options: { path: string; editor: 'vscode' | 'cursor' | 'windsurf' | 'goland' }): Promise<IpcResult> =>
     ipcRenderer.invoke('shell:open-in-editor', options),

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -470,6 +470,30 @@ export function setViewedAgentId(agentId: string | null): void {
 
 const NOTIFIABLE_STATUSES = new Set(['needs_approval', 'needs_input', 'errored', 'completed', 'disconnected', 'idle'])
 
+const MAX_PREVIEW_LENGTH = 200
+
+function getLastAssistantPreview(sessionId: string): string | undefined {
+  const messages = state.messages.get(sessionId)
+  if (!messages) return undefined
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i]
+    if (msg.role !== 'assistant') continue
+
+    const fullText = msg.parts
+      .filter((p) => p.type === 'text' && p.text)
+      .map((p) => p.text!)
+      .join(' ')
+      .trim()
+
+    if (fullText.length === 0) continue
+    return fullText.length > MAX_PREVIEW_LENGTH
+      ? fullText.slice(0, MAX_PREVIEW_LENGTH) + '…'
+      : fullText
+  }
+  return undefined
+}
+
 function notifyIfNeeded(agent: LiveAgent, newStatus: string): void {
   if (agent.status === newStatus) return
   if (!NOTIFIABLE_STATUSES.has(newStatus)) return
@@ -481,7 +505,8 @@ function notifyIfNeeded(agent: LiveAgent, newStatus: string): void {
   const notifyStatus = (newStatus === 'idle' && agent.status === 'running') ? 'completed' : newStatus
   if (notifyStatus === 'idle') return // only notify idle when coming from running
 
-  window.api?.notifyAgentStatus(agent.id, notifyStatus, agent.name, agent.projectName)
+  const preview = getLastAssistantPreview(agent.sessionId)
+  window.api?.notifyAgentStatus(agent.id, notifyStatus, agent.name, agent.projectName, preview)
 }
 
 function processEvent(payload: OpenCodeEventPayload): void {

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -76,7 +76,7 @@ export interface OrchestratorApi {
   getVersion: () => Promise<IpcResult<string>>
 
   // ── Shell Integration ──
-  notifyAgentStatus: (agentId: string, status: string, agentName: string, projectName?: string) => Promise<IpcResult>
+  notifyAgentStatus: (agentId: string, status: string, agentName: string, projectName?: string, preview?: string) => Promise<IpcResult>
   openInEditor: (options: { path: string; editor: 'vscode' | 'cursor' | 'windsurf' | 'goland' }) => Promise<IpcResult>
   openTerminal: (options: { path: string; terminal?: string }) => Promise<IpcResult>
   openExternal: (url: string) => Promise<IpcResult>


### PR DESCRIPTION
Show the last assistant message text in notification body for completed and errored agents. Blocked statuses (needs_approval, needs_input, disconnected) keep their action-oriented generic body. Project name is preserved alongside the preview for multi-project context.