### PR TITLE
Add negative (exclude) filter mode to fleet filter bar

### DIFF
--- a/src/__tests__/filter-sort.test.ts
+++ b/src/__tests__/filter-sort.test.ts
@@ -17,11 +17,15 @@ type AgentLabel = 'in_review' | 'blocked' | 'done' | 'draft'
 
 type StatusFilter = 'blocked' | 'running' | 'idle' | 'errored' | 'completed'
 type LabelFilter = AgentLabel
+type FilterMode = 'include' | 'exclude'
 
 interface FilterState {
   statuses: Set<StatusFilter>
   labels: Set<LabelFilter>
   projects: Set<string>
+  excludeStatuses: Set<StatusFilter>
+  excludeLabels: Set<LabelFilter>
+  excludeProjects: Set<string>
 }
 
 interface AgentRow {
@@ -46,33 +50,68 @@ const STATUS_MAP: Record<StatusFilter, AgentStatus[]> = {
   completed: ['completed']
 }
 
+function isFilterEmpty(filter: FilterState): boolean {
+  return (
+    filter.statuses.size === 0 &&
+    filter.labels.size === 0 &&
+    filter.projects.size === 0 &&
+    filter.excludeStatuses.size === 0 &&
+    filter.excludeLabels.size === 0 &&
+    filter.excludeProjects.size === 0
+  )
+}
+
+function expandStatuses(filters: Set<StatusFilter>): Set<AgentStatus> {
+  const result = new Set<AgentStatus>()
+  for (const sf of filters) {
+    for (const s of STATUS_MAP[sf]) result.add(s)
+  }
+  return result
+}
+
 function matchesFilter(
   agent: { status: AgentStatus; label: AgentLabel | null; projectName: string },
   filter: FilterState
 ): boolean {
-  const hasStatuses = filter.statuses.size > 0
-  const hasLabels = filter.labels.size > 0
-  const hasProjects = filter.projects.size > 0
+  if (isFilterEmpty(filter)) return true
 
-  if (!hasStatuses && !hasLabels && !hasProjects) return true
+  // Exclude filters: reject if agent matches any excluded value
+  if (filter.excludeStatuses.size > 0 && expandStatuses(filter.excludeStatuses).has(agent.status)) return false
+  if (filter.excludeLabels.size > 0 && agent.label && filter.excludeLabels.has(agent.label)) return false
+  if (filter.excludeProjects.size > 0 && filter.excludeProjects.has(agent.projectName)) return false
 
-  if (hasStatuses) {
-    const allowedStatuses = new Set<AgentStatus>()
-    for (const sf of filter.statuses) {
-      for (const s of STATUS_MAP[sf]) allowedStatuses.add(s)
-    }
-    if (!allowedStatuses.has(agent.status)) return false
-  }
-
-  if (hasLabels) {
-    if (!agent.label || !filter.labels.has(agent.label)) return false
-  }
-
-  if (hasProjects) {
-    if (!filter.projects.has(agent.projectName)) return false
-  }
+  // Include filters: agent must match at least one value in each active include dimension
+  if (filter.statuses.size > 0 && !expandStatuses(filter.statuses).has(agent.status)) return false
+  if (filter.labels.size > 0 && (!agent.label || !filter.labels.has(agent.label))) return false
+  if (filter.projects.size > 0 && !filter.projects.has(agent.projectName)) return false
 
   return true
+}
+
+function getFilterMode(
+  includeSet: Set<unknown>,
+  excludeSet: Set<unknown>,
+  value: unknown
+): FilterMode | null {
+  if (includeSet.has(value)) return 'include'
+  if (excludeSet.has(value)) return 'exclude'
+  return null
+}
+
+function cycleFilter<T>(includeSet: Set<T>, excludeSet: Set<T>, value: T): { include: Set<T>; exclude: Set<T> } {
+  const nextInclude = new Set(includeSet)
+  const nextExclude = new Set(excludeSet)
+
+  if (nextInclude.has(value)) {
+    nextInclude.delete(value)
+    nextExclude.add(value)
+  } else if (nextExclude.has(value)) {
+    nextExclude.delete(value)
+  } else {
+    nextInclude.add(value)
+  }
+
+  return { include: nextInclude, exclude: nextExclude }
 }
 
 // ── Sorting and search logic ──
@@ -150,22 +189,37 @@ function createAgent(overrides: Partial<AgentRow> = {}): AgentRow {
   }
 }
 
