### PR TITLE
Improve fleet table icon layout and visibility

### DIFF
--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -175,6 +175,7 @@ export function FleetTable({
               </th>
             ))}
             <th className="w-24 px-3 py-2 bg-kumo-overlay border-b border-kumo-line" />
+            <th className="w-10 p-0 bg-kumo-overlay border-b border-kumo-line border-l" />
           </tr>
         </thead>
         <tbody>
@@ -540,7 +541,6 @@ function AgentRow({
             onApprove={onApprove}
             onReply={onReply}
             onStop={onStop}
-            onOpen={onOpen}
             onRemove={onRemove}
           />
           <button
@@ -552,6 +552,15 @@ function AgentRow({
           </button>
         </div>
       </td>
+      <td className="w-10 p-0 border-l border-kumo-line bg-kumo-fill/50">
+        <button
+          onClick={(event) => { event.stopPropagation(); onOpen?.() }}
+          className="w-full h-full flex items-center justify-center text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill transition-colors cursor-pointer"
+          title="Open"
+        >
+          <ArrowRight size={14} weight="bold" />
+        </button>
+      </td>
     </tr>
   )
 }
@@ -561,18 +570,18 @@ function RowActions({
   onApprove,
   onReply,
   onStop,
-  onOpen,
   onRemove
 }: {
   agent: AgentRuntime
   onApprove?: () => void
   onReply?: () => void
   onStop?: () => void
-  onOpen?: () => void
   onRemove?: () => void
 }) {
   const buttonBase = 'w-6 h-6 flex items-center justify-center bg-kumo-fill border border-kumo-line rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors cursor-pointer'
   const destructiveButton = 'w-6 h-6 flex items-center justify-center bg-kumo-danger/10 border border-kumo-danger/20 rounded text-kumo-danger hover:bg-kumo-danger/20 transition-colors cursor-pointer'
+  const isStoppable = agent.status === 'running' || agent.status === 'needs_input' || agent.status === 'needs_approval' || agent.status === 'stopping'
+  const isStopping = agent.status === 'stopping'
 
   return (
     <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -603,18 +612,11 @@ function RowActions({
           <Pause size={12} weight="bold" />
         </button>
       )}
-      <button
-        className={buttonBase}
-        title="Open"
-        onClick={(event) => { event.stopPropagation(); onOpen?.() }}
-      >
-        <ArrowRight size={12} weight="bold" />
-      </button>
-      {(agent.status === 'running' || agent.status === 'needs_input' || agent.status === 'needs_approval' || agent.status === 'stopping') && (
+      {isStoppable && (
         <button
-          className={`${buttonBase} ${agent.status === 'stopping' ? 'opacity-50 cursor-not-allowed' : ''}`}
-          title={agent.status === 'stopping' ? 'Stopping...' : 'Stop'}
-          disabled={agent.status === 'stopping'}
+          className={`${buttonBase} ${isStopping ? 'opacity-50 cursor-not-allowed' : ''}`}
+          title={isStopping ? 'Stopping...' : 'Stop'}
+          disabled={isStopping}
           onClick={(event) => { event.stopPropagation(); onStop?.() }}
         >
           <Square size={12} weight="fill" />

--- a/src/renderer/src/components/TopBar.tsx
+++ b/src/renderer/src/components/TopBar.tsx
@@ -19,12 +19,22 @@ export function TopBar({
 }: TopBarProps) {
   return (
     <div className="drag-region flex items-center justify-between h-12 pl-20 pr-4 bg-kumo-elevated border-b border-kumo-line shrink-0">
-      {/* Left: Logo — pl-20 clears macOS traffic light buttons */}
+      {/* Left: Logo + Settings */}
       <div className="no-drag flex items-center gap-3">
         <div className="flex items-center gap-2">
           <img src="/favicon.svg" alt="" className="w-5 h-5" />
           <span className="font-bold text-sm text-kumo-strong">OC Orchestrator</span>
         </div>
+        {onSettings && (
+          <button
+            type="button"
+            onClick={onSettings}
+            className="flex items-center justify-center w-7 h-7 rounded-md text-kumo-subtle hover:bg-kumo-fill hover:text-kumo-default transition-colors"
+            title="Settings"
+          >
+            <GearSix size={16} />
+          </button>
+        )}
       </div>
 
       {/* Center: Fleet Stats */}
@@ -47,16 +57,6 @@ export function TopBar({
           </kbd>
           <span>Command</span>
         </button>
-        {onSettings && (
-          <button
-            type="button"
-            onClick={onSettings}
-            className="flex items-center justify-center w-8 h-8 rounded-md border border-kumo-line text-kumo-subtle hover:bg-kumo-fill hover:text-kumo-default transition-colors"
-            title="Settings"
-          >
-            <GearSix size={16} />
-          </button>
-        )}
         <button
           type="button"
           onClick={onLaunch}


### PR DESCRIPTION
Move settings gear to TopBar left section next to logo. Pull open arrow out of hover-only RowActions into a dedicated always-visible column with gray background at the far right of each row. Reorder Pause and Stop buttons to be adjacent. Extract isStoppable/isStopping variables for readability.