### PR TITLE
Consolidate action rail buttons into dropdown menus

### DIFF
--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -15,7 +15,8 @@ import {
   ChatCircleDots,
   Brain,
   PaperPlaneTilt,
-  Paperclip
+  Paperclip,
+  ArrowLineUpRight
 } from '@phosphor-icons/react'
 import type { AgentRuntime, Message, AgentLabel } from '../types'
 import { formatBranchLabel } from '../types'
@@ -28,6 +29,7 @@ import { Markdown } from './Markdown'
 import { FilesChanged } from './FilesChanged'
 import { ToolsUsage } from './ToolsUsage'
 import { EventLog } from './EventLog'
+import { useDismiss } from '../hooks/useDismiss'
 import type { FileChange } from './FilesChanged'
 import type { ToolCall } from './ToolsUsage'
 import type { EventEntry } from './EventLog'
@@ -668,14 +670,22 @@ export const DetailDrawer = memo(function DetailDrawer({
           {onChangeModel && (
             <ActionButton icon={<Brain size={12} />} label="Model" onClick={onChangeModel} />
           )}
-          {agent.prUrl && (
-            <ActionButton icon={<GitPullRequest size={12} />} label="View PR" onClick={() => window.api?.openExternal(agent.prUrl!)} />
-          )}
-          {onCreatePr && (
-            <ActionButton icon={<GitPullRequest size={12} />} label="Create PR" onClick={onCreatePr} />
-          )}
-          <ActionButton icon={<Terminal size={12} />} label="Terminal" onClick={onOpenTerminal} />
-          <ActionButton icon={<ArrowSquareOut size={12} />} label="Editor" onClick={onOpenInEditor} />
+          <ActionDropdownButton
+            icon={<GitPullRequest size={12} />}
+            label="PR"
+            items={[
+              { icon: <GitPullRequest size={12} />, label: 'Create PR', onClick: onCreatePr },
+              { icon: <ArrowLineUpRight size={12} />, label: 'View PR', onClick: agent.prUrl ? () => window.api?.openExternal(agent.prUrl!) : undefined }
+            ]}
+          />
+          <ActionDropdownButton
+            icon={<ArrowSquareOut size={12} />}
+            label="Open In"
+            items={[
+              { icon: <Terminal size={12} />, label: 'Terminal', onClick: onOpenTerminal },
+              { icon: <ArrowSquareOut size={12} />, label: 'Editor', onClick: onOpenInEditor }
+            ]}
+          />
         </div>
 
         {/* Input */}
@@ -1201,6 +1211,71 @@ function ActionButton({
       {icon}
       {label}
     </button>
+  )
+}
+
+interface DropdownItem {
+  icon: React.ReactNode
+  label: string
+  onClick?: () => void
+  disabled?: boolean
+}
+
+function ActionDropdownButton({
+  icon,
+  label,
+  items
+}: {
+  icon: React.ReactNode
+  label: string
+  items: DropdownItem[]
+}) {
+  const { open, toggle, close, containerRef } = useDismiss()
+
+  const visibleItems = items.filter((i) => i.onClick)
+  if (visibleItems.length === 0) return null
+
+  if (visibleItems.length === 1) {
+    const item = visibleItems[0]
+    return (
+      <ActionButton
+        icon={item.icon}
+        label={item.label}
+        onClick={item.onClick}
+        disabled={item.disabled}
+      />
+    )
+  }
+
+  return (
+    <div ref={containerRef} className="relative inline-flex">
+      <button
+        onClick={toggle}
+        className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md border bg-kumo-control border-kumo-line text-kumo-default hover:bg-kumo-fill transition-colors"
+      >
+        {icon}
+        {label}
+        <CaretDown size={10} className="ml-0.5" />
+      </button>
+      {open && (
+        <div className="absolute bottom-full left-0 mb-1 z-[100] min-w-[140px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl">
+          {visibleItems.map((item) => (
+            <button
+              key={item.label}
+              disabled={item.disabled}
+              onClick={() => {
+                item.onClick?.()
+                close()
+              }}
+              className={`flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] rounded transition-colors text-left text-kumo-default hover:bg-kumo-fill ${item.disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+            >
+              {item.icon}
+              {item.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/src/renderer/src/components/LabelDropdown.tsx
+++ b/src/renderer/src/components/LabelDropdown.tsx
@@ -1,4 +1,3 @@
-import { useState, useRef, useEffect } from 'react'
 import {
   CaretDown,
   CheckCircle,
@@ -10,6 +9,7 @@ import {
 } from '@phosphor-icons/react'
 import type { AgentLabel } from '../types'
 import { agentLabelDisplay } from '../types'
+import { useDismiss } from '../hooks/useDismiss'
 
 const LABEL_OPTIONS: { value: AgentLabel | null; label: string; icon: React.ReactNode }[] = [
   { value: null, label: 'None', icon: <XCircle size={12} /> },
@@ -26,35 +26,16 @@ interface LabelDropdownProps {
 }
 
 export function LabelDropdown({ current, onSelect, variant = 'row' }: LabelDropdownProps) {
-  const [open, setOpen] = useState(false)
-  const containerRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!open) return
-    const handleClickOutside = (event: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        setOpen(false)
-      }
-    }
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setOpen(false)
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    document.addEventListener('keydown', handleEscape)
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
-      document.removeEventListener('keydown', handleEscape)
-    }
-  }, [open])
+  const { open, toggle, close, containerRef } = useDismiss()
 
   const selectAndClose = (value: AgentLabel | null) => {
     onSelect(value)
-    setOpen(false)
+    close()
   }
 
-  const toggle = (event: React.MouseEvent) => {
+  const handleToggle = (event: React.MouseEvent) => {
     event.stopPropagation()
-    setOpen(!open)
+    toggle()
   }
 
   const currentLabel = agentLabelDisplay(current)
@@ -67,7 +48,7 @@ export function LabelDropdown({ current, onSelect, variant = 'row' }: LabelDropd
       menuPosition = 'absolute bottom-full left-0 mb-1'
       trigger = (
         <button
-          onClick={toggle}
+          onClick={handleToggle}
           className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md border bg-kumo-control border-kumo-line text-kumo-default hover:bg-kumo-fill transition-colors"
         >
           {LABEL_OPTIONS.find((o) => o.value === current)?.icon}
@@ -81,7 +62,7 @@ export function LabelDropdown({ current, onSelect, variant = 'row' }: LabelDropd
       menuPosition = 'absolute top-full left-0 mt-1'
       trigger = current ? (
         <button
-          onClick={toggle}
+          onClick={handleToggle}
           className="inline-flex items-center px-1.5 py-px rounded text-[10px] font-medium bg-kumo-brand/10 text-kumo-brand hover:bg-kumo-brand/20 transition-colors cursor-pointer"
           title="Change label"
         >
@@ -89,7 +70,7 @@ export function LabelDropdown({ current, onSelect, variant = 'row' }: LabelDropd
         </button>
       ) : (
         <button
-          onClick={toggle}
+          onClick={handleToggle}
           className="inline-flex items-center gap-0.5 px-1 py-px rounded text-[10px] text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill transition-colors cursor-pointer opacity-0 group-hover:opacity-100"
           title="Add label"
         >
@@ -102,7 +83,7 @@ export function LabelDropdown({ current, onSelect, variant = 'row' }: LabelDropd
       menuPosition = 'absolute top-full right-0 mt-1'
       trigger = (
         <button
-          onClick={toggle}
+          onClick={handleToggle}
           className="w-6 h-6 flex items-center justify-center bg-kumo-fill border border-kumo-line rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors cursor-pointer"
           title={`Label: ${currentLabel}`}
         >

--- a/src/renderer/src/hooks/useDismiss.ts
+++ b/src/renderer/src/hooks/useDismiss.ts
@@ -1,0 +1,29 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+
+export function useDismiss<T extends HTMLElement = HTMLDivElement>() {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<T>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleEscape)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleEscape)
+    }
+  }, [open])
+
+  const toggle = useCallback(() => setOpen((prev) => !prev), [])
+  const close = useCallback(() => setOpen(false), [])
+
+  return { open, toggle, close, containerRef } as const
+}


### PR DESCRIPTION
Consolidate View PR / Create PR into a single PR dropdown and Terminal / Editor into an Open In dropdown to reduce action rail clutter. New ActionDropdownButton auto-collapses to a flat button when only one option is available.

Extract shared useDismiss hook for click-outside/escape-key dismiss logic, replacing duplicated code in LabelDropdown and the new dropdown.

<img width="668" height="236" alt="image" src="https://github.com/user-attachments/assets/cca3a2c4-d42e-4768-b552-8db0c9c8e058" />
