### PR TITLE
Reduce re-renders from SSE events to fix typing lag in prompt boxes

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -53,7 +53,7 @@ export function App() {
 
   const [sortColumn, setSortColumn] = useState<SortColumn | null>(null)
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
-  const [, setTick] = useState(0)
+  const [tick, setTick] = useState(0)
   const [agentCommands, setAgentCommands] = useState<ChatCommand[]>([])
   const [agentConfigs, setAgentConfigs] = useState<Array<{ name: string; description?: string }>>([])
   const [showModelPicker, setShowModelPicker] = useState(false)
@@ -66,6 +66,9 @@ export function App() {
   const store = useAgentStore()
 
   // ── Fetch available commands and agent configs when an agent is selected ──
+  // Deps use specific stable callbacks (not the whole store object) to avoid
+  // re-fetching on unrelated SSE events.
+  const { listCommands, listAgentConfigs } = store
   useEffect(() => {
     if (!selectedAgentId) {
       setAgentCommands([])
@@ -76,7 +79,7 @@ export function App() {
     let cancelled = false
 
     const fetchCommands = async (): Promise<void> => {
-      const commands = await store.listCommands(selectedAgentId)
+      const commands = await listCommands(selectedAgentId)
       if (cancelled) return
 
       const builtInCommands: ChatCommand[] = [
@@ -102,7 +105,7 @@ export function App() {
     }
 
     const fetchAgentConfigs = async (): Promise<void> => {
-      const configs = await store.listAgentConfigs(selectedAgentId)
+      const configs = await listAgentConfigs(selectedAgentId)
       if (cancelled) return
       setAgentConfigs(configs ?? [])
     }
@@ -111,7 +114,7 @@ export function App() {
     void fetchAgentConfigs()
 
     return () => { cancelled = true }
-  }, [selectedAgentId, store])
+  }, [selectedAgentId, listCommands, listAgentConfigs])
 
   // ── Live timestamp refresh (every 30s) ──
   useEffect(() => {
@@ -201,7 +204,7 @@ export function App() {
       blockedSince: agent.blockedSince ? formatTimeAgo(agent.blockedSince) : undefined,
       blockedSinceMs: agent.blockedSince
     }))
-  }, [store.agents])
+  }, [store.agents, tick])
 
   // ── Convert live permissions + needs_input agents to Interrupt shape ──
   const liveInterrupts: Interrupt[] = useMemo(() => {
@@ -247,7 +250,7 @@ export function App() {
       }))
 
     return [...permissionInterrupts, ...questionInterrupts, ...inputInterrupts]
-  }, [store.permissions, store.questions, store.agents])
+  }, [store.permissions, store.questions, store.agents, tick])
 
   // ── Display data: always live (no mock fallback) ──
   const displayAgents = liveAgentsAsRuntimes
@@ -671,6 +674,29 @@ export function App() {
     await store.abortAgent(selectedAgentId)
   }, [selectedAgentId, store])
 