-const EMPTY: FilterState = { statuses: new Set(), labels: new Set(), projects: new Set() }
+const EMPTY: FilterState = {
+  statuses: new Set(), labels: new Set(), projects: new Set(),
+  excludeStatuses: new Set(), excludeLabels: new Set(), excludeProjects: new Set()
+}
 
 function statusFilter(...statuses: StatusFilter[]): FilterState {
-  return { statuses: new Set(statuses), labels: new Set(), projects: new Set() }
+  return { ...EMPTY, statuses: new Set(statuses) }
 }
 
 function labelFilter(...labels: LabelFilter[]): FilterState {
-  return { statuses: new Set(), labels: new Set(labels), projects: new Set() }
+  return { ...EMPTY, labels: new Set(labels) }
 }
 
 function projectFilter(...projects: string[]): FilterState {
-  return { statuses: new Set(), labels: new Set(), projects: new Set(projects) }
+  return { ...EMPTY, projects: new Set(projects) }
 }
 
 function combinedFilter(statuses: StatusFilter[], projects: string[]): FilterState {
-  return { statuses: new Set(statuses), labels: new Set(), projects: new Set(projects) }
+  return { ...EMPTY, statuses: new Set(statuses), projects: new Set(projects) }
+}
+
+function excludeStatusFilter(...statuses: StatusFilter[]): FilterState {
+  return { ...EMPTY, excludeStatuses: new Set(statuses) }
+}
+
+function excludeLabelFilter(...labels: LabelFilter[]): FilterState {
+  return { ...EMPTY, excludeLabels: new Set(labels) }
+}
+
+function excludeProjectFilter(...projects: string[]): FilterState {
+  return { ...EMPTY, excludeProjects: new Set(projects) }
 }
 
 // ── Tests ──
