### PR TITLE
Reduce detail drawer re-renders and cap rendered message count

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -67,10 +67,27 @@ export function App() {
 
   const store = useAgentStore()
 
-  // ── Fetch available commands and agent configs when an agent is selected ──
-  // Deps use specific stable callbacks (not the whole store object) to avoid
-  // re-fetching on unrelated SSE events.
-  const { listCommands, listAgentConfigs } = store
+  // Destructure stable callbacks (all use useCallback(fn, [])) to avoid
+  // depending on the whole `store` object in downstream hooks.
+  const {
+    listCommands,
+    listAgentConfigs,
+    getMessagesForSession,
+    getFileChangesForSession,
+    getEventsForSession,
+    sendMessage: storeSendMessage,
+    replyToQuestion: storeReplyToQuestion,
+    resetSession: storeResetSession,
+    respondToPermission: storeRespondToPermission,
+    rejectQuestion: storeRejectQuestion,
+    abortAgent: storeAbortAgent,
+    removeAgent: storeRemoveAgent,
+    setAgentModel: storeSetAgentModel,
+    executeCommand: storeExecuteCommand,
+    setLabel: storeSetLabel,
+    renameAgent: storeRenameAgent
+  } = store
+
   useEffect(() => {
     if (!selectedAgentId) {
       setAgentCommands([])
@@ -382,7 +399,7 @@ export function App() {
     const liveAgent = store.agents.find((agent) => agent.id === selectedAgent.id)
     if (!liveAgent) return []
 
-    const liveMessages = store.getMessagesForSession(liveAgent.sessionId)
+    const liveMessages = getMessagesForSession(liveAgent.sessionId)
     const transcriptItems: Message[] = []
     let pendingToolCalls: ToolCall[] = []
 
@@ -401,29 +418,40 @@ export function App() {
     }
 
     for (const msg of liveMessages) {
-      const textContent = msg.parts
-        .filter((part) => part.type === 'text' && part.text)
-        .map((part) => part.text!)
-        .join('\n')
+      const textParts: string[] = []
+      const toolCalls: ToolCall[] = []
+      const images: Array<{ mime: string; url: string; filename?: string }> = []
 
-      const toolCalls = msg.parts
-        .filter((part) => part.type === 'tool')
-        .map((part) => ({
-          id: part.id,
-          name: part.toolName ?? 'unknown',
-          state: mapToolState(part.toolState),
-          input: part.toolInput,
-          output: part.text ?? undefined,
-          timestamp: msg.createdAt
-        }))
+      for (const part of msg.parts) {
+        switch (part.type) {
+          case 'text':
+            if (part.text) {
+              textParts.push(part.text)
+            }
+            break
+          case 'tool':
+            toolCalls.push({
+              id: part.id,
+              name: part.toolName ?? 'unknown',
+              state: mapToolState(part.toolState),
+              input: part.toolInput,
+              output: part.text ?? undefined,
+              timestamp: msg.createdAt
+            })
+            break
+          case 'file':
+            if (part.fileUrl && part.fileMime?.startsWith('image/')) {
+              images.push({
+                mime: part.fileMime!,
+                url: part.fileUrl!,
+                filename: part.fileName
+              })
+            }
+            break
+        }
+      }
 
-      const images = msg.parts
-        .filter((part) => part.type === 'file' && part.fileUrl && part.fileMime?.startsWith('image/'))
-        .map((part) => ({
-          mime: part.fileMime!,
-          url: part.fileUrl!,
-          filename: part.fileName
-        }))
+      const textContent = textParts.join('\n')
 
       if (textContent.trim() || images.length > 0) {
         flushPendingToolCalls(msg.id, msg.createdAt)
@@ -452,7 +480,7 @@ export function App() {
     }
 
     return transcriptItems
-  }, [selectedAgent, store])
+  }, [selectedAgent, store.agents, getMessagesForSession])
 
   // ── File changes for selected agent ──
   const selectedFiles: FileChange[] = useMemo(() => {
@@ -460,35 +488,19 @@ export function App() {
     const liveAgent = store.agents.find((agent) => agent.id === selectedAgent.id)
     if (!liveAgent) return []
 
-    return store.getFileChangesForSession(liveAgent.sessionId)
-  }, [selectedAgent, store])
+    return getFileChangesForSession(liveAgent.sessionId)
+  }, [selectedAgent, store.agents, getFileChangesForSession])
 
-  // ── Extract tool calls from store messages ──
+  // ── Extract tool calls from selectedMessages (derived, avoids redundant iteration) ──
   const selectedTools: ToolCall[] = useMemo(() => {
-    if (!selectedAgent) return []
-    const liveAgent = store.agents.find((agent) => agent.id === selectedAgent.id)
-    if (!liveAgent) return []
-
-    const liveMessages = store.getMessagesForSession(liveAgent.sessionId)
     const tools: ToolCall[] = []
-
-    for (const msg of liveMessages) {
-      for (const part of msg.parts) {
-        if (part.type === 'tool') {
-            tools.push({
-              id: part.id,
-              name: part.toolName ?? 'unknown',
-              state: mapToolState(part.toolState),
-              input: part.toolInput,
-              output: part.text ?? undefined,
-              timestamp: msg.createdAt
-            })
-          }
-        }
+    for (const msg of selectedMessages) {
+      if (msg.role === 'tool-group' && msg.toolCalls) {
+        tools.push(...msg.toolCalls)
       }
-
+    }
     return tools
-  }, [selectedAgent, store])
+  }, [selectedMessages])
 
   // ── Events for selected agent ──
   const selectedEvents: EventEntry[] = useMemo(() => {
@@ -496,8 +508,8 @@ export function App() {
     const liveAgent = store.agents.find((agent) => agent.id === selectedAgent.id)
     if (!liveAgent) return []
 
-    return store.getEventsForSession(liveAgent.sessionId)
-  }, [selectedAgent, store])
+    return getEventsForSession(liveAgent.sessionId)
+  }, [selectedAgent, store.agents, getEventsForSession])
 
   // ── Permission for selected agent ──
   const selectedPermission = useMemo(() => {
@@ -565,25 +577,25 @@ export function App() {
   const handleRowApprove = useCallback(async (agentId: string) => {
     const permission = findPermissionForAgent(agentId)
     if (permission) {
-      await store.respondToPermission(agentId, permission.id, 'once')
+      await storeRespondToPermission(agentId, permission.id, 'once')
     }
-  }, [findPermissionForAgent, store])
+  }, [findPermissionForAgent, storeRespondToPermission])
 
   const handleRowReply = useCallback((agentId: string) => {
     setSelectedAgentId(agentId)
   }, [])
 
   const handleRowStop = useCallback(async (agentId: string) => {
-    await store.abortAgent(agentId)
-  }, [store])
+    await storeAbortAgent(agentId)
+  }, [storeAbortAgent])
 
   const handleRowOpen = useCallback((agentId: string) => {
     setSelectedAgentId(agentId)
   }, [])
 
   const handleSetLabel = useCallback((agentId: string, label: AgentLabel | null) => {
-    store.setLabel(agentId, label)
-  }, [store])
+    storeSetLabel(agentId, label)
+  }, [storeSetLabel])
 
   const handleRemoveAgent = useCallback((agentId: string) => {
     const liveAgent = findLiveAgent(agentId)
@@ -595,12 +607,12 @@ export function App() {
 
     if (!window.confirm(confirmMessage)) return
 
-    store.removeAgent(agentId)
+    storeRemoveAgent(agentId)
 
     if (selectedAgentId === agentId) {
       setSelectedAgentId(null)
     }
-  }, [findLiveAgent, selectedAgentId, store])
+  }, [findLiveAgent, selectedAgentId, storeRemoveAgent])
 
   // ── Built-in command handlers ──
   const handleBuiltInCommand = useCallback(async (agentId: string, commandName: string, commandArgs: string): Promise<boolean> => {
@@ -613,7 +625,7 @@ export function App() {
         // Direct model set: /model provider/model-id
         const updateResult = await window.api.updateConfig(agentId, { model: commandArgs })
         if (updateResult.ok) {
-          store.setAgentModel(agentId, commandArgs)
+          storeSetAgentModel(agentId, commandArgs)
         } else {
           console.error('Failed to update model:', updateResult.error)
         }
@@ -650,13 +662,13 @@ export function App() {
         // Check if it's a custom command from the API (skills, /init, /review, etc.)
         const isKnownCommand = agentCommands.some((cmd) => cmd.command === `/${commandName}`)
         if (isKnownCommand) {
-          await store.executeCommand(agentId, commandName, commandArgs)
+          await storeExecuteCommand(agentId, commandName, commandArgs)
           return true
         }
         return false
       }
     }
-  }, [agentCommands, store])
+  }, [agentCommands, storeSetAgentModel, storeExecuteCommand])
 
   // ── Detail drawer actions ──
   const handleSendMessage = useCallback(async (text: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>) => {
@@ -667,14 +679,14 @@ export function App() {
     if (selectedQuestion && trimmedText && selectedQuestion.questions.length === 1) {
       const q = selectedQuestion.questions[0]
       if (q.custom !== false) {
-        await store.replyToQuestion(selectedAgentId, selectedQuestion.id, [[trimmedText]])
+        await storeReplyToQuestion(selectedAgentId, selectedQuestion.id, [[trimmedText]])
         return
       }
     }
 
     if (trimmedText === NEW_AGENT_COMMAND || trimmedText.startsWith(`${NEW_AGENT_COMMAND} `)) {
       const followUpPrompt = trimmedText.slice(NEW_AGENT_COMMAND.length).trim() || undefined
-      await store.resetSession(selectedAgentId, followUpPrompt)
+      await storeResetSession(selectedAgentId, followUpPrompt)
       return
     }
 
@@ -695,38 +707,38 @@ export function App() {
       const isKnownAgent = agentConfigs.some((cfg) => cfg.name === mentionedAgent)
       if (isKnownAgent) {
         const cleanText = trimmedText.replace(AGENT_MENTION_REGEX, '').trim()
-        await store.sendMessage(selectedAgentId, cleanText || trimmedText, mentionedAgent, attachments)
+        await storeSendMessage(selectedAgentId, cleanText || trimmedText, mentionedAgent, attachments)
         return
       }
     }
 
-    await store.sendMessage(selectedAgentId, text, undefined, attachments)
-  }, [agentConfigs, handleBuiltInCommand, selectedAgentId, selectedQuestion, store])
+    await storeSendMessage(selectedAgentId, text, undefined, attachments)
+  }, [agentConfigs, handleBuiltInCommand, selectedAgentId, selectedQuestion, storeSendMessage, storeReplyToQuestion, storeResetSession])
 
   const handleApprove = useCallback(async (permissionId: string) => {
     if (!selectedAgentId) return
-    await store.respondToPermission(selectedAgentId, permissionId, 'once')
-  }, [selectedAgentId, store])
+    await storeRespondToPermission(selectedAgentId, permissionId, 'once')
+  }, [selectedAgentId, storeRespondToPermission])
 
   const handleDeny = useCallback(async (permissionId: string) => {
     if (!selectedAgentId) return
-    await store.respondToPermission(selectedAgentId, permissionId, 'reject')
-  }, [selectedAgentId, store])
+    await storeRespondToPermission(selectedAgentId, permissionId, 'reject')
+  }, [selectedAgentId, storeRespondToPermission])
 
   const handleReplyQuestion = useCallback(async (answers: string[][]) => {
     if (!selectedAgentId || !selectedQuestion) return
-    await store.replyToQuestion(selectedAgentId, selectedQuestion.id, answers)
-  }, [selectedAgentId, selectedQuestion, store])
+    await storeReplyToQuestion(selectedAgentId, selectedQuestion.id, answers)
+  }, [selectedAgentId, selectedQuestion, storeReplyToQuestion])
 
   const handleRejectQuestion = useCallback(async () => {
     if (!selectedAgentId || !selectedQuestion) return
-    await store.rejectQuestion(selectedAgentId, selectedQuestion.id)
-  }, [selectedAgentId, selectedQuestion, store])
+    await storeRejectQuestion(selectedAgentId, selectedQuestion.id)
+  }, [selectedAgentId, selectedQuestion, storeRejectQuestion])
 
   const handleAbort = useCallback(async () => {
     if (!selectedAgentId) return
-    await store.abortAgent(selectedAgentId)
-  }, [selectedAgentId, store])
+    await storeAbortAgent(selectedAgentId)
+  }, [selectedAgentId, storeAbortAgent])
 
   const handleCloseDrawer = useCallback(() => setSelectedAgentId(null), [])
 