+  const handleCloseDrawer = useCallback(() => setSelectedAgentId(null), [])
+
+  const handleDrawerApprove = useCallback(() => {
+    if (selectedPermission) handleApprove(selectedPermission.id)
+  }, [selectedPermission, handleApprove])
+
+  const handleDrawerDeny = useCallback(() => {
+    if (selectedPermission) handleDeny(selectedPermission.id)
+  }, [selectedPermission, handleDeny])
+
+  const handleDrawerRemove = useCallback(() => {
+    if (selectedAgentId) void handleRemoveAgent(selectedAgentId)
+  }, [selectedAgentId, handleRemoveAgent])
+
+  const handleDrawerChangeModel = useCallback(() => {
+    setModelPickerAgentId(selectedAgentId)
+    setShowModelPicker(true)
+  }, [selectedAgentId])
+
+  const handleDrawerSetStatusOverride = useCallback((override: StatusOverride | null) => {
+    if (selectedAgentId) handleSetStatusOverride(selectedAgentId, override)
+  }, [selectedAgentId, handleSetStatusOverride])
+
   const handleCreatePr = useCallback(async () => {
     if (!selectedAgentId) return
     await store.sendMessage(selectedAgentId, loadSettings().createPrPrompt, undefined, undefined, 'Create PR')
@@ -1014,19 +1040,19 @@ export function App() {
           events={selectedEvents}
           commands={agentCommands}
           agentConfigs={agentConfigs}
-          onClose={() => setSelectedAgentId(null)}
+          onClose={handleCloseDrawer}
           onSendMessage={handleSendMessage}
-          onApprove={selectedPermission ? () => handleApprove(selectedPermission.id) : undefined}
-          onDeny={selectedPermission ? () => handleDeny(selectedPermission.id) : undefined}
+          onApprove={selectedPermission ? handleDrawerApprove : undefined}
+          onDeny={selectedPermission ? handleDrawerDeny : undefined}
           onReplyQuestion={selectedQuestion ? handleReplyQuestion : undefined}
           onRejectQuestion={selectedQuestion ? handleRejectQuestion : undefined}
           onAbort={handleAbort}
-          onRemove={() => void handleRemoveAgent(selectedAgent.id)}
+          onRemove={handleDrawerRemove}
           onCreatePr={handleCreatePr}
           onOpenInEditor={handleOpenInEditor}
-          onChangeModel={() => { setModelPickerAgentId(selectedAgentId); setShowModelPicker(true) }}
+          onChangeModel={handleDrawerChangeModel}
           onOpenTerminal={handleOpenTerminalForDrawer}
-          onSetStatusOverride={(override) => handleSetStatusOverride(selectedAgent.id, override)}
+          onSetStatusOverride={handleDrawerSetStatusOverride}
         />
       )}
 

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo, memo } from 'react'
 import {
   X,
   Square,
@@ -87,7 +87,7 @@ interface DetailDrawerProps {
   onSetStatusOverride?: (override: StatusOverride | null) => void
 }
 
-export function DetailDrawer({
+export const DetailDrawer = memo(function DetailDrawer({
   agent,
   messages,
   permission,
@@ -163,31 +163,40 @@ export function DetailDrawer({
     document.addEventListener('mouseup', handleMouseUp)
   }, [drawerWidth])
 
-  const matchingCommands = inputText.startsWith('/')
-    ? commands.filter(({ command }) => command.startsWith(inputText.trim().toLowerCase()))
-    : []
-
   const trimmedInput = inputText.trim().toLowerCase()
-  const exactCommandMatch = commands.some(({ command }) => command === trimmedInput)
-  const showCommandAutocomplete = matchingCommands.length > 0 && trimmedInput.length > 0 && !exactCommandMatch
+
+  const matchingCommands = useMemo(
+    () => inputText.startsWith('/')
+      ? commands.filter(({ command }) => command.startsWith(trimmedInput))
+      : [],
+    [inputText, trimmedInput, commands]
+  )
+
+  const showCommandAutocomplete = useMemo(() => {
+    if (matchingCommands.length === 0 || trimmedInput.length === 0) return false
+    return !commands.some(({ command }) => command === trimmedInput)
+  }, [matchingCommands, trimmedInput, commands])
 
   // ── @ Agent mention detection ──
   // Find the @mention being typed at or before the cursor position.
   // We look for "@" followed by optional word characters, where the cursor
   // is within or right after this token.
-  const agentMentionResult = (() => {
+  const agentMentionResult = useMemo(() => {
     if (agentConfigs.length === 0) return null
     const textBeforeCursor = inputText.slice(0, cursorPos)
     const match = textBeforeCursor.match(/@(\w*)$/)
     if (!match) return null
     const start = textBeforeCursor.length - match[0].length
     return { query: match[1].toLowerCase(), start, end: cursorPos }
-  })()
+  }, [agentConfigs.length, inputText, cursorPos])
 
   const agentMention = !agentPickerDismissed ? agentMentionResult : null
-  const matchingAgents = agentMention
-    ? agentConfigs.filter((cfg) => cfg.name.toLowerCase().startsWith(agentMention.query))
-    : []
+  const matchingAgents = useMemo(
+    () => agentMention
+      ? agentConfigs.filter((cfg) => cfg.name.toLowerCase().startsWith(agentMention.query))
+      : [],
+    [agentMention, agentConfigs]
+  )
   const showAgentPicker = matchingAgents.length > 0 && !showCommandAutocomplete
 
   // Slide-in animation on mount
@@ -761,7 +770,7 @@ export function DetailDrawer({
       </div>
     </div>
   )
-}
+})
 
 function QuestionCard({
   question,

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react'
 import type { AgentStatus, StatusOverride } from '../types'
 import type {
   OpenCodeEventPayload,
@@ -161,6 +161,17 @@ let state: AgentStoreState = {
 
 let eventCounter = 0
 
+// Per-collection version counters. Incremented only when the corresponding Map
+// is actually mutated, allowing downstream useMemo hooks to skip re-derivation
+// when an SSE event only touches a different collection (e.g. a message update
+// shouldn't re-create the agents array).
+let agentsVersion = 0
+let permissionsVersion = 0
+let questionsVersion = 0
+let messagesVersion = 0
+let fileChangesVersion = 0
+let eventLogVersion = 0
+
 // Tracks agents whose taskSummary was set via an explicit override (e.g. "Create PR",
 // "/review") so the SSE echo of the raw prompt text doesn't clobber the friendly label.
 // Cleared when a server-generated session title arrives (which is a better summary).
@@ -168,7 +179,20 @@ const taskSummaryLocked = new Set<string>()
 
 const listeners = new Set<() => void>()
 
-function emit(): void {
+interface EmitFlags {
+  agents?: boolean
+  permissions?: boolean
+  questions?: boolean
+  messages?: boolean
+}
+
+function emit(changed?: EmitFlags): void {
+  // Bump per-collection version counters so downstream useMemo hooks can
+  // skip re-derivation when only unrelated collections changed.
+  if (!changed || changed.agents) agentsVersion++
+  if (!changed || changed.permissions) permissionsVersion++
+  if (!changed || changed.questions) questionsVersion++
+  if (!changed || changed.messages) messagesVersion++
   // Create new state reference to trigger re-renders
   state = { ...state }
   for (const listener of listeners) {
@@ -283,6 +307,7 @@ function logEvent(sessionId: string, type: string, props: Record<string, unknown
     data: props
   })
   state.eventLog.set(sessionId, entries)
+  eventLogVersion++
 }
 
 function resolveSessionIdForEvent(
@@ -315,6 +340,7 @@ function trackFileChange(sessionId: string, filePath: string, action: FileChange
     timestamp: Date.now()
   })
   state.fileChanges.set(sessionId, changes)
+  fileChangesVersion++
 }
 
 function getMessageCreatedAt(info: Record<string, unknown> | HistoricalMessageInfo): number {
@@ -537,7 +563,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
           if (newStatus === 'completed') {
             persistAgentMeta(agent.id, { persistedStatus: 'completed' })
           }
-          emit()
+          emit({ agents: true })
         }
       }
       break
@@ -552,7 +578,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
         agent.lastActivityAt = Date.now()
         agent.blockedSince = undefined
         agent.respondedAt = undefined
-        emit()
+        emit({ agents: true })
       }
       break
     }
@@ -565,7 +591,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
         agent.status = 'errored'
         agent.lastActivityAt = Date.now()
         agent.respondedAt = undefined
-        emit()
+        emit({ agents: true })
       }
       break
     }
@@ -580,7 +606,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
         agent.blockedSince = undefined
         agent.respondedAt = undefined
         persistAgentMeta(agent.id, { persistedStatus: 'completed' })
-        emit()
+        emit({ agents: true })
       }
       break
     }
@@ -603,7 +629,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
           agent.taskSummary = title.slice(0, 120)
           persistAgentMeta(agent.id, { taskSummary: agent.taskSummary })
         }