@@ -295,9 +349,9 @@ describe('label filters', () => {
 
   it('combines status AND label filters', () => {
     const filter: FilterState = {
+      ...EMPTY,
       statuses: new Set<StatusFilter>(['running']),
-      labels: new Set<LabelFilter>(['in_review']),
-      projects: new Set()
+      labels: new Set<LabelFilter>(['in_review'])
     }
     expect(matchesFilter({ status: 'running', label: 'in_review', projectName: 'proj' }, filter)).toBe(true)
     expect(matchesFilter({ status: 'idle', label: 'in_review', projectName: 'proj' }, filter)).toBe(false)
@@ -308,6 +362,192 @@ describe('label filters', () => {
     const filter = statusFilter('running')
     expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
     expect(matchesFilter({ status: 'running', label: 'done', projectName: 'proj' }, filter)).toBe(true)
+  })
+})
+
+describe('negative (exclude) filters', () => {
+  it('excludes agents matching an excluded status', () => {
+    const filter = excludeStatusFilter('completed')
+    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', label: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', label: null, projectName: 'proj' }, filter)).toBe(false)
+  })
+
+  it('excludes agents matching excluded "blocked" status (needs_input + needs_approval)', () => {
+    const filter = excludeStatusFilter('blocked')
+    expect(matchesFilter({ status: 'needs_input', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'needs_approval', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', label: null, projectName: 'proj' }, filter)).toBe(true)
+  })
+
+  it('excludes agents matching multiple excluded statuses', () => {
+    const filter: FilterState = { ...EMPTY, excludeStatuses: new Set<StatusFilter>(['completed', 'errored']) }
+    expect(matchesFilter({ status: 'completed', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'errored', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
+  })
+
+  it('excludes agents matching an excluded label', () => {
+    const filter = excludeLabelFilter('done')
+    expect(matchesFilter({ status: 'running', label: 'done', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', label: 'in_review', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
+  })
+
+  it('excludes agents matching an excluded project', () => {
+    const filter = excludeProjectFilter('my-app')
+    expect(matchesFilter({ status: 'running', label: null, projectName: 'my-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', label: null, projectName: 'other-app' }, filter)).toBe(true)
+  })
+
+  it('combines include status + exclude status (e.g. running but not errored)', () => {
+    const filter: FilterState = {
+      ...EMPTY,
+      statuses: new Set<StatusFilter>(['running', 'errored']),
+      excludeStatuses: new Set<StatusFilter>(['errored'])
+    }
+    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'errored', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', label: null, projectName: 'proj' }, filter)).toBe(false)
+  })
+
+  it('exclude takes precedence over include for same dimension', () => {
+    // Include running + exclude running = nothing matches for running
+    const filter: FilterState = {
+      ...EMPTY,
+      statuses: new Set<StatusFilter>(['running']),
+      excludeStatuses: new Set<StatusFilter>(['running'])
+    }
+    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(false)
+  })
+
+  it('combines exclude status with include project', () => {
+    const filter: FilterState = {
+      ...EMPTY,
+      excludeStatuses: new Set<StatusFilter>(['completed']),
+      projects: new Set(['my-app'])
+    }
+    expect(matchesFilter({ status: 'running', label: null, projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', label: null, projectName: 'my-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', label: null, projectName: 'other-app' }, filter)).toBe(false)
+  })
+
+  it('combines include status with exclude project', () => {
+    const filter: FilterState = {
+      ...EMPTY,
+      statuses: new Set<StatusFilter>(['running']),
+      excludeProjects: new Set(['my-app'])
+    }
+    expect(matchesFilter({ status: 'running', label: null, projectName: 'other-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', label: null, projectName: 'my-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', label: null, projectName: 'other-app' }, filter)).toBe(false)
+  })
+
+  it('combines exclude label with include status', () => {
+    const filter: FilterState = {
+      ...EMPTY,
+      statuses: new Set<StatusFilter>(['running']),
+      excludeLabels: new Set<LabelFilter>(['done'])
+    }
+    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', label: 'in_review', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', label: 'done', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', label: null, projectName: 'proj' }, filter)).toBe(false)
+  })
+
+  it('excludes multiple projects', () => {
+    const filter = excludeProjectFilter('app-a', 'app-b')
+    expect(matchesFilter({ status: 'running', label: null, projectName: 'app-a' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', label: null, projectName: 'app-b' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', label: null, projectName: 'app-c' }, filter)).toBe(true)
+  })
+
+  it('exclude-only filter still passes agents not matching the exclusion', () => {
+    const filter = excludeStatusFilter('idle')
+    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', label: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'errored', label: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', label: null, projectName: 'proj' }, filter)).toBe(false)
+  })
+})
+
+describe('cycleFilter', () => {
+  it('adds value to include set when not present in either set', () => {
+    const include = new Set<string>()
+    const exclude = new Set<string>()
+    const result = cycleFilter(include, exclude, 'running')
+    expect(result.include.has('running')).toBe(true)
+    expect(result.exclude.has('running')).toBe(false)
+  })
+
+  it('moves value from include to exclude on second cycle', () => {
+    const include = new Set(['running'])
+    const exclude = new Set<string>()
+    const result = cycleFilter(include, exclude, 'running')
+    expect(result.include.has('running')).toBe(false)
+    expect(result.exclude.has('running')).toBe(true)
+  })
+
+  it('removes value from exclude on third cycle', () => {
+    const include = new Set<string>()
+    const exclude = new Set(['running'])
+    const result = cycleFilter(include, exclude, 'running')
+    expect(result.include.has('running')).toBe(false)
+    expect(result.exclude.has('running')).toBe(false)
+  })
+
+  it('full cycle: off -> include -> exclude -> off', () => {
+    // off -> include
+    let result = cycleFilter(new Set<string>(), new Set<string>(), 'idle')
+    expect(result.include.has('idle')).toBe(true)
+    expect(result.exclude.has('idle')).toBe(false)
+
+    // include -> exclude
+    result = cycleFilter(result.include, result.exclude, 'idle')
+    expect(result.include.has('idle')).toBe(false)
+    expect(result.exclude.has('idle')).toBe(true)
+
+    // exclude -> off
+    result = cycleFilter(result.include, result.exclude, 'idle')
+    expect(result.include.has('idle')).toBe(false)
+    expect(result.exclude.has('idle')).toBe(false)
+  })
+
+  it('does not mutate original sets', () => {
+    const include = new Set(['a'])
+    const exclude = new Set(['b'])
+    const result = cycleFilter(include, exclude, 'a')
+    expect(include.has('a')).toBe(true)
+    expect(result.include.has('a')).toBe(false)
+    expect(result.exclude.has('a')).toBe(true)
+  })
+
+  it('preserves other values when cycling one value', () => {
+    const include = new Set(['a', 'b'])
+    const exclude = new Set<string>()
+    const result = cycleFilter(include, exclude, 'a')
+    expect(result.include.has('b')).toBe(true)
+    expect(result.include.has('a')).toBe(false)
+    expect(result.exclude.has('a')).toBe(true)
+  })
+})
+
+describe('getFilterMode', () => {
+  it('returns "include" when value is in include set', () => {
+    expect(getFilterMode(new Set(['a']), new Set(), 'a')).toBe('include')
+  })
+
+  it('returns "exclude" when value is in exclude set', () => {
+    expect(getFilterMode(new Set(), new Set(['a']), 'a')).toBe('exclude')
+  })
+
+  it('returns null when value is in neither set', () => {
+    expect(getFilterMode(new Set(), new Set(), 'a')).toBeNull()
+  })
+
+  it('returns "include" when value is in both (include takes precedence)', () => {
+    expect(getFilterMode(new Set(['a']), new Set(['a']), 'a')).toBe('include')
   })
 })
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import { TopBar } from './components/TopBar'
 import { InterruptBanner } from './components/InterruptBanner'
-import { FilterBar, matchesFilter, EMPTY_FILTER, type FilterState, type StatusFilter } from './components/FilterBar'
+import { FilterBar, matchesFilter, EMPTY_FILTER, cycleFilter, type FilterState, type StatusFilter } from './components/FilterBar'
 import { FleetTable } from './components/FleetTable'
 import { StatusBar } from './components/StatusBar'
 import { DetailDrawer, type ChatCommand } from './components/DetailDrawer'
@@ -20,13 +20,6 @@ import { loadSettings } from './data/settings'
 
 type SortColumn = 'agent' | 'status' | 'task' | 'branch' | 'model'
 type SortDirection = 'asc' | 'desc'
-
-function toggleInSet<T>(set: Set<T>, value: T): Set<T> {
-  const next = new Set(set)
-  if (next.has(value)) next.delete(value)
-  else next.add(value)
-  return next
-}
 
 const NEW_AGENT_COMMAND = '/new'
 const AGENT_MENTION_REGEX = /@(\w+)/
@@ -999,21 +992,30 @@ export function App() {
       {showInterruptBanner && (
         <InterruptBanner
           interrupts={displayInterrupts}
-          onReviewAll={() => setFilter({ statuses: new Set<StatusFilter>(['blocked']), labels: new Set(), projects: new Set() })}
+          onReviewAll={() => setFilter({ ...EMPTY_FILTER, statuses: new Set<StatusFilter>(['blocked']) })}
           onDismiss={() => setDismissedInterruptIds(new Set(displayInterrupts.map((i) => i.id)))}
         />
       )}
 
       <FilterBar
         filter={filter}
-        onToggleStatus={(status) => {
-          setFilter((prev) => ({ ...prev, statuses: toggleInSet(prev.statuses, status) }))
+        onCycleStatus={(status) => {
+          setFilter((prev) => {
+            const { include, exclude } = cycleFilter(prev.statuses, prev.excludeStatuses, status)
+            return { ...prev, statuses: include, excludeStatuses: exclude }
+          })
         }}
-        onToggleLabel={(label) => {
-          setFilter((prev) => ({ ...prev, labels: toggleInSet(prev.labels, label) }))
+        onCycleLabel={(label) => {
+          setFilter((prev) => {
+            const { include, exclude } = cycleFilter(prev.labels, prev.excludeLabels, label)
+            return { ...prev, labels: include, excludeLabels: exclude }
+          })
         }}
-        onToggleProject={(project) => {
-          setFilter((prev) => ({ ...prev, projects: toggleInSet(prev.projects, project) }))
+        onCycleProject={(project) => {
+          setFilter((prev) => {
+            const { include, exclude } = cycleFilter(prev.projects, prev.excludeProjects, project)
+            return { ...prev, projects: include, excludeProjects: exclude }
+          })
         }}
         onClearFilters={() => setFilter(EMPTY_FILTER)}
         searchQuery={searchQuery}

--- a/src/renderer/src/components/CommandPalette.tsx
+++ b/src/renderer/src/components/CommandPalette.tsx
@@ -171,7 +171,7 @@ export function CommandPalette({
         category: 'navigation',
         action: () => {
           onClose()
-          onFilterChange({ statuses: new Set<StatusFilter>(['blocked']), labels: new Set(), projects: new Set() })
+          onFilterChange({ ...EMPTY_FILTER, statuses: new Set<StatusFilter>(['blocked']) })
         }
       },
       {
@@ -182,7 +182,7 @@ export function CommandPalette({
         category: 'navigation',
         action: () => {
           onClose()
-          onFilterChange({ statuses: new Set<StatusFilter>(['running']), labels: new Set(), projects: new Set() })
+          onFilterChange({ ...EMPTY_FILTER, statuses: new Set<StatusFilter>(['running']) })
         }
       }
     ]

--- a/src/renderer/src/components/FilterBar.tsx
+++ b/src/renderer/src/components/FilterBar.tsx
@@ -4,27 +4,68 @@ import type { AgentStatus, AgentLabel } from '../types'
 export type StatusFilter = 'blocked' | 'running' | 'idle' | 'errored' | 'completed'
 export type LabelFilter = AgentLabel
 
+export type FilterMode = 'include' | 'exclude'
+
 export interface FilterState {
   statuses: Set<StatusFilter>
   labels: Set<LabelFilter>
   projects: Set<string>
+  excludeStatuses: Set<StatusFilter>
+  excludeLabels: Set<LabelFilter>
+  excludeProjects: Set<string>
 }
 
 export const EMPTY_FILTER: FilterState = {
   statuses: new Set(),
   labels: new Set(),
-  projects: new Set()
+  projects: new Set(),
+  excludeStatuses: new Set(),
+  excludeLabels: new Set(),
+  excludeProjects: new Set()
 }
 
 export function isFilterEmpty(filter: FilterState): boolean {
-  return filter.statuses.size === 0 && filter.labels.size === 0 && filter.projects.size === 0
+  return (
+    filter.statuses.size === 0 &&
+    filter.labels.size === 0 &&
+    filter.projects.size === 0 &&
+    filter.excludeStatuses.size === 0 &&
+    filter.excludeLabels.size === 0 &&
+    filter.excludeProjects.size === 0
+  )
+}
+
+export function getFilterMode(
+  includeSet: Set<unknown>,
+  excludeSet: Set<unknown>,
+  value: unknown
+): FilterMode | null {
+  if (includeSet.has(value)) return 'include'
+  if (excludeSet.has(value)) return 'exclude'
+  return null
+}
+
+export function cycleFilter<T>(includeSet: Set<T>, excludeSet: Set<T>, value: T): { include: Set<T>; exclude: Set<T> } {
+  const nextInclude = new Set(includeSet)
+  const nextExclude = new Set(excludeSet)
+
+  if (nextInclude.has(value)) {
+    nextInclude.delete(value)
+    nextExclude.add(value)
+  } else if (nextExclude.has(value)) {
+    nextExclude.delete(value)
+  } else {
+    nextInclude.add(value)
+  }
+
+  return { include: nextInclude, exclude: nextExclude }
 }
 
 interface FilterBarProps {
   filter: FilterState
-  onToggleStatus: (status: StatusFilter) => void
-  onToggleLabel: (label: LabelFilter) => void
-  onToggleProject: (project: string) => void
+  onCycleStatus: (status: StatusFilter) => void
+  onCycleLabel: (label: LabelFilter) => void
+  onCycleProject: (project: string) => void
   onClearFilters: () => void
   searchQuery: string
   onSearchChange: (query: string) => void
@@ -47,9 +88,9 @@ interface FilterBarProps {
 
 export function FilterBar({
   filter,
-  onToggleStatus,
-  onToggleLabel,
-  onToggleProject,
+  onCycleStatus,
+  onCycleLabel,
+  onCycleProject,
   onClearFilters,
   searchQuery,
   onSearchChange,
@@ -77,28 +118,28 @@ export function FilterBar({
       <div className="w-px h-5 bg-kumo-line" />
 
       {/* Status filters */}
-      <FilterPill label={`All (${counts.all})`} active={noFilters} onClick={onClearFilters} />
-      <FilterPill label={`Blocked (${counts.blocked})`} active={filter.statuses.has('blocked')} onClick={() => onToggleStatus('blocked')} />
-      <FilterPill label={`Running (${counts.running})`} active={filter.statuses.has('running')} onClick={() => onToggleStatus('running')} />
-      <FilterPill label={`Idle (${counts.idle})`} active={filter.statuses.has('idle')} onClick={() => onToggleStatus('idle')} />
-      <FilterPill label={`Errored (${counts.errored})`} active={filter.statuses.has('errored')} onClick={() => onToggleStatus('errored')} />
-      <FilterPill label={`Completed (${counts.completed})`} active={filter.statuses.has('completed')} onClick={() => onToggleStatus('completed')} />
+      <FilterPill label={`All (${counts.all})`} mode={noFilters ? 'include' : null} onClick={onClearFilters} />
+      <FilterPill label={`Blocked (${counts.blocked})`} mode={getFilterMode(filter.statuses, filter.excludeStatuses, 'blocked')} onClick={() => onCycleStatus('blocked')} />
+      <FilterPill label={`Running (${counts.running})`} mode={getFilterMode(filter.statuses, filter.excludeStatuses, 'running')} onClick={() => onCycleStatus('running')} />
+      <FilterPill label={`Idle (${counts.idle})`} mode={getFilterMode(filter.statuses, filter.excludeStatuses, 'idle')} onClick={() => onCycleStatus('idle')} />
+      <FilterPill label={`Errored (${counts.errored})`} mode={getFilterMode(filter.statuses, filter.excludeStatuses, 'errored')} onClick={() => onCycleStatus('errored')} />
+      <FilterPill label={`Completed (${counts.completed})`} mode={getFilterMode(filter.statuses, filter.excludeStatuses, 'completed')} onClick={() => onCycleStatus('completed')} />
 
       {/* Label filters */}
       {Object.values(labelCounts).some((count) => count > 0) && (
         <>
           <div className="w-px h-5 bg-kumo-line" />
           {labelCounts.draft > 0 && (
-            <FilterPill label={`Draft (${labelCounts.draft})`} active={filter.labels.has('draft')} onClick={() => onToggleLabel('draft')} variant="label" />
+            <FilterPill label={`Draft (${labelCounts.draft})`} mode={getFilterMode(filter.labels, filter.excludeLabels, 'draft')} onClick={() => onCycleLabel('draft')} variant="label" />
           )}
           {labelCounts.in_review > 0 && (
-            <FilterPill label={`Review (${labelCounts.in_review})`} active={filter.labels.has('in_review')} onClick={() => onToggleLabel('in_review')} variant="label" />
+            <FilterPill label={`Review (${labelCounts.in_review})`} mode={getFilterMode(filter.labels, filter.excludeLabels, 'in_review')} onClick={() => onCycleLabel('in_review')} variant="label" />
           )}
           {labelCounts.blocked > 0 && (
-            <FilterPill label={`Blocked (${labelCounts.blocked})`} active={filter.labels.has('blocked')} onClick={() => onToggleLabel('blocked')} variant="label" />
+            <FilterPill label={`Blocked (${labelCounts.blocked})`} mode={getFilterMode(filter.labels, filter.excludeLabels, 'blocked')} onClick={() => onCycleLabel('blocked')} variant="label" />
           )}
           {labelCounts.done > 0 && (
-            <FilterPill label={`Done (${labelCounts.done})`} active={filter.labels.has('done')} onClick={() => onToggleLabel('done')} variant="label" />
+            <FilterPill label={`Done (${labelCounts.done})`} mode={getFilterMode(filter.labels, filter.excludeLabels, 'done')} onClick={() => onCycleLabel('done')} variant="label" />
           )}
         </>
       )}
@@ -110,38 +151,51 @@ export function FilterBar({
         <FilterPill
           key={project}
           label={project}
-          active={filter.projects.has(project)}
-          onClick={() => onToggleProject(project)}
+          mode={getFilterMode(filter.projects, filter.excludeProjects, project)}
+          onClick={() => onCycleProject(project)}
         />
       ))}
     </div>
   )
 }
 
+const FILTER_TOOLTIPS: Record<string, string> = {
+  include: 'Showing only matching agents. Click to exclude instead.',
+  exclude: 'Hiding matching agents. Click to clear filter.',
+  inactive: 'Click to include. Click again to exclude.'
+}
+
 function FilterPill({
   label,
-  active,
+  mode,
   onClick,
   variant = 'status'
 }: {
   label: string
-  active: boolean
+  mode: FilterMode | null
   onClick: () => void
   variant?: 'status' | 'label'
 }) {
-  const activeClass = variant === 'label'
-    ? 'bg-kumo-brand/12 border-kumo-brand/30 text-kumo-brand'
-    : 'bg-kumo-interact/12 border-kumo-interact/30 text-kumo-link'
+  let modeClass: string
+  if (mode === 'include') {
+    modeClass = variant === 'label'
+      ? 'bg-kumo-brand/12 border-kumo-brand/30 text-kumo-brand'
+      : 'bg-kumo-interact/12 border-kumo-interact/30 text-kumo-link'
+  } else if (mode === 'exclude') {
+    modeClass = 'bg-red-500/12 border-red-500/30 text-red-400'
+  } else {
+    modeClass = 'bg-kumo-control border-kumo-line text-kumo-subtle hover:border-kumo-fill-hover hover:text-kumo-default'
+  }
+
+  const tooltip = mode ? FILTER_TOOLTIPS[mode] : FILTER_TOOLTIPS.inactive
 
   return (
     <button
       onClick={onClick}
-      className={`flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] border transition-colors cursor-pointer ${
-        active
-          ? activeClass
-          : 'bg-kumo-control border-kumo-line text-kumo-subtle hover:border-kumo-fill-hover hover:text-kumo-default'
-      }`}
+      title={tooltip}
+      className={`flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] border transition-colors cursor-pointer ${modeClass}`}
     >
+      {mode === 'exclude' && <span aria-hidden="true" className="text-[9px] leading-none">−</span>}
       {label}
     </button>
   )
@@ -155,31 +209,29 @@ const STATUS_MAP: Record<StatusFilter, AgentStatus[]> = {
   completed: ['completed']
 }
 
+function expandStatuses(filters: Set<StatusFilter>): Set<AgentStatus> {
+  const result = new Set<AgentStatus>()
+  for (const sf of filters) {
+    for (const s of STATUS_MAP[sf]) result.add(s)
+  }
+  return result
+}
+
 export function matchesFilter(
   agent: { status: AgentStatus; label: AgentLabel | null; projectName: string },
   filter: FilterState
 ): boolean {
-  const hasStatuses = filter.statuses.size > 0
-  const hasLabels = filter.labels.size > 0
-  const hasProjects = filter.projects.size > 0
+  if (isFilterEmpty(filter)) return true
 
-  if (!hasStatuses && !hasLabels && !hasProjects) return true
+  // Exclude filters: reject if agent matches any excluded value
+  if (filter.excludeStatuses.size > 0 && expandStatuses(filter.excludeStatuses).has(agent.status)) return false
+  if (filter.excludeLabels.size > 0 && agent.label && filter.excludeLabels.has(agent.label)) return false
+  if (filter.excludeProjects.size > 0 && filter.excludeProjects.has(agent.projectName)) return false
 
-  if (hasStatuses) {
-    const allowedStatuses = new Set<AgentStatus>()
-    for (const sf of filter.statuses) {
-      for (const s of STATUS_MAP[sf]) allowedStatuses.add(s)
-    }
-    if (!allowedStatuses.has(agent.status)) return false
-  }
-
-  if (hasLabels) {
-    if (!agent.label || !filter.labels.has(agent.label)) return false
-  }
-
-  if (hasProjects) {
-    if (!filter.projects.has(agent.projectName)) return false
-  }
+  // Include filters: agent must match at least one value in each active include dimension
+  if (filter.statuses.size > 0 && !expandStatuses(filter.statuses).has(agent.status)) return false
+  if (filter.labels.size > 0 && (!agent.label || !filter.labels.has(agent.label))) return false
+  if (filter.projects.size > 0 && !filter.projects.has(agent.projectName)) return false
 
   return true
 }


### PR DESCRIPTION
Filter pills now cycle through three states: inactive → include (blue) → exclude (red) → inactive. Exclude filters reject matching agents and take precedence over includes. Each pill shows a tooltip and excluded pills display a minus prefix for visual distinction.

Adds cycleFilter/getFilterMode utilities, expandStatuses helper to deduplicate STATUS_MAP logic, and 24 new tests for the exclude behavior.