@@ -753,11 +765,11 @@ export function App() {
 
   const handleCreatePr = useCallback(async () => {
     if (!selectedAgentId) return
-    const result = await store.sendMessage(selectedAgentId, loadSettings().createPrPrompt, undefined, undefined, 'Create PR')
+    const result = await storeSendMessage(selectedAgentId, loadSettings().createPrPrompt, undefined, undefined, 'Create PR')
     if (result?.ok) {
-      store.setLabel(selectedAgentId, 'in_review')
+      storeSetLabel(selectedAgentId, 'in_review')
     }
-  }, [selectedAgentId, store])
+  }, [selectedAgentId, storeSendMessage, storeSetLabel])
 
   const handleOpenInEditor = useCallback(() => {
     if (!selectedAgentId) return
@@ -1117,7 +1129,7 @@ export function App() {
         onStop={handleRowStop}
         onOpen={handleRowOpen}
         onRemove={handleRemoveAgent}
-        onRename={(agentId, newName) => store.renameAgent(agentId, newName)}
+        onRename={storeRenameAgent}
         onOpenTerminal={handleOpenTerminal}
         onOpenInEditor={handleOpenInEditorForAgent}
         onCreatePr={handleCreatePrForAgent}

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -38,6 +38,8 @@ const DRAWER_WIDTH_KEY = 'oc-orchestrator:drawer-width'
 const DEFAULT_DRAWER_WIDTH = 600
 const MIN_DRAWER_WIDTH = 400
 const MAX_DRAWER_WIDTH = 1000
+const VISIBLE_MESSAGE_WINDOW = 50
+const LOAD_MORE_INCREMENT = 50
 
 function loadDrawerWidth(): number {
   try {
@@ -122,6 +124,21 @@ export const DetailDrawer = memo(function DetailDrawer({
   const [agentPickerIndex, setAgentPickerIndex] = useState(0)
   const [commandPickerIndex, setCommandPickerIndex] = useState(0)
   const [cursorPos, setCursorPos] = useState(0)
+  const [visibleMessageCount, setVisibleMessageCount] = useState(VISIBLE_MESSAGE_WINDOW)
+
+  // Reset the visible window when switching agents
+  const prevAgentIdRef = useRef(agent.id)
+  if (prevAgentIdRef.current !== agent.id) {
+    prevAgentIdRef.current = agent.id
+    setVisibleMessageCount(VISIBLE_MESSAGE_WINDOW)
+  }
+
+  const hiddenCount = Math.max(0, messages.length - visibleMessageCount)
+  const visibleMessages = hiddenCount > 0 ? messages.slice(hiddenCount) : messages
+
+  const handleLoadMore = useCallback(() => {
+    setVisibleMessageCount((prev) => prev + LOAD_MORE_INCREMENT)
+  }, [])
 
   // Verbose mode: global setting, reactive to changes from SettingsModal
   const [isVerbose, setIsVerbose] = useState(() => loadSettings().verboseMode)
@@ -270,7 +287,7 @@ export const DetailDrawer = memo(function DetailDrawer({
     } else if (userScrolledRef.current) {
       setShowJumpToLatest(true)
     }
-  }, [messages, activeTab])
+  }, [messages, visibleMessages, activeTab])
 
   const handleTranscriptScroll = () => {
     // Skip scroll events caused by our own scrollTop assignments
@@ -522,7 +539,15 @@ export const DetailDrawer = memo(function DetailDrawer({
                         {sessionNotice}
                       </div>
                     )}
-                    {messages.map((message) => (
+                    {hiddenCount > 0 && (
+                      <button
+                        onClick={handleLoadMore}
+                        className="self-center px-3 py-1.5 text-[11px] font-medium text-kumo-link hover:text-kumo-strong bg-kumo-fill hover:bg-kumo-fill-hover border border-kumo-line rounded-full transition-colors cursor-pointer"
+                      >
+                        Load {Math.min(LOAD_MORE_INCREMENT, hiddenCount)} earlier message{hiddenCount === 1 ? '' : 's'}
+                      </button>
+                    )}
+                    {visibleMessages.map((message) => (
                       <MessageBubble key={message.id} message={message} verbose={isVerbose} />
                     ))}
                   </>
@@ -1003,7 +1028,7 @@ function Tab({
   )
 }
 
-function MessageBubble({ message, verbose = false }: { message: Message; verbose?: boolean }) {
+const MessageBubble = memo(function MessageBubble({ message, verbose = false }: { message: Message; verbose?: boolean }) {
   if (message.role === 'tool-group') {
     return <ToolGroupBubble message={message} verbose={verbose} />
   }
@@ -1011,18 +1036,12 @@ function MessageBubble({ message, verbose = false }: { message: Message; verbose
   if (message.role === 'tool') {
     const toolName = message.toolName ?? extractToolName(message.content)
     const toolOutput = message.content ? extractToolOutput(message.content) : ''
-    const toolIconClass = message.toolState === 'failed'
-      ? 'text-kumo-danger'
-      : message.toolState === 'completed'
-        ? 'text-kumo-success'
-        : 'text-kumo-link animate-spin'
-
     return (
       <div className="font-mono text-[11px] px-2.5 py-1.5 bg-kumo-overlay border-l-2 border-kumo-fill-hover rounded-r-md text-kumo-subtle">
         <div className="flex items-center gap-1.5 mb-0.5">
           <Wrench size={11} className="shrink-0" />
           <span className="font-semibold text-kumo-default">{toolName}</span>
-          <CircleNotch size={11} className={toolIconClass} />
+          <CircleNotch size={11} className={toolIconStyle(message.toolState)} />
         </div>
         {toolOutput && (
           <div className="whitespace-pre-wrap break-all mt-1">{toolOutput}</div>
@@ -1070,6 +1089,24 @@ function MessageBubble({ message, verbose = false }: { message: Message; verbose
       )}
     </div>
   )
+}, (prev, next) =>
+  prev.message.id === next.message.id &&
+  prev.message.content === next.message.content &&
+  prev.message.role === next.message.role &&
+  prev.message.toolCalls === next.message.toolCalls &&
+  prev.verbose === next.verbose
+)
+
+const toolStateStyles: Record<string, string> = {
+  failed: 'text-kumo-danger',
+  completed: 'text-kumo-success',
+  running: 'text-kumo-link'
+}
+
+function toolIconStyle(toolState: string | undefined): string {
+  if (toolState === 'failed') return 'text-kumo-danger'
+  if (toolState === 'completed') return 'text-kumo-success'
+  return 'text-kumo-link animate-spin'
 }
 
 function parseToolCommand(input: string | undefined): string | undefined {
@@ -1081,7 +1118,7 @@ function parseToolCommand(input: string | undefined): string | undefined {
   }
 }
 
-function ToolGroupBubble({ message, verbose = false }: { message: Message; verbose?: boolean }) {
+const ToolGroupBubble = memo(function ToolGroupBubble({ message, verbose = false }: { message: Message; verbose?: boolean }) {
   const [expanded, setExpanded] = useState(verbose)
   const toolCalls = message.toolCalls ?? []
 
@@ -1109,7 +1146,7 @@ function ToolGroupBubble({ message, verbose = false }: { message: Message; verbo
             <div key={tool.id} className="rounded-md bg-kumo-control border border-kumo-line px-2.5 py-2">
               <div className="flex items-center gap-2">
                 <span className="font-mono text-[11px] text-kumo-default">{tool.name}</span>
-                <span className={`text-[10px] ${tool.state === 'failed' ? 'text-kumo-danger' : tool.state === 'completed' ? 'text-kumo-success' : 'text-kumo-link'}`}>
+                <span className={`text-[10px] ${toolStateStyles[tool.state] ?? 'text-kumo-link'}`}>
                   {tool.state}
                 </span>
               </div>
@@ -1129,7 +1166,12 @@ function ToolGroupBubble({ message, verbose = false }: { message: Message; verbo
       )}
     </div>
   )
-}
+}, (prev, next) =>
+  prev.message.id === next.message.id &&
+  prev.message.content === next.message.content &&
+  prev.message.toolCalls === next.message.toolCalls &&
+  prev.verbose === next.verbose
+)
 
 function ActionButton({
   icon,

--- a/src/renderer/src/components/EventLog.tsx
+++ b/src/renderer/src/components/EventLog.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from 'react'
+import { useState, useMemo, useEffect, useRef, memo } from 'react'
 import { ListBullets, CaretDown, CaretRight, Funnel } from '@phosphor-icons/react'
 
 export interface EventEntry {
@@ -42,7 +42,7 @@ function formatJson(data: unknown): string {
   }
 }
 
-export function EventLog({ events, verbose = false }: EventLogProps) {
+export const EventLog = memo(function EventLog({ events, verbose = false }: EventLogProps) {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(() =>
     verbose ? new Set(events.map((e) => e.id)) : new Set()
   )
@@ -101,7 +101,10 @@ export function EventLog({ events, verbose = false }: EventLogProps) {
     )
   }
 
-  const sorted = [...filteredEvents].sort((eventA, eventB) => eventB.timestamp - eventA.timestamp)
+  const sorted = useMemo(
+    () => [...filteredEvents].sort((eventA, eventB) => eventB.timestamp - eventA.timestamp),
+    [filteredEvents]
+  )
 
   return (
     <div className="flex flex-col gap-2 py-2">
@@ -209,4 +212,4 @@ export function EventLog({ events, verbose = false }: EventLogProps) {
       </div>
     </div>
   )
-}
+})

--- a/src/renderer/src/components/FilesChanged.tsx
+++ b/src/renderer/src/components/FilesChanged.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from 'react'
 import { File, FilePlus, FileMinus, PencilSimple } from '@phosphor-icons/react'
 
 export interface FileChange {
@@ -49,18 +50,19 @@ function extractFilename(filePath: string): string {
   return segments[segments.length - 1] || filePath
 }
 
-export function FilesChanged({ files }: FilesChangedProps) {
-  const latestByPath = new Map<string, FileChange>()
-  for (const file of files) {
-    const existingFile = latestByPath.get(file.path)
-    if (!existingFile || existingFile.timestamp < file.timestamp) {
-      latestByPath.set(file.path, file)
+export const FilesChanged = memo(function FilesChanged({ files }: FilesChangedProps) {
+  const sorted = useMemo(() => {
+    const latestByPath = new Map<string, FileChange>()
+    for (const file of files) {
+      const existingFile = latestByPath.get(file.path)
+      if (!existingFile || existingFile.timestamp < file.timestamp) {
+        latestByPath.set(file.path, file)
+      }
     }
-  }
+    return Array.from(latestByPath.values()).sort((fileA, fileB) => fileB.timestamp - fileA.timestamp)
+  }, [files])
 
-  const dedupedFiles = Array.from(latestByPath.values())
-
-  if (dedupedFiles.length === 0) {
+  if (sorted.length === 0) {
     return (
       <div className="flex-1 flex flex-col items-center justify-center gap-2 text-kumo-subtle py-12">
         <File size={28} weight="duotone" />
@@ -69,12 +71,10 @@ export function FilesChanged({ files }: FilesChangedProps) {
     )
   }
 
-  const sorted = dedupedFiles.sort((fileA, fileB) => fileB.timestamp - fileA.timestamp)
-
   return (
     <div className="flex flex-col gap-1 py-2">
       <div className="text-[11px] text-kumo-subtle px-1 pb-1">
-        {dedupedFiles.length} file{dedupedFiles.length !== 1 ? 's' : ''} changed
+        {sorted.length} file{sorted.length !== 1 ? 's' : ''} changed
       </div>
       {sorted.map((file, index) => (
         <div
@@ -110,4 +110,4 @@ export function FilesChanged({ files }: FilesChangedProps) {
       ))}
     </div>
   )
-}
+})

--- a/src/renderer/src/components/Markdown.tsx
+++ b/src/renderer/src/components/Markdown.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import type { ComponentPropsWithoutRef, MouseEvent } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -22,18 +23,22 @@ function ExternalLink({ href, children, ...props }: ComponentPropsWithoutRef<'a'
   )
 }
 
-export function Markdown({ children, className }: MarkdownProps) {
+// Hoist to module scope — stable references prevent ReactMarkdown from
+// re-parsing markdown on every render due to referential inequality.
+const REMARK_PLUGINS = [remarkGfm]
+const DISALLOWED_ELEMENTS = ['script', 'iframe', 'object', 'embed', 'form']
+const COMPONENTS = { a: ExternalLink }
+
+export const Markdown = memo(function Markdown({ children, className }: MarkdownProps) {
   return (
     <div className={`markdown-body ${className ?? ''}`}>
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        disallowedElements={['script', 'iframe', 'object', 'embed', 'form']}
-        components={{
-          a: ExternalLink
-        }}
+        remarkPlugins={REMARK_PLUGINS}
+        disallowedElements={DISALLOWED_ELEMENTS}
+        components={COMPONENTS}
       >
         {children}
       </ReactMarkdown>
     </div>
   )
-}
+})

--- a/src/renderer/src/components/ToolsUsage.tsx
+++ b/src/renderer/src/components/ToolsUsage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from 'react'
+import { useState, useMemo, useEffect, useRef, memo } from 'react'
 import { Wrench, CaretDown, CaretRight, MagnifyingGlass } from '@phosphor-icons/react'
 
 export interface ToolCall {
@@ -38,7 +38,7 @@ function formatRelativeTime(timestamp: number): string {
   return `${days}d ago`
 }
 
-export function ToolsUsage({ tools, verbose = false }: ToolsUsageProps) {
+export const ToolsUsage = memo(function ToolsUsage({ tools, verbose = false }: ToolsUsageProps) {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(() =>
     verbose ? new Set(tools.map((t) => t.id)) : new Set()
   )
@@ -97,7 +97,10 @@ export function ToolsUsage({ tools, verbose = false }: ToolsUsageProps) {
     )
   }
 
-  const sorted = [...filteredTools].sort((toolA, toolB) => toolB.timestamp - toolA.timestamp)
+  const sorted = useMemo(
+    () => [...filteredTools].sort((toolA, toolB) => toolB.timestamp - toolA.timestamp),
+    [filteredTools]
+  )
 
   return (
     <div className="flex flex-col gap-2 py-2">
@@ -205,4 +208,4 @@ export function ToolsUsage({ tools, verbose = false }: ToolsUsageProps) {
       </div>
     </div>
   )
-}
+})

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -188,16 +188,37 @@ interface EmitFlags {
 }
 
 function emit(changed?: EmitFlags): void {
-  // Bump per-collection version counters so downstream useMemo hooks can
-  // skip re-derivation when only unrelated collections changed.
   if (!changed || changed.agents) agentsVersion++
   if (!changed || changed.permissions) permissionsVersion++
   if (!changed || changed.questions) questionsVersion++
   if (!changed || changed.messages) messagesVersion++
-  // Create new state reference to trigger re-renders
   state = { ...state }
   for (const listener of listeners) {
     listener()
+  }
+}
+
+// Coalesced emit for high-frequency message updates. Mutations happen
+// synchronously (so data is never lost), but React is only notified once
+// per animation frame to avoid re-rendering the transcript dozens of
+// times per second during agent streaming.
+let pendingMessageEmit = false
+let pendingAgentEmit = false
+
+function emitMessagesThrottled(agentChanged: boolean): void {
+  if (agentChanged) pendingAgentEmit = true
+
+  if (!pendingMessageEmit) {
+    pendingMessageEmit = true
+    requestAnimationFrame(() => {
+      pendingMessageEmit = false
+      const flags: EmitFlags = { messages: true }
+      if (pendingAgentEmit) {
+        flags.agents = true
+        pendingAgentEmit = false
+      }
+      emit(flags)
+    })
   }
 }
 
@@ -307,6 +328,8 @@ function generateEventSummary(type: string, props: Record<string, unknown>): str
   }
 }
 
+const MAX_EVENT_LOG_ENTRIES = 500
+
 function logEvent(sessionId: string, type: string, props: Record<string, unknown>): void {
   const entries = state.eventLog.get(sessionId) ?? []
   eventCounter += 1
@@ -317,6 +340,10 @@ function logEvent(sessionId: string, type: string, props: Record<string, unknown
     timestamp: Date.now(),
     data: props
   })
+  // Cap the log to prevent unbounded memory growth in long sessions
+  if (entries.length > MAX_EVENT_LOG_ENTRIES) {
+    entries.splice(0, entries.length - MAX_EVENT_LOG_ENTRIES)
+  }
   state.eventLog.set(sessionId, entries)
   eventLogVersion++
 }
@@ -835,10 +862,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
           }
         }
 
-        // This is the hottest event path — fire dozens of times per second while
-        // agents are working. Only flag the collections that actually changed to
-        // avoid invalidating unrelated useMemo hooks (e.g. agents array).
-        emit({ messages: true, agents: agentChanged })
+        emitMessagesThrottled(agentChanged)
       }
       break
     }
@@ -1050,10 +1074,9 @@ function processEvent(payload: OpenCodeEventPayload): void {
     }
 
     case 'server.heartbeat': {
-      // Mark healthy
       if (!state.healthy) {
         state.healthy = true
-        emit()
+        emit({ agents: true })
       }
       break
     }
@@ -1069,7 +1092,7 @@ const RESUME_MESSAGE_LIMIT = 10
 
 function handleAgentLaunched(payload: AgentLaunchedPayload): void {
   upsertAgent(payload)
-  emit()
+  emit({ agents: true })
 
   // Fetch historical messages so resumed sessions aren't blank.
   // Fire-and-forget — the initial upsert already emitted.
@@ -1079,7 +1102,7 @@ function handleAgentLaunched(payload: AgentLaunchedPayload): void {
       const entries = result.data as HistoricalSessionMessage[]
       if (!Array.isArray(entries) || entries.length === 0) return
       hydrateHistoricalMessages(entries.slice(-RESUME_MESSAGE_LIMIT))
-      emit()
+      emit({ messages: true })
     })
   }
 }
@@ -1123,7 +1146,8 @@ function handleSessionReset(payload: { id: string; sessionId: string; oldSession
     agent.status = 'idle'
   }
 
-  emit()
+  // Session reset touches everything
+  emit({ agents: true, messages: true, permissions: true, questions: true })
 }
 
 function removeAgentState(agentId: string): void {
@@ -1269,7 +1293,7 @@ function reconcileStatuses(statuses: AgentStatusesPayload): void {
     changed = true
   }
 
-  if (changed) emit()
+  if (changed) emit({ agents: true })
 }
 
 /**
@@ -1353,7 +1377,7 @@ function reconcileQuestions(
     }
   }
 
-  if (changed) emit()
+  if (changed) emit({ agents: true, questions: true })
 }
 
 // ── Helpers ──
@@ -1521,7 +1545,7 @@ export function useAgentStore() {
         shouldEmit = true
       }
 
-      if (shouldEmit) emit()
+      if (shouldEmit) emit({ agents: true, messages: true })
 
       // Fetch pending questions for agents that are in needs_input state
       try {
@@ -1538,7 +1562,7 @@ export function useAgentStore() {
               })
             }
           }
-          emit()
+          emit({ questions: true })
         }
       } catch {
         // Questions API may not be available on older servers
@@ -1552,7 +1576,7 @@ export function useAgentStore() {
       window.api.onEventError((data) => {
         console.error(`[EventError] Runtime ${data.runtimeId}: ${data.error}`)
         state.healthy = false
-        emit()
+        emit({ agents: true })
       })
     ]
 
@@ -1604,15 +1628,15 @@ export function useAgentStore() {
   // storeState from the render, so the data is always fresh when the memo executes.
   const agents = useMemo(
     () => Array.from(storeState.agents.values()),
-    [agentsVersion] // eslint-disable-line
+    [agentsVersion]
   )
   const permissions = useMemo(
     () => Array.from(storeState.permissions.values()),
-    [permissionsVersion] // eslint-disable-line
+    [permissionsVersion]
   )
   const questions = useMemo(
     () => Array.from(storeState.questions.values()),
-    [questionsVersion] // eslint-disable-line
+    [questionsVersion]
   )
 
   const launchAgent = useCallback(async (directory: string, prompt?: string, title?: string, model?: string, attachments?: MessageAttachment[]) => {
@@ -1683,7 +1707,7 @@ export function useAgentStore() {
       }
     }
 
-    emit()
+    emit({ agents: true, questions: true })
 
     const result = await window.api.sendMessage(agentId, text, agentConfig, attachments)
 
@@ -1700,7 +1724,7 @@ export function useAgentStore() {
       for (const [qId, q] of removedQuestions) {
         state.questions.set(qId, q)
       }
-      emit()
+      emit({ agents: true, questions: true })
     }
 
     return result
@@ -1743,7 +1767,7 @@ export function useAgentStore() {
       agent.blockedSince = undefined
       taskSummaryLocked.add(agentId)
       persistAgentMeta(agentId, { taskSummary: agent.taskSummary, persistedStatus: 'running' })
-      emit()
+      emit({ agents: true })
     }
 
     const result = await window.api.executeCommand(agentId, command, args)
@@ -1755,7 +1779,7 @@ export function useAgentStore() {
         agentAfter.taskSummary = previousSummary ?? agentAfter.taskSummary
         agentAfter.lastActivityAt = Date.now()
         taskSummaryLocked.delete(agentId)
-        emit()
+        emit({ agents: true })
       }
     }
 
@@ -1783,7 +1807,7 @@ export function useAgentStore() {
     agent.lastActivityAt = Date.now()
     agent.blockedSince = undefined
     persistAgentMeta(agentId, { displayName: agent.name, taskSummary: agent.taskSummary })
-    emit()
+    emit({ agents: true })
   }, [])
 
   const respondToPermission = useCallback(async (agentId: string, permissionId: string, response: 'once' | 'always' | 'reject') => {
@@ -1806,7 +1830,7 @@ export function useAgentStore() {
       agent.respondedAt = Date.now()
 
     }
-    emit()
+    emit({ agents: true, permissions: true })
 
     const result = await window.api.respondToPermission(agentId, permissionId, response)
 
@@ -1822,7 +1846,7 @@ export function useAgentStore() {
       if (removedPermission) {
         state.permissions.set(permissionId, removedPermission)
       }
-      emit()
+      emit({ agents: true, permissions: true })
     }
 
     return result
@@ -1846,7 +1870,7 @@ export function useAgentStore() {
       agent.respondedAt = Date.now()
 
     }
-    emit()
+    emit({ agents: true, questions: true })
 
     const result = await window.api.replyToQuestion(agentId, requestId, answers)
 
@@ -1862,7 +1886,7 @@ export function useAgentStore() {
       if (removedQuestion) {
         state.questions.set(requestId, removedQuestion)
       }
-      emit()
+      emit({ agents: true, questions: true })
     }
 
     return result
@@ -1886,7 +1910,7 @@ export function useAgentStore() {
       agent.respondedAt = Date.now()
 
     }
-    emit()
+    emit({ agents: true, questions: true })
 
     const result = await window.api.rejectQuestion(agentId, requestId)
 
@@ -1902,7 +1926,7 @@ export function useAgentStore() {
       if (removedQuestion) {
         state.questions.set(requestId, removedQuestion)
       }
-      emit()
+      emit({ agents: true, questions: true })
     }
 
     return result
@@ -1916,7 +1940,7 @@ export function useAgentStore() {
     if (agent) {
       agent.status = 'stopping'
       agent.lastActivityAt = Date.now()
-      emit()
+      emit({ agents: true })
     }
 
     const result = await window.api.abortAgent(agentId)
@@ -1928,7 +1952,7 @@ export function useAgentStore() {
       if (agentAfter && agentAfter.status === 'stopping') {
         agentAfter.status = 'idle'
         agentAfter.lastActivityAt = Date.now()
-        emit()
+        emit({ agents: true })
       }
     } else {
       // Safety timeout: if the server acknowledged the abort but the SSE event
@@ -1940,7 +1964,7 @@ export function useAgentStore() {
           console.warn(`[AgentStore] Agent ${agentId} stuck in 'stopping' for 10s, forcing idle`)
           agentAfter.status = 'idle'
           agentAfter.lastActivityAt = Date.now()
-          emit()
+          emit({ agents: true })
         }
       }, 10_000)
     }
@@ -1957,7 +1981,7 @@ export function useAgentStore() {
     if (!window.api) return
 
     removeAgentState(agentId)
-    emit()
+    emit({ agents: true, messages: true, permissions: true, questions: true })
 
     // Background cleanup (runtime stop, worktree removal) in main process
     window.api.removeAgent(agentId).then((result) => {
@@ -1978,26 +2002,26 @@ export function useAgentStore() {
 
   const getMessagesForSession = useCallback((sessionId: string): LiveMessage[] => {
     return storeState.messages.get(sessionId) ?? []
-  }, [messagesVersion]) // eslint-disable-line
+  }, [messagesVersion])
 
   const getFileChangesForSession = useCallback((sessionId: string): FileChangeRecord[] => {
     return storeState.fileChanges.get(sessionId) ?? []
-  }, [fileChangesVersion]) // eslint-disable-line
+  }, [fileChangesVersion])
 
   const getEventsForSession = useCallback((sessionId: string): EventLogEntry[] => {
     return storeState.eventLog.get(sessionId) ?? []
-  }, [eventLogVersion]) // eslint-disable-line
+  }, [eventLogVersion])
 
   const getToolCallsForSession = useCallback((sessionId: string): ToolCallInfo[] => {
     const messages = storeState.messages.get(sessionId) ?? []
     return extractToolCallsFromMessages(messages)
-  }, [messagesVersion]) // eslint-disable-line
+  }, [messagesVersion])
 
   const setAgentModel = useCallback((agentId: string, modelPath: string) => {
     const agent = state.agents.get(agentId)
     if (!agent) return
     agent.model = formatModelName(modelPath)
-    emit()
+    emit({ agents: true })
   }, [])
 
   const renameAgent = useCallback((agentId: string, newName: string) => {
@@ -2006,7 +2030,7 @@ export function useAgentStore() {
     agent.name = newName
     agent.autoNamed = false
     persistAgentMeta(agentId, { displayName: newName })
-    emit()
+    emit({ agents: true })
   }, [])
 
   const setLabel = useCallback((agentId: string, label: AgentLabel | null) => {
@@ -2015,7 +2039,7 @@ export function useAgentStore() {
     agent.label = label
     agent.lastActivityAt = Date.now()
     persistAgentMeta(agentId, { persistedStatus: label ?? '' })
-    emit()
+    emit({ agents: true })
   }, [])
 
   return useMemo(() => ({


### PR DESCRIPTION
Throttle message.part.updated emissions via requestAnimationFrame so React is notified at ~60fps instead of on every SSE event during streaming. Add a sliding window to the transcript (last 50 messages rendered by default, load-more button at top). Break the store dependency cascade in App.tsx by destructuring stable callbacks and specific getters. Add explicit EmitFlags to all emit() calls. Wrap Markdown, MessageBubble, ToolGroupBubble, EventLog, ToolsUsage, and FilesChanged in React.memo. Hoist ReactMarkdown config to module scope. Cap event log at 500 entries per session.