### PR TITLE
Show bash command in transcript when verbose mode is enabled

### DIFF
--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -1123,6 +1123,15 @@ function MessageBubble({ message, verbose = false }: { message: Message; verbose
   )
 }
 
+function parseToolCommand(input: string | undefined): string | undefined {
+  if (!input) return undefined
+  try {
+    return JSON.parse(input).command as string | undefined
+  } catch {
+    return undefined
+  }
+}
+
 function ToolGroupBubble({ message, verbose = false }: { message: Message; verbose?: boolean }) {
   const [expanded, setExpanded] = useState(verbose)
   const toolCalls = message.toolCalls ?? []
@@ -1155,6 +1164,11 @@ function ToolGroupBubble({ message, verbose = false }: { message: Message; verbo
                   {tool.state}
                 </span>
               </div>
+              {verbose && parseToolCommand(tool.input) && (
+                <pre className="mt-1.5 whitespace-pre-wrap break-all font-mono text-[10px] text-kumo-link bg-kumo-overlay rounded-md px-2 py-1.5 overflow-x-auto">
+                  $ {parseToolCommand(tool.input)}
+                </pre>
+              )}
               {tool.output && (
                 <pre className="mt-2 whitespace-pre-wrap break-all font-mono text-[10px] text-kumo-subtle bg-kumo-overlay rounded-md px-2 py-1.5 overflow-x-auto">
                   {tool.output}


### PR DESCRIPTION
The transcript tab's ToolGroupBubble had access to tool.input but never rendered it. When verbose mode is on, bash tool calls now display the actual command string between the tool header and output. Extracted a parseToolCommand helper to cleanly handle JSON parsing of the tool input.