-        emit()
+        emit({ agents: true })
       }
       break
     }
@@ -615,21 +641,27 @@ function processEvent(payload: OpenCodeEventPayload): void {
       const role = info.role as 'user' | 'assistant'
       const createdAt = getMessageCreatedAt(info)
 
+      let agentChanged = false
       const agent = findAgentBySession(sessionId)
       if (agent) {
+        // lastActivityAt is intentionally not tracked via agentChanged — it feeds
+        // the "Xs ago" display which already refreshes on a 30s timer. Tracking it
+        // here would bump agentsVersion on every message event, defeating the
+        // optimization for typing responsiveness.
         agent.lastActivityAt = Date.now()
 
         // Update cost/tokens from assistant messages
         if (role === 'assistant') {
           const cost = info.cost as number | undefined
           const tokens = info.tokens as { input: number; output: number } | undefined
-          if (cost !== undefined) agent.cost = cost
-          if (tokens) agent.tokens = { input: tokens.input, output: tokens.output }
+          if (cost !== undefined) { agent.cost = cost; agentChanged = true }
+          if (tokens) { agent.tokens = { input: tokens.input, output: tokens.output }; agentChanged = true }
 
           // Extract model info
           const modelId = info.modelID as string | undefined
           if (modelId) {
             agent.model = formatModelName(modelId)
+            agentChanged = true
           }
         }
       }
@@ -651,7 +683,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
         existing.role = role
       }
 
