### PR TITLE
Add quick launch button for instant agent sessions

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,5 +1,6 @@
 import { ipcMain, dialog, shell } from 'electron'
 import { execFile } from 'child_process'
+import os from 'os'
 import { agentController } from './services/agent-controller'
 import { runtimeManager } from './services/runtime-manager'
 import { workspaceManager } from './services/workspace-manager'
@@ -660,6 +661,10 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle('app:version', () => {
     return { ok: true, data: getAppVersion() }
+  })
+
+  ipcMain.handle('app:home-directory', () => {
+    return { ok: true, data: os.homedir() }
   })
 
   // ── Shell Integration ──

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -184,6 +184,9 @@ const api = {
   getVersion: (): Promise<IpcResult<string>> =>
     ipcRenderer.invoke('app:version'),
 
+  getHomeDirectory: (): Promise<IpcResult<string>> =>
+    ipcRenderer.invoke('app:home-directory'),
+
   // ── Shell Integration ──
   notifyAgentStatus: (agentId: string, status: string, agentName: string, projectName?: string, preview?: string): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:notify-status', agentId, status, agentName, projectName, preview),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -64,6 +64,7 @@ export function App() {
   const [dismissedInterruptIds, setDismissedInterruptIds] = useState<Set<string> | null>(null)
   const [launchCommands, setLaunchCommands] = useState<ChatCommand[]>([])
   const [launchAgentConfigs, setLaunchAgentConfigs] = useState<Array<{ name: string; description?: string }>>([])
+  const [quickLaunching, setQuickLaunching] = useState(false)
 
   const store = useAgentStore()
 
@@ -904,6 +905,30 @@ export function App() {
     }
   }, [store])
 
+  const handleQuickLaunch = useCallback(async () => {
+    if (quickLaunching) return
+    setQuickLaunching(true)
+    try {
+      const homeResult = await window.api.getHomeDirectory()
+      if (!homeResult.ok || !homeResult.data) {
+        console.error('[App] Failed to get home directory:', homeResult.error)
+        return
+      }
+
+      const title = `QuickStart-${Math.random().toString(36).slice(2, 10)}`
+      const result = await store.launchAgent(homeResult.data, undefined, title, 'auto')
+
+      if (!result?.ok || !result.data) return
+
+      const agentId = (result.data as { id: string }).id
+      setSelectedAgentId(agentId)
+    } catch (error) {
+      console.error('[App] Quick launch failed:', error)
+    } finally {
+      setQuickLaunching(false)
+    }
+  }, [store, quickLaunching])
+
   const handleResumeSession = useCallback(async (directory: string, sessionId: string, title: string) => {
     const result = await window.api.resumeAgent({ directory, sessionId, title })
     if (!result?.ok) {
@@ -968,6 +993,14 @@ export function App() {
         event.preventDefault()
         const searchInput = document.querySelector<HTMLInputElement>('input[placeholder="Filter agents..."]')
         searchInput?.focus()
+        return
+      }
+
+      // Q -> quick launch
+      if (event.key === 'q' || event.key === 'Q') {
+        if (!showLaunchModal && !showSettings && !showSessionBrowser) {
+          void handleQuickLaunch()
+        }
         return
       }
 
@@ -1048,7 +1081,7 @@ export function App() {
         return
       }
     },
-    [filteredAgents, selectedAgentId, showLaunchModal, showSettings, showCommandPalette, showSessionBrowser, findPermissionForAgent, store]
+    [filteredAgents, selectedAgentId, showLaunchModal, showSettings, showCommandPalette, showSessionBrowser, findPermissionForAgent, store, handleQuickLaunch]
   )
 
   useEffect(() => {
@@ -1063,6 +1096,8 @@ export function App() {
         blockedCount={counts.blocked}
         idleCount={counts.idle}
         onLaunch={() => setShowLaunchModal(true)}
+        onQuickLaunch={handleQuickLaunch}
+        quickLaunching={quickLaunching}
         onOpenCommandPalette={() => setShowCommandPalette(true)}
         onSettings={() => setShowSettings(true)}
       />

--- a/src/renderer/src/components/TopBar.tsx
+++ b/src/renderer/src/components/TopBar.tsx
@@ -1,10 +1,12 @@
-import { Command, GearSix, Plus } from '@phosphor-icons/react'
+import { CircleNotch, Command, GearSix, Lightning, Plus } from '@phosphor-icons/react'
 
 interface TopBarProps {
   runningCount: number
   blockedCount: number
   idleCount: number
   onLaunch: () => void
+  onQuickLaunch: () => void
+  quickLaunching?: boolean
   onOpenCommandPalette?: () => void
   onSettings?: () => void
 }
@@ -14,6 +16,8 @@ export function TopBar({
   blockedCount,
   idleCount,
   onLaunch,
+  onQuickLaunch,
+  quickLaunching,
   onOpenCommandPalette,
   onSettings,
 }: TopBarProps) {
@@ -56,6 +60,22 @@ export function TopBar({
             <Command size={10} className="inline" />K
           </kbd>
           <span>Command</span>
+        </button>
+        <button
+          type="button"
+          onClick={onQuickLaunch}
+          disabled={quickLaunching}
+          className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border text-xs font-medium transition-colors ${
+            quickLaunching
+              ? 'border-kumo-line text-kumo-subtle cursor-not-allowed'
+              : 'border-kumo-brand text-kumo-brand hover:bg-kumo-brand/10'
+          }`}
+          title="Quick launch — starts in home directory with system model (Q)"
+        >
+          {quickLaunching
+            ? <CircleNotch size={14} className="animate-spin" />
+            : <Lightning size={14} weight="bold" />}
+          {quickLaunching ? 'Starting...' : 'Quick'}
         </button>
         <button
           type="button"

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -76,6 +76,7 @@ export interface OrchestratorApi {
 
   // ── App Info ──
   getVersion: () => Promise<IpcResult<string>>
+  getHomeDirectory: () => Promise<IpcResult<string>>
 
   // ── Shell Integration ──
   notifyAgentStatus: (agentId: string, status: string, agentName: string, projectName?: string, preview?: string) => Promise<IpcResult>


### PR DESCRIPTION
Adds a "Quick" button next to "Launch Agent" in the TopBar that launches an agent in the user's home directory with the system default model and a QuickStart-{randomId} session name. No prompt or worktree needed — the drawer opens immediately.

Includes a loading state with spinner while the runtime spins up, double-click prevention, and a Q keyboard shortcut.