### PR TITLE
Track and display PR links in the dashboard

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -334,12 +334,13 @@ export function registerIpcHandlers(): void {
         title: agent.title,
         displayName: agent.displayName,
         taskSummary: agent.taskSummary,
-        persistedStatus: agent.persistedStatus
+        persistedStatus: agent.persistedStatus,
+        prUrl: agent.prUrl
       }))
     }
   })
 
-  ipcMain.handle('agent:update-meta', async (_event, agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string }) => {
+  ipcMain.handle('agent:update-meta', async (_event, agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; prUrl?: string }) => {
     try {
       agentController.updateAgentMeta(agentId, meta)
       return { ok: true }

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -76,6 +76,7 @@ export interface AgentHandle {
   displayName: string
   taskSummary: string
   persistedStatus?: string
+  prUrl?: string
   bridge: EventBridge
 }
 
@@ -88,6 +89,7 @@ interface PersistedAgentHandle {
   displayName?: string
   taskSummary?: string
   persistedStatus?: string
+  prUrl?: string
 }
 
 const ACTIVE_AGENTS_PREFERENCE_KEY = 'active_agents'
@@ -289,13 +291,14 @@ class AgentController {
   /**
    * Update the persisted display name, task summary, and/or status for an agent.
    */
-  updateAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string }): void {
+  updateAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; prUrl?: string }): void {
     const handle = this.agents.get(agentId)
     if (!handle) return
 
     if (meta.displayName !== undefined) handle.displayName = meta.displayName
     if (meta.taskSummary !== undefined) handle.taskSummary = meta.taskSummary
     if (meta.persistedStatus !== undefined) handle.persistedStatus = meta.persistedStatus
+    if (meta.prUrl !== undefined) handle.prUrl = meta.prUrl
     this.persistAgents()
   }
 
@@ -1097,7 +1100,8 @@ class AgentController {
       title: agent.title,
       displayName: agent.displayName,
       taskSummary: agent.taskSummary,
-      persistedStatus: agent.persistedStatus
+      persistedStatus: agent.persistedStatus,
+      prUrl: agent.prUrl
     }))
 
     database.setPreference(ACTIVE_AGENTS_PREFERENCE_KEY, JSON.stringify(persistedAgents))

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -206,6 +206,7 @@ export function App() {
       status: agent.status,
       label: agent.label,
       model: agent.model,
+      prUrl: agent.prUrl,
       lastActivityAt: formatTimeAgo(agent.lastActivityAt),
       lastActivityAtMs: agent.lastActivityAt,
       blockedSince: agent.blockedSince ? formatTimeAgo(agent.blockedSince) : undefined,

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -462,6 +462,7 @@ export const DetailDrawer = memo(function DetailDrawer({
               <span className="truncate">
                 {agent.projectName} · {formatBranchLabel(agent) || agent.taskSummary.slice(0, 40)}
               </span>
+
             </div>
           </div>
           <div className="flex items-center gap-1.5 shrink-0">
@@ -642,6 +643,9 @@ export const DetailDrawer = memo(function DetailDrawer({
           <div className="flex-1" />
           {onChangeModel && (
             <ActionButton icon={<Brain size={12} />} label="Model" onClick={onChangeModel} />
+          )}
+          {agent.prUrl && (
+            <ActionButton icon={<GitPullRequest size={12} />} label="View PR" onClick={() => window.api?.openExternal(agent.prUrl!)} />
           )}
           {onCreatePr && (
             <ActionButton icon={<GitPullRequest size={12} />} label="Create PR" onClick={onCreatePr} />

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -17,6 +17,7 @@ import {
 import type { AgentRuntime, AgentLabel } from '../types'
 import { formatBranchLabel, isUrgent } from '../types'
 import { StatusBadge } from './StatusBadge'
+import { PrBadge } from './PrBadge'
 import { LabelDropdown } from './LabelDropdown'
 
 interface FleetTableProps {
@@ -418,6 +419,11 @@ function ContextMenu({
           <Square size={13} weight="fill" /> {isStopping ? 'Stopping...' : 'Stop'}
         </button>
       )}
+      {agent.prUrl && (
+        <button className={itemClass} onClick={() => window.api?.openExternal(agent.prUrl!)}>
+          <GitPullRequest size={13} /> View PR
+        </button>
+      )}
       <button className={itemClass} onClick={onCreatePr}>
         <GitPullRequest size={13} /> Create PR
       </button>
@@ -520,7 +526,10 @@ function AgentRow({
         {agent.taskSummary}
       </td>
       <td className="px-3 py-2 font-mono text-[11px] text-kumo-subtle">
-        {formatBranchLabel(agent)}
+        <div className="flex items-center gap-1.5">
+          <span className="truncate">{formatBranchLabel(agent)}</span>
+          {agent.prUrl && <PrBadge url={agent.prUrl} stopPropagation />}
+        </div>
       </td>
       <td className="px-3 py-2 min-w-[7rem] max-w-[10rem]">
         {agent.model && agent.model !== 'starting...' && (

--- a/src/renderer/src/components/PrBadge.tsx
+++ b/src/renderer/src/components/PrBadge.tsx
@@ -1,0 +1,22 @@
+import { GitPullRequest } from '@phosphor-icons/react'
+
+interface PrBadgeProps {
+  url: string
+  stopPropagation?: boolean
+}
+
+export function PrBadge({ url, stopPropagation }: PrBadgeProps) {
+  return (
+    <button
+      onClick={(event) => {
+        if (stopPropagation) event.stopPropagation()
+        window.api?.openExternal(url)
+      }}
+      className="shrink-0 inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-kumo-brand/10 text-kumo-brand hover:bg-kumo-brand/20 transition-colors text-[9px] font-medium cursor-pointer"
+      title={url}
+    >
+      <GitPullRequest size={10} weight="bold" />
+      PR
+    </button>
+  )
+}

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -63,6 +63,7 @@ export interface LiveAgent {
   model: string
   lastActivityAt: number
   blockedSince?: number
+  prUrl: string | null
   cost: number
   tokens: { input: number; output: number }
   /** Whether the name was auto-generated and should be replaced by the first prompt */
@@ -200,7 +201,7 @@ function emit(changed?: EmitFlags): void {
   }
 }
 
-function persistAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string }): void {
+function persistAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; prUrl?: string }): void {
   window.api?.updateAgentMeta(agentId, meta)
 }
 
@@ -234,6 +235,16 @@ function deriveFreshAgentName(projectName: string): string {
     .replace(/-$/, '')
 
   return cleaned ? `${cleaned}-fresh` : 'fresh-agent'
+}
+
+// ── PR URL Extraction ──
+
+/** Matches GitHub and GitLab PR/MR URLs in message text. */
+const PR_URL_REGEX = /https?:\/\/(?:github\.com|gitlab\.com|gitlab\.[a-z0-9.-]+)\S*\/(?:pull|merge_requests)\/\d+\b/gi
+
+function extractPrUrl(text: string): string | null {
+  const matches = text.match(PR_URL_REGEX)
+  return matches ? matches[matches.length - 1] : null
 }
 
 function subscribe(listener: () => void): () => void {
@@ -479,6 +490,22 @@ function hydrateHistoricalMessages(entries: unknown): void {
 
       if (entry.info.modelID) {
         agent.model = formatModelName(entry.info.modelID)
+      }
+
+      // Extract PR URL from historical assistant messages (text and tool output)
+      if (!agent.prUrl) {
+        for (const part of entry.parts) {
+          const text = part.type === 'tool'
+            ? (part.text ?? part.state?.output ?? part.state?.error)
+            : part.text
+          if ((part.type === 'text' || part.type === 'tool') && text) {
+            const prUrl = extractPrUrl(text)
+            if (prUrl) {
+              agent.prUrl = prUrl
+              break
+            }
+          }
+        }
       }
     }
   }
@@ -737,8 +764,9 @@ function processEvent(payload: OpenCodeEventPayload): void {
           return getToolOutput(part, toolState) ?? part.text as string | undefined
         }
 
+        const partText = extractText()
         if (existingPart) {
-          existingPart.text = extractText()
+          existingPart.text = partText
           if (partType === 'tool') {
             existingPart.toolState = getToolState(toolState)
             existingPart.toolInput = stringifyToolInput(toolState?.input)
@@ -752,7 +780,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
           const newPart: LiveMessagePart = {
             id: partId,
             type: partType,
-            text: extractText()
+            text: partText
           }
           if (partType === 'tool') {
             newPart.toolName = part.tool as string | undefined
@@ -771,6 +799,15 @@ function processEvent(payload: OpenCodeEventPayload): void {
         let agentChanged = false
         const agent = findAgentBySession(sessionId)
         if (agent) {
+          // Extract PR URL from assistant text and tool output parts
+          if (message.role === 'assistant' && (partType === 'text' || partType === 'tool') && partText) {
+            const prUrl = extractPrUrl(partText)
+            if (prUrl && agent.prUrl !== prUrl) {
+              agent.prUrl = prUrl
+              agentChanged = true
+              persistAgentMeta(agent.id, { prUrl })
+            }
+          }
           agent.lastActivityAt = Date.now()
           if (agent.status !== 'needs_input' && agent.status !== 'needs_approval' && agent.status !== 'stopping' && agent.status !== 'completed' && agent.status !== 'idle') {
             agent.status = 'running'
@@ -1071,6 +1108,7 @@ function handleSessionReset(payload: { id: string; sessionId: string; oldSession
   // Update agent with new session
   agent.sessionId = payload.sessionId
   agent.branchName = payload.branchName
+  agent.prUrl = null
   agent.cost = 0
   agent.tokens = { input: 0, output: 0 }
   agent.lastActivityAt = Date.now()
@@ -1137,6 +1175,7 @@ function upsertAgent(payload: AgentLaunchedPayload, initialStatus?: AgentStatus)
     status: initialStatus ?? existingAgent?.status ?? (hasPrompt ? 'running' : 'idle'),
     label: existingAgent?.label ?? null,
     model: existingAgent?.model ?? 'starting...',
+    prUrl: existingAgent?.prUrl ?? payload.prUrl ?? null,
     lastActivityAt: existingAgent?.lastActivityAt ?? Date.now(),
     cost: existingAgent?.cost ?? 0,
     tokens: existingAgent?.tokens ?? { input: 0, output: 0 },

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -35,7 +35,7 @@ export interface OrchestratorApi {
   listSessions: (directory: string) => Promise<IpcResult<SessionListEntry[]>>
   resumeAgent: (options: { directory: string; sessionId: string; title?: string }) => Promise<IpcResult>
   listAgents: () => Promise<IpcResult<ListAgentsPayload>>
-  updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string }) => Promise<IpcResult>
+  updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; prUrl?: string }) => Promise<IpcResult>
   getStatuses: () => Promise<IpcResult<AgentStatusesPayload>>
   replyToQuestion: (agentId: string, requestId: string, answers: string[][]) => Promise<IpcResult>
   rejectQuestion: (agentId: string, requestId: string) => Promise<IpcResult>
@@ -155,6 +155,7 @@ export interface AgentLaunchedPayload {
   displayName?: string
   taskSummary?: string
   persistedStatus?: string
+  prUrl?: string
 }
 
 export interface SessionResetPayload {

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -44,6 +44,7 @@ export interface AgentRuntime {
   status: AgentStatus
   label: AgentLabel | null
   model: string
+  prUrl: string | null
   lastActivityAt: string
   lastActivityAtMs: number
   blockedSince?: string


### PR DESCRIPTION
Extract PR URLs from agent messages (GitHub and GitLab), persist them across restarts, and surface them as clickable badges in the fleet table and detail drawer so completed PRs are one click away.