-      emit()
+      emit({ messages: true, agents: agentChanged })
       break
     }
 
@@ -709,6 +741,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
         }
 
         // Update agent activity (but don't clobber blocked/stopping/terminal states)
+        let agentChanged = false
         const agent = findAgentBySession(sessionId)
         if (agent) {
           agent.lastActivityAt = Date.now()
@@ -733,11 +766,15 @@ function processEvent(payload: OpenCodeEventPayload): void {
               }
 
               persistAgentMeta(agent.id, { displayName: agent.name, taskSummary: agent.taskSummary })
+              agentChanged = true
             }
           }
         }
 
-        emit()
+        // This is the hottest event path — fire dozens of times per second while
+        // agents are working. Only flag the collections that actually changed to
+        // avoid invalidating unrelated useMemo hooks (e.g. agents array).
+        emit({ messages: true, agents: agentChanged })
       }
       break
     }
@@ -769,7 +806,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
           createdAt: Date.now()
         })
 
-        emit()
+        emit({ agents: true, permissions: true })
       }
       break
     }
@@ -788,7 +825,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
         agent.lastActivityAt = Date.now()
       }
 
-      emit()
+      emit({ agents: true, permissions: true })
       break
     }
 
@@ -816,7 +853,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
           createdAt: Date.now()
         })
 
-        emit()
+        emit({ agents: true, questions: true })
       }
       break
     }
@@ -835,7 +872,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
         agent.lastActivityAt = Date.now()
       }
 
-      emit()
+      emit({ agents: true, questions: true })
       break
     }
 
@@ -853,7 +890,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
         agent.lastActivityAt = Date.now()
       }
 
-      emit()
+      emit({ agents: true, questions: true })
       break
     }
 
@@ -872,7 +909,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
             inferFileAction(diff.before as string | undefined, diff.after as string | undefined)
           )
         }
-        emit()
+        emit({ agents: true })
       }
       break
     }
@@ -884,7 +921,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
         agent.lastActivityAt = Date.now()
         const filePath = (props.file ?? props.path ?? 'unknown') as string
         trackFileChange(agent.sessionId, filePath, 'modified')
-        emit()
+        emit({ agents: true })
       }
       break
     }
@@ -903,7 +940,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
               : 'modified'
           trackFileChange(agent.sessionId, filePath, action)
         }
-        emit()
+        emit({ agents: true })
       }
       break
     }
@@ -917,7 +954,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
           agent.lastActivityAt = Date.now()
         }
       }
-      emit()
+      emit({ agents: true })
       break
     }
 
@@ -927,7 +964,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
         agent.lastActivityAt = Date.now()
         const filePath = (props.file ?? props.path ?? 'unknown') as string
         trackFileChange(agent.sessionId, filePath, 'created')
-        emit()
+        emit({ agents: true })
       }
       break
     }
@@ -938,7 +975,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
         agent.lastActivityAt = Date.now()
         const filePath = (props.file ?? props.path ?? 'unknown') as string
         trackFileChange(agent.sessionId, filePath, 'deleted')
-        emit()
+        emit({ agents: true })
       }
       break
     }
@@ -1476,9 +1513,28 @@ export function useAgentStore() {
     }
   }, [])
 
-  const agents = Array.from(storeState.agents.values())
-  const permissions = Array.from(storeState.permissions.values())
-  const questions = Array.from(storeState.questions.values())
+  // Stabilize array references: only create new arrays when the underlying Map
+  // contents actually change. Without this, every SSE event creates new arrays →
+  // all downstream useMemo deps invalidate → the entire App tree re-renders,
+  // causing typing lag in DetailDrawer.
+  //
+  // Deps intentionally use module-level version counters instead of storeState.
+  // This works because emit() always creates a new state reference which triggers
+  // useSyncExternalStore to re-render, at which point the updated counter value
+  // is visible to useMemo's comparison. The callback closures capture the current
+  // storeState from the render, so the data is always fresh when the memo executes.
+  const agents = useMemo(
+    () => Array.from(storeState.agents.values()),
+    [agentsVersion] // eslint-disable-line
+  )
+  const permissions = useMemo(
+    () => Array.from(storeState.permissions.values()),
+    [permissionsVersion] // eslint-disable-line
+  )
+  const questions = useMemo(
+    () => Array.from(storeState.questions.values()),
+    [questionsVersion] // eslint-disable-line
+  )
 
   const launchAgent = useCallback(async (directory: string, prompt?: string, title?: string, model?: string, attachments?: MessageAttachment[]) => {
     if (!window.api) return
@@ -1831,20 +1887,20 @@ export function useAgentStore() {
 
   const getMessagesForSession = useCallback((sessionId: string): LiveMessage[] => {
     return storeState.messages.get(sessionId) ?? []
-  }, [storeState])
+  }, [messagesVersion]) // eslint-disable-line
 
   const getFileChangesForSession = useCallback((sessionId: string): FileChangeRecord[] => {
     return storeState.fileChanges.get(sessionId) ?? []
-  }, [storeState])
+  }, [fileChangesVersion]) // eslint-disable-line
 
   const getEventsForSession = useCallback((sessionId: string): EventLogEntry[] => {
     return storeState.eventLog.get(sessionId) ?? []
-  }, [storeState])
+  }, [eventLogVersion]) // eslint-disable-line
 
   const getToolCallsForSession = useCallback((sessionId: string): ToolCallInfo[] => {
     const messages = storeState.messages.get(sessionId) ?? []
     return extractToolCallsFromMessages(messages)
-  }, [storeState])
+  }, [messagesVersion]) // eslint-disable-line
 
   const setAgentModel = useCallback((agentId: string, modelPath: string) => {
     const agent = state.agents.get(agentId)
@@ -1871,7 +1927,7 @@ export function useAgentStore() {
     emit()
   }, [])
 
-  return {
+  return useMemo(() => ({
     agents,
     permissions,
     questions,
@@ -1896,5 +1952,14 @@ export function useAgentStore() {
     getFileChangesForSession,
     getEventsForSession,
     getToolCallsForSession
-  }
+  }), [
+    agents, permissions, questions, storeState.healthy,
+    launchAgent, sendMessage, listCommands, listAgentConfigs,
+    executeCommand, prepareFreshAgent, resetSession,
+    respondToPermission, replyToQuestion, rejectQuestion,
+    abortAgent, removeAgent, renameAgent, setAgentModel,
+    setStatusOverride, selectDirectory,
+    getMessagesForSession, getFileChangesForSession,
+    getEventsForSession, getToolCallsForSession
+  ])
 }


### PR DESCRIPTION
High-frequency SSE events (especially message.part.updated) caused the entire App → DetailDrawer tree to re-render dozens of times per second, blocking keystroke handling. This introduces per-collection version counters in the agent store so arrays only regenerate when their specific collection changes, wraps DetailDrawer in React.memo with stable callback props, and memoizes inline computations to prevent unnecessary work during typing.