### PR TITLE
Support /commands and @agent mentions in Launch New Agent prompt

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -392,6 +392,26 @@ export function registerIpcHandlers(): void {
     }
   })
 
+  ipcMain.handle('runtime:commands', async () => {
+    try {
+      const data = await agentController.listCommandsFromAnyRuntime()
+      return { ok: true, data }
+    } catch (error) {
+      console.error('[IPC] runtime:commands failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  ipcMain.handle('runtime:agent-configs', async () => {
+    try {
+      const data = await agentController.listAgentConfigsFromAnyRuntime()
+      return { ok: true, data }
+    } catch (error) {
+      console.error('[IPC] runtime:agent-configs failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
   ipcMain.handle('runtime:config', async () => {
     try {
       const data = await agentController.getConfigFromAnyRuntime()

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -534,6 +534,46 @@ class AgentController {
   }
 
   /**
+   * List commands from any available runtime.
+   * Useful for launch screens where no specific agent is selected.
+   */
+  async listCommandsFromAnyRuntime(): Promise<unknown> {
+    for (const handle of this.agents.values()) {
+      try {
+        const runtime = await this.ensureRuntimeForAgent(handle)
+        const result = await runtime.client.command.list({
+          directory: handle.directory
+        })
+        return result.data
+      } catch {
+        continue
+      }
+    }
+
+    return null
+  }
+
+  /**
+   * List agent configs from any available runtime.
+   * Useful for launch screens where no specific agent is selected.
+   */
+  async listAgentConfigsFromAnyRuntime(): Promise<unknown> {
+    for (const handle of this.agents.values()) {
+      try {
+        const runtime = await this.ensureRuntimeForAgent(handle)
+        const result = await runtime.client.app.agents({
+          directory: handle.directory
+        })
+        return result.data
+      } catch {
+        continue
+      }
+    }
+
+    return null
+  }
+
+  /**
    * Get MCP server status for an agent's runtime.
    */
   async getMcpStatus(agentId: string): Promise<unknown> {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -112,6 +112,12 @@ const api = {
   getSystemConfig: (): Promise<IpcResult> =>
     ipcRenderer.invoke('runtime:config'),
 
+  listAllCommands: (): Promise<IpcResult> =>
+    ipcRenderer.invoke('runtime:commands'),
+
+  listAllAgentConfigs: (): Promise<IpcResult> =>
+    ipcRenderer.invoke('runtime:agent-configs'),
+
   // ── Dialog ──
   selectDirectory: (): Promise<IpcResult<string>> =>
     ipcRenderer.invoke('dialog:select-directory'),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -69,6 +69,8 @@ export function App() {
   const [updateInfo, setUpdateInfo] = useState<{ currentVersion: string; latestVersion: string } | null>(null)
   const [appVersion, setAppVersion] = useState('')
   const [dismissedInterruptIds, setDismissedInterruptIds] = useState<Set<string> | null>(null)
+  const [launchCommands, setLaunchCommands] = useState<ChatCommand[]>([])
+  const [launchAgentConfigs, setLaunchAgentConfigs] = useState<Array<{ name: string; description?: string }>>([])
 
   const store = useAgentStore()
 
@@ -122,6 +124,42 @@ export function App() {
 
     return () => { cancelled = true }
   }, [selectedAgentId, listCommands, listAgentConfigs])
+
+  // ── Fetch commands & agent configs for the launch modal from any available runtime ──
+  useEffect(() => {
+    if (!showLaunchModal) {
+      setLaunchCommands([])
+      setLaunchAgentConfigs([])
+      return
+    }
+
+    let cancelled = false
+
+    const fetchLaunchData = async (): Promise<void> => {
+      // Only custom runtime commands are shown — built-in drawer commands
+      // (/new, /model, /compact, etc.) don't apply at launch time.
+      try {
+        const cmdResult = await window.api.listAllCommands()
+        if (cancelled) return
+        const cmds = Array.isArray(cmdResult.data) ? cmdResult.data as Array<{ name: string; description?: string; template?: string }> : []
+        setLaunchCommands(cmds.map((cmd) => ({
+          command: `/${cmd.name}`,
+          description: cmd.description || cmd.template || cmd.name
+        })))
+      } catch { /* no runtime available */ }
+
+      try {
+        const cfgResult = await window.api.listAllAgentConfigs()
+        if (cancelled) return
+        const configs = Array.isArray(cfgResult.data) ? cfgResult.data as Array<{ name: string; description?: string }> : []
+        setLaunchAgentConfigs(configs)
+      } catch { /* no runtime available */ }
+    }
+
+    void fetchLaunchData()
+
+    return () => { cancelled = true }
+  }, [showLaunchModal])
 
   // ── Live timestamp refresh (every 30s) ──
   useEffect(() => {
@@ -798,22 +836,65 @@ export function App() {
       launchDirectory = worktreeResult.data.worktreePath
     }
 
-    const result = await store.launchAgent(launchDirectory, prompt || undefined, title, model, attachments)
+    // Detect leading @agent mentions and /commands in the prompt.
+    // Only leading tokens are treated as special syntax to avoid
+    // false positives from @mentions mid-sentence.
+    const trimmedPrompt = prompt?.trim() ?? ''
+    const isSlashCommand = trimmedPrompt.startsWith('/')
+    const leadingAgentMatch = trimmedPrompt.match(/^@(\w+)(?:\s|$)/)
+    const needsPostLaunchHandling = isSlashCommand || !!leadingAgentMatch
+
+    // If the prompt needs special handling, launch without it — the
+    // runtime must exist before we can route commands or agent mentions.
+    const launchPrompt = needsPostLaunchHandling ? undefined : (prompt || undefined)
+    const result = await store.launchAgent(launchDirectory, launchPrompt, title, model, attachments)
 
     if (!result?.ok) {
       throw new Error('Failed to launch agent')
     }
 
-    // Auto-open the detail drawer for the newly launched agent
-    // (especially useful when no prompt is given so the user can interact immediately)
-    if (result.data) {
-      const data = result.data as { id: string }
-      setSelectedAgentId(data.id)
+    if (!result.data) return
 
-      // Optimistically show the selected model in the table immediately
-      if (model && model !== 'auto') {
-        store.setAgentModel(data.id, model)
+    const agentId = (result.data as { id: string }).id
+    setSelectedAgentId(agentId)
+
+    if (model && model !== 'auto') {
+      store.setAgentModel(agentId, model)
+    }
+
+    if (!needsPostLaunchHandling || !trimmedPrompt) return
+
+    // Handle @agent mentions and /commands that were deferred from launch.
+    // Only custom runtime commands apply — built-in drawer commands
+    // (/new, /compact, /share, etc.) don't apply at launch time.
+    // Wrapped in try/catch so a failure here doesn't make the already-
+    // successful launch appear failed (which would keep the modal open).
+    try {
+      if (isSlashCommand) {
+        const spaceIndex = trimmedPrompt.indexOf(' ')
+        const commandName = spaceIndex === -1 ? trimmedPrompt.slice(1) : trimmedPrompt.slice(1, spaceIndex)
+        const commandArgs = spaceIndex === -1 ? '' : trimmedPrompt.slice(spaceIndex + 1).trim()
+
+        const runtimeCommands = await store.listCommands(agentId)
+        const isCustomCommand = runtimeCommands?.some((cmd: { name: string }) => cmd.name === commandName)
+        if (isCustomCommand) {
+          await store.executeCommand(agentId, commandName, commandArgs)
+        } else {
+          await store.sendMessage(agentId, trimmedPrompt, undefined, attachments)
+        }
+      } else if (leadingAgentMatch) {
+        const mentionedAgent = leadingAgentMatch[1]
+        const configs = await store.listAgentConfigs(agentId)
+        const isKnownAgent = configs?.some((cfg: { name: string }) => cfg.name === mentionedAgent)
+        if (isKnownAgent) {
+          const cleanText = trimmedPrompt.slice(leadingAgentMatch[0].length).trim()
+          await store.sendMessage(agentId, cleanText || trimmedPrompt, mentionedAgent, attachments)
+        } else {
+          await store.sendMessage(agentId, trimmedPrompt, undefined, attachments)
+        }
       }
+    } catch (error) {
+      console.error('[App] Post-launch command/agent handling failed:', error)
     }
   }, [store])
 
@@ -1089,6 +1170,8 @@ export function App() {
             directory: a.directory,
             isWorktree: a.isWorktree
           }))}
+          commands={launchCommands}
+          agentConfigs={launchAgentConfigs}
         />
       )}
 

--- a/src/renderer/src/components/LaunchModal.tsx
+++ b/src/renderer/src/components/LaunchModal.tsx
@@ -5,6 +5,7 @@ import { useModelOptions } from '../hooks/useModelOptions'
 import { useImageAttachments } from '../hooks/useImageAttachments'
 import { loadSettings } from '../data/settings'
 import type { Project, MessageAttachment } from '../types/api'
+import type { ChatCommand, AgentConfigItem } from './DetailDrawer'
 
 type WorktreeStrategy = 'new-worktree' | 'current-directory'
 
@@ -48,9 +49,11 @@ interface LaunchModalProps {
   onSelectDirectory: () => Promise<string | null>
   onValidateDirectory?: (dir: string) => Promise<boolean>
   knownDirectories?: KnownDirectory[]
+  commands?: ChatCommand[]
+  agentConfigs?: AgentConfigItem[]
 }
 
-export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDirectory, knownDirectories }: LaunchModalProps) {
+export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDirectory, knownDirectories, commands = [], agentConfigs = [] }: LaunchModalProps) {
   const [directory, setDirectory] = useState('')
   const [prompt, setPrompt] = useState('')
   const [title, setTitle] = useState('')
@@ -69,6 +72,121 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
     handlePaste, handleDragOver, handleDragEnter, handleDragLeave, handleDrop, handleFileInputChange
   } = useImageAttachments()
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const promptRef = useRef<HTMLTextAreaElement>(null)
+  const [cursorPos, setCursorPos] = useState(0)
+  const [agentPickerDismissed, setAgentPickerDismissed] = useState(false)
+  const [agentPickerIndex, setAgentPickerIndex] = useState(0)
+  const [commandPickerIndex, setCommandPickerIndex] = useState(0)
+
+  const trimmedPrompt = prompt.trim().toLowerCase()
+
+  const matchingCommands = useMemo(
+    () => prompt.startsWith('/')
+      ? commands.filter(({ command }) => command.startsWith(trimmedPrompt))
+      : [],
+    [prompt, trimmedPrompt, commands]
+  )
+
+  const showCommandAutocomplete = useMemo(() => {
+    if (matchingCommands.length === 0 || trimmedPrompt.length === 0) return false
+    return !commands.some(({ command }) => command === trimmedPrompt)
+  }, [matchingCommands, trimmedPrompt, commands])
+
+  const agentMentionResult = useMemo(() => {
+    if (agentConfigs.length === 0) return null
+    const textBeforeCursor = prompt.slice(0, cursorPos)
+    const match = textBeforeCursor.match(/@(\w*)$/)
+    if (!match) return null
+    const start = textBeforeCursor.length - match[0].length
+    return { query: match[1].toLowerCase(), start, end: cursorPos }
+  }, [agentConfigs.length, prompt, cursorPos])
+
+  const agentMention = !agentPickerDismissed ? agentMentionResult : null
+  const matchingAgents = useMemo(
+    () => agentMention
+      ? agentConfigs.filter((cfg) => cfg.name.toLowerCase().startsWith(agentMention.query))
+      : [],
+    [agentMention, agentConfigs]
+  )
+  const showAgentPicker = matchingAgents.length > 0 && !showCommandAutocomplete
+
+  const handlePromptChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setPrompt(event.target.value)
+    setCursorPos(event.target.selectionStart)
+    setAgentPickerDismissed(false)
+    setAgentPickerIndex(0)
+    setCommandPickerIndex(0)
+  }
+
+  const insertAgentMention = (agentName: string) => {
+    if (!agentMention) return
+    const before = prompt.slice(0, agentMention.start)
+    const after = prompt.slice(agentMention.end)
+    const newText = `${before}@${agentName} ${after}`
+    const newCursorPos = agentMention.start + agentName.length + 2 // @ + name + space
+    setPrompt(newText)
+    setCursorPos(newCursorPos)
+    setAgentPickerDismissed(false)
+    setAgentPickerIndex(0)
+    requestAnimationFrame(() => {
+      const textarea = promptRef.current
+      if (textarea) {
+        textarea.selectionStart = newCursorPos
+        textarea.selectionEnd = newCursorPos
+        textarea.focus()
+      }
+    })
+  }
+
+  const handlePromptKeyDown = (event: React.KeyboardEvent) => {
+    if (showAgentPicker) {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setAgentPickerDismissed(true)
+        return
+      }
+      if (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey)) {
+        event.preventDefault()
+        const selected = matchingAgents[agentPickerIndex]
+        if (selected) insertAgentMention(selected.name)
+        return
+      }
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        setAgentPickerIndex((prev) => (prev + 1) % matchingAgents.length)
+        return
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        setAgentPickerIndex((prev) => (prev - 1 + matchingAgents.length) % matchingAgents.length)
+        return
+      }
+    }
+
+    if (showCommandAutocomplete) {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setPrompt('')
+        return
+      }
+      if (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey)) {
+        event.preventDefault()
+        const selected = matchingCommands[commandPickerIndex]
+        if (selected) setPrompt(`${selected.command} `)
+        return
+      }
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        setCommandPickerIndex((prev) => (prev + 1) % matchingCommands.length)
+        return
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        setCommandPickerIndex((prev) => (prev - 1 + matchingCommands.length) % matchingCommands.length)
+        return
+      }
+    }
+  }
 
   const estimatedWorktreePath = useMemo(() => {
     if (worktreeStrategy !== 'new-worktree') return ''
@@ -426,7 +544,7 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
               Initial Prompt <span className="text-kumo-subtle/60">(optional — you can prompt from the session)</span>
             </label>
             <div
-              className={`flex flex-col gap-0 rounded-md border transition-colors ${
+              className={`relative flex flex-col gap-0 rounded-md border transition-colors ${
                 isDragOver ? 'border-kumo-brand bg-kumo-brand/[0.04]' : 'border-kumo-line focus-within:border-kumo-ring'
               }`}
               onDragOver={handleDragOver}
@@ -459,11 +577,71 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
                   ))}
                 </div>
               )}
+
+              {/* Command autocomplete dropdown */}
+              {showCommandAutocomplete && (
+                <div className="absolute bottom-full left-0 right-0 z-20 mb-2 rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl">
+                  {matchingCommands.map((item, index) => (
+                    <button
+                      key={item.command}
+                      type="button"
+                      onMouseDown={(event) => {
+                        event.preventDefault()
+                        setPrompt(`${item.command} `)
+                      }}
+                      className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
+                        index === commandPickerIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
+                      }`}
+                    >
+                      <span className="font-mono text-[11px] text-kumo-default">{item.command}</span>
+                      <span className="text-[11px] text-kumo-subtle">{item.description}</span>
+                    </button>
+                  ))}
+                  <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
+                    Tab/Enter to select · Arrow keys to navigate · Esc to dismiss
+                  </div>
+                </div>
+              )}
+
+              {/* Agent picker dropdown */}
+              {showAgentPicker && (
+                <div className="absolute bottom-full left-0 right-0 z-20 mb-2 rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl">
+                  <div className="px-2.5 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wide">
+                    Agents
+                  </div>
+                  {matchingAgents.map((cfg, index) => (
+                    <button
+                      key={cfg.name}
+                      type="button"
+                      onMouseDown={(event) => {
+                        event.preventDefault()
+                        insertAgentMention(cfg.name)
+                      }}
+                      className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
+                        index === agentPickerIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
+                      }`}
+                    >
+                      <span className="font-mono text-[11px] text-kumo-brand">@{cfg.name}</span>
+                      {cfg.description && (
+                        <span className="text-[11px] text-kumo-subtle truncate">{cfg.description}</span>
+                      )}
+                    </button>
+                  ))}
+                  <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
+                    Tab/Enter to select · Arrow keys to navigate · Esc to dismiss
+                  </div>
+                </div>
+              )}
+
               <textarea
+                ref={promptRef}
                 value={prompt}
-                onChange={(event) => setPrompt(event.target.value)}
+                onChange={handlePromptChange}
+                onKeyDown={handlePromptKeyDown}
+                onKeyUp={(e) => setCursorPos(e.currentTarget.selectionStart)}
+                onClick={(e) => setCursorPos(e.currentTarget.selectionStart)}
                 onPaste={handlePaste}
-                placeholder={isDragOver ? 'Drop image here...' : 'Leave empty to start an interactive session...'}
+                placeholder={isDragOver ? 'Drop image here...' : 'Leave empty to start an interactive session... Type / for commands, @ for agents.'}
                 rows={3}
                 className="px-3 py-2 bg-kumo-control rounded-md text-sm text-kumo-default outline-none placeholder:text-kumo-subtle resize-none border-0 focus:ring-0"
               />

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -44,6 +44,8 @@ export interface OrchestratorApi {
   stopRuntime: (runtimeId: string) => Promise<IpcResult>
   listAllProviders: () => Promise<IpcResult>
   getSystemConfig: () => Promise<IpcResult>
+  listAllCommands: () => Promise<IpcResult>
+  listAllAgentConfigs: () => Promise<IpcResult>
   selectDirectory: () => Promise<IpcResult<string>>
 
   // ── Workspace Operations ──


### PR DESCRIPTION
Add slash command and @agent autocomplete to the launch modal, matching the existing transcript input behavior. The agent is launched first to create the runtime, then deferred /commands and @agent mentions are routed through the runtime API.

Only custom runtime commands appear in autocomplete — built-in drawer commands are excluded. Agent mentions are only recognized as leading tokens to avoid false positives from @-words mid-sentence.