### PR TITLE
Add editable PR links with always-visible PR icon

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -86,7 +86,8 @@ export function App() {
     setAgentModel: storeSetAgentModel,
     executeCommand: storeExecuteCommand,
     setLabel: storeSetLabel,
-    renameAgent: storeRenameAgent
+    renameAgent: storeRenameAgent,
+    setPrUrl: storeSetPrUrl
   } = store
 
   useEffect(() => {
@@ -764,6 +765,10 @@ export function App() {
     if (selectedAgentId) handleSetLabel(selectedAgentId, label)
   }, [selectedAgentId, handleSetLabel])
 
+  const handleDrawerSetPrUrl = useCallback((prUrl: string | null) => {
+    if (selectedAgentId) storeSetPrUrl(selectedAgentId, prUrl)
+  }, [selectedAgentId, storeSetPrUrl])
+
   const handleCreatePr = useCallback(async () => {
     if (!selectedAgentId) return
     const result = await storeSendMessage(selectedAgentId, loadSettings().createPrPrompt, undefined, undefined, 'Create PR')
@@ -1168,6 +1173,7 @@ export function App() {
         onOpenTerminal={handleOpenTerminal}
         onOpenInEditor={handleOpenInEditorForAgent}
         onCreatePr={handleCreatePrForAgent}
+        onSetPrUrl={storeSetPrUrl}
         onChangeModel={(agentId) => {
           setModelPickerAgentId(agentId)
           setShowModelPicker(true)
@@ -1201,8 +1207,9 @@ export function App() {
           onRejectQuestion={selectedQuestion ? handleRejectQuestion : undefined}
           onAbort={handleAbort}
           onRemove={handleDrawerRemove}
-          onCreatePr={handleCreatePr}
-          onOpenInEditor={handleOpenInEditor}
+           onCreatePr={handleCreatePr}
+           onSetPrUrl={handleDrawerSetPrUrl}
+           onOpenInEditor={handleOpenInEditor}
           onChangeModel={handleDrawerChangeModel}
           onOpenTerminal={handleOpenTerminalForDrawer}
           onSetLabel={handleDrawerSetLabel}

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -16,7 +16,8 @@ import {
   Brain,
   PaperPlaneTilt,
   Paperclip,
-  ArrowLineUpRight
+  ArrowLineUpRight,
+  Link
 } from '@phosphor-icons/react'
 import type { AgentRuntime, Message, AgentLabel } from '../types'
 import { formatBranchLabel } from '../types'
@@ -25,6 +26,7 @@ import { loadSettings, SETTINGS_CHANGED_EVENT } from '../data/settings'
 import { useImageAttachments } from '../hooks/useImageAttachments'
 import { StatusBadge } from './StatusBadge'
 import { LabelDropdown } from './LabelDropdown'
+import { TextInputModal } from './TextInputModal'
 import { Markdown } from './Markdown'
 import { FilesChanged } from './FilesChanged'
 import { ToolsUsage } from './ToolsUsage'
@@ -103,6 +105,7 @@ interface DetailDrawerProps {
   onAbort?: () => void
   onRemove?: () => void
   onCreatePr?: () => void
+  onSetPrUrl?: (prUrl: string | null) => void
   onOpenInEditor?: () => void
   onChangeModel?: () => void
   onOpenTerminal?: () => void
@@ -129,6 +132,7 @@ export const DetailDrawer = memo(function DetailDrawer({
   onAbort,
   onRemove,
   onCreatePr,
+  onSetPrUrl,
   onOpenInEditor,
   onChangeModel,
   onOpenTerminal,
@@ -145,6 +149,7 @@ export const DetailDrawer = memo(function DetailDrawer({
   const [commandPickerIndex, setCommandPickerIndex] = useState(0)
   const [cursorPos, setCursorPos] = useState(0)
   const [visibleMessageCount, setVisibleMessageCount] = useState(VISIBLE_MESSAGE_WINDOW)
+  const [showPrLinkModal, setShowPrLinkModal] = useState(false)
 
   // Reset the visible window when switching agents
   const prevAgentIdRef = useRef(agent.id)
@@ -723,8 +728,26 @@ export const DetailDrawer = memo(function DetailDrawer({
             icon={<GitPullRequest size={12} />}
             label="PR"
             items={[
-              { icon: <GitPullRequest size={12} />, label: 'Create PR', onClick: onCreatePr },
-              { icon: <ArrowLineUpRight size={12} />, label: 'View PR', onClick: agent.prUrl ? () => window.api?.openExternal(agent.prUrl!) : undefined }
+              {
+                icon: <ArrowLineUpRight size={12} />,
+                label: 'View PR',
+                onClick: agent.prUrl ? () => window.api?.openExternal(agent.prUrl!) : undefined
+              },
+              {
+                icon: <Link size={12} />,
+                label: agent.prUrl ? 'Edit PR Link' : 'Add PR Link',
+                onClick: onSetPrUrl ? () => setShowPrLinkModal(true) : undefined
+              },
+              {
+                icon: <Trash size={12} />,
+                label: 'Remove PR Link',
+                onClick: agent.prUrl && onSetPrUrl ? () => onSetPrUrl(null) : undefined
+              },
+              {
+                icon: <GitPullRequest size={12} />,
+                label: 'Create PR',
+                onClick: onCreatePr
+              }
             ]}
           />
           <ActionDropdownButton
@@ -875,6 +898,21 @@ export const DetailDrawer = memo(function DetailDrawer({
         </div>
         </div>{/* end bottom pane */}
       </div>
+
+      {showPrLinkModal && onSetPrUrl && (
+        <TextInputModal
+          title={agent.prUrl ? 'Edit PR Link' : 'Add PR Link'}
+          initialValue={agent.prUrl ?? ''}
+          submitLabel="Save"
+          placeholder="https://github.com/org/repo/pull/123"
+          allowEmpty
+          onSubmit={(url) => {
+            onSetPrUrl(url || null)
+            setShowPrLinkModal(false)
+          }}
+          onClose={() => setShowPrLinkModal(false)}
+        />
+      )}
     </div>
   )
 })

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -12,13 +12,15 @@ import {
   Trash,
   Terminal,
   GitPullRequest,
-  ArrowSquareOut
+  ArrowSquareOut,
+  Link,
+  ArrowLineUpRight
 } from '@phosphor-icons/react'
 import type { AgentRuntime, AgentLabel } from '../types'
 import { formatBranchLabel, isUrgent } from '../types'
 import { StatusBadge } from './StatusBadge'
-import { PrBadge } from './PrBadge'
 import { LabelDropdown } from './LabelDropdown'
+import { TextInputModal } from './TextInputModal'
 import { useDismiss } from '../hooks/useDismiss'
 
 interface FleetTableProps {
@@ -35,6 +37,7 @@ interface FleetTableProps {
   onOpenTerminal?: (agentId: string) => void
   onOpenInEditor?: (agentId: string) => void
   onCreatePr?: (agentId: string) => void
+  onSetPrUrl?: (agentId: string, prUrl: string | null) => void
   onChangeModel?: (agentId: string) => void
   onSetLabel?: (agentId: string, label: AgentLabel | null) => void
 }
@@ -61,6 +64,11 @@ interface RenameState {
   currentName: string
 }
 
+interface PrLinkState {
+  agentId: string
+  currentUrl: string
+}
+
 export function FleetTable({
   agents,
   selectedId,
@@ -75,6 +83,7 @@ export function FleetTable({
   onOpenTerminal,
   onOpenInEditor,
   onCreatePr,
+  onSetPrUrl,
   onChangeModel,
   onSetLabel
 }: FleetTableProps) {
@@ -82,6 +91,7 @@ export function FleetTable({
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
   const [renameState, setRenameState] = useState<RenameState | null>(null)
+  const [prLinkState, setPrLinkState] = useState<PrLinkState | null>(null)
   const [inlineEditId, setInlineEditId] = useState<string | null>(null)
 
   const handleSort = useCallback((column: SortColumn) => {
@@ -196,6 +206,7 @@ export function FleetTable({
               onRemove={onRemove ? () => onRemove(agent.id) : undefined}
               onChangeModel={onChangeModel ? () => onChangeModel(agent.id) : undefined}
               onSetLabel={onSetLabel ? (label: AgentLabel | null) => onSetLabel(agent.id, label) : undefined}
+              onEditPrLink={() => setPrLinkState({ agentId: agent.id, currentUrl: agent.prUrl ?? '' })}
               onOpenTerminal={onOpenTerminal ? () => onOpenTerminal(agent.id) : undefined}
               onOpenInEditor={onOpenInEditor ? () => onOpenInEditor(agent.id) : undefined}
               isInlineEditing={inlineEditId === agent.id}
@@ -249,6 +260,15 @@ export function FleetTable({
             onCreatePr?.(contextMenu.agentId)
             closeContextMenu()
           }}
+          onRemovePrLink={() => {
+            onSetPrUrl?.(contextMenu.agentId, null)
+            closeContextMenu()
+          }}
+          onEditPrLink={() => {
+            const agent = agents.find((agnt) => agnt.id === contextMenu.agentId)
+            setPrLinkState({ agentId: contextMenu.agentId, currentUrl: agent?.prUrl ?? '' })
+            closeContextMenu()
+          }}
           onSetLabel={(label: AgentLabel | null) => {
             onSetLabel?.(contextMenu.agentId, label)
             closeContextMenu()
@@ -257,8 +277,10 @@ export function FleetTable({
       )}
 
       {renameState && (
-        <RenameModal
-          currentName={renameState.currentName}
+        <TextInputModal
+          title="Rename Agent"
+          initialValue={renameState.currentName}
+          submitLabel="Rename"
           onSubmit={(newName) => {
             onRename?.(renameState.agentId, newName)
             setRenameState(null)
@@ -266,77 +288,21 @@ export function FleetTable({
           onClose={() => setRenameState(null)}
         />
       )}
-    </div>
-  )
-}
 
-function RenameModal({
-  currentName,
-  onSubmit,
-  onClose
-}: {
-  currentName: string
-  onSubmit: (newName: string) => void
-  onClose: () => void
-}) {
-  const [value, setValue] = useState(currentName)
-  const inputRef = useRef<HTMLInputElement>(null)
-
-  useEffect(() => {
-    inputRef.current?.focus()
-    inputRef.current?.select()
-  }, [])
-
-  const handleSubmit = () => {
-    const trimmed = value.trim()
-    if (trimmed) {
-      onSubmit(trimmed)
-    }
-  }
-
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter') {
-      event.preventDefault()
-      handleSubmit()
-    } else if (event.key === 'Escape') {
-      event.preventDefault()
-      onClose()
-    }
-  }
-
-  return (
-    <div
-      className="fixed inset-0 z-[200] flex items-center justify-center bg-black/40"
-      onClick={onClose}
-    >
-      <div
-        className="w-80 rounded-lg border border-kumo-line bg-kumo-elevated p-4 shadow-xl"
-        onClick={(event) => event.stopPropagation()}
-      >
-        <div className="text-sm font-semibold text-kumo-strong mb-3">Rename Agent</div>
-        <input
-          ref={inputRef}
-          value={value}
-          onChange={(event) => setValue(event.target.value)}
-          onKeyDown={handleKeyDown}
-          className="w-full px-2.5 py-1.5 bg-kumo-control border border-kumo-line rounded-md text-sm text-kumo-default outline-none focus:border-kumo-ring"
+      {prLinkState && (
+        <TextInputModal
+          title={prLinkState.currentUrl ? 'Edit PR Link' : 'Add PR Link'}
+          initialValue={prLinkState.currentUrl}
+          submitLabel="Save"
+          placeholder="https://github.com/org/repo/pull/123"
+          allowEmpty
+          onSubmit={(url) => {
+            onSetPrUrl?.(prLinkState.agentId, url || null)
+            setPrLinkState(null)
+          }}
+          onClose={() => setPrLinkState(null)}
         />
-        <div className="flex justify-end gap-2 mt-3">
-          <button
-            onClick={onClose}
-            className="px-3 py-1.5 text-xs font-medium rounded-md border border-kumo-line text-kumo-default hover:bg-kumo-fill transition-colors"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleSubmit}
-            disabled={!value.trim()}
-            className="px-3 py-1.5 text-xs font-medium rounded-md bg-kumo-brand text-white hover:bg-kumo-brand-hover transition-colors disabled:opacity-40"
-          >
-            Rename
-          </button>
-        </div>
-      </div>
+      )}
     </div>
   )
 }
@@ -354,6 +320,8 @@ function ContextMenu({
   onOpenTerminal,
   onOpenInEditor,
   onCreatePr,
+  onRemovePrLink,
+  onEditPrLink,
   onSetLabel
 }: {
   agent: AgentRuntime
@@ -368,6 +336,8 @@ function ContextMenu({
   onOpenTerminal: () => void
   onOpenInEditor: () => void
   onCreatePr: () => void
+  onRemovePrLink: () => void
+  onEditPrLink: () => void
   onSetLabel: (label: AgentLabel | null) => void
 }) {
   const menuRef = useRef<HTMLDivElement>(null)
@@ -433,7 +403,15 @@ function ContextMenu({
       )}
       {agent.prUrl && (
         <button className={itemClass} onClick={() => window.api?.openExternal(agent.prUrl!)}>
-          <GitPullRequest size={13} /> View PR
+          <ArrowLineUpRight size={13} /> View PR
+        </button>
+      )}
+      <button className={itemClass} onClick={onEditPrLink}>
+        <Link size={13} /> {agent.prUrl ? 'Edit' : 'Add'} PR Link
+      </button>
+      {agent.prUrl && (
+        <button className={itemClass} onClick={onRemovePrLink}>
+          <Trash size={13} /> Remove PR Link
         </button>
       )}
       <button className={itemClass} onClick={onCreatePr}>
@@ -478,6 +456,7 @@ function AgentRow({
   onRemove,
   onChangeModel,
   onSetLabel,
+  onEditPrLink,
   onOpenTerminal,
   onOpenInEditor,
   isInlineEditing,
@@ -496,6 +475,7 @@ function AgentRow({
   onRemove?: () => void
   onChangeModel?: () => void
   onSetLabel?: (label: AgentLabel | null) => void
+  onEditPrLink?: () => void
   onOpenTerminal?: () => void
   onOpenInEditor?: () => void
   isInlineEditing: boolean
@@ -603,10 +583,7 @@ function AgentRow({
         {agent.taskSummary}
       </td>
       <td className="px-3 py-2 font-mono text-[11px] text-kumo-subtle">
-        <div className="flex items-center gap-1.5">
-          <span className="truncate">{formatBranchLabel(agent)}</span>
-          {agent.prUrl && <PrBadge url={agent.prUrl} stopPropagation />}
-        </div>
+        <span className="truncate">{formatBranchLabel(agent)}</span>
       </td>
       <td className="px-3 py-2 min-w-[7rem] max-w-[10rem]">
         {agent.model && agent.model !== 'starting...' && (
@@ -628,6 +605,23 @@ function AgentRow({
             onStop={onStop}
             onRemove={onRemove}
           />
+          {agent.prUrl ? (
+            <button
+              onClick={(event) => { event.stopPropagation(); window.api?.openExternal(agent.prUrl!) }}
+              className="w-6 h-6 flex items-center justify-center rounded text-kumo-brand hover:bg-kumo-brand/20 transition-colors cursor-pointer"
+              title={agent.prUrl}
+            >
+              <GitPullRequest size={13} weight="bold" />
+            </button>
+          ) : (
+            <button
+              onClick={(event) => { event.stopPropagation(); onEditPrLink?.() }}
+              className="w-6 h-6 flex items-center justify-center rounded text-kumo-subtle/40 hover:text-kumo-subtle hover:bg-kumo-fill transition-colors cursor-pointer"
+              title="Add PR link"
+            >
+              <GitPullRequest size={13} />
+            </button>
+          )}
           <button
             onClick={(event) => { event.stopPropagation(); onContextMenu(event) }}
             className="w-6 h-6 flex items-center justify-center rounded text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill transition-colors cursor-pointer"

--- a/src/renderer/src/components/TextInputModal.tsx
+++ b/src/renderer/src/components/TextInputModal.tsx
@@ -1,0 +1,82 @@
+import { useState, useEffect, useRef } from 'react'
+
+interface TextInputModalProps {
+  title: string
+  initialValue?: string
+  submitLabel?: string
+  placeholder?: string
+  allowEmpty?: boolean
+  onSubmit: (value: string) => void
+  onClose: () => void
+}
+
+export function TextInputModal({
+  title,
+  initialValue = '',
+  submitLabel = 'Save',
+  placeholder,
+  allowEmpty = false,
+  onSubmit,
+  onClose
+}: TextInputModalProps) {
+  const [value, setValue] = useState(initialValue)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    inputRef.current?.focus()
+    inputRef.current?.select()
+  }, [])
+
+  const canSubmit = allowEmpty || !!value.trim()
+
+  const handleSubmit = () => {
+    if (canSubmit) onSubmit(value.trim())
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      handleSubmit()
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      onClose()
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[200] flex items-center justify-center bg-black/40"
+      onClick={onClose}
+    >
+      <div
+        className="w-80 rounded-lg border border-kumo-line bg-kumo-elevated p-4 shadow-xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="text-sm font-semibold text-kumo-strong mb-3">{title}</div>
+        <input
+          ref={inputRef}
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className="w-full px-2.5 py-1.5 bg-kumo-control border border-kumo-line rounded-md text-sm text-kumo-default outline-none focus:border-kumo-ring"
+        />
+        <div className="flex justify-end gap-2 mt-3">
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs font-medium rounded-md border border-kumo-line text-kumo-default hover:bg-kumo-fill transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="px-3 py-1.5 text-xs font-medium rounded-md bg-kumo-brand text-white hover:bg-kumo-brand-hover transition-colors disabled:opacity-40"
+          >
+            {submitLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -2059,6 +2059,14 @@ export function useAgentStore() {
     emit({ agents: true })
   }, [])
 
+  const setPrUrl = useCallback((agentId: string, prUrl: string | null) => {
+    const agent = state.agents.get(agentId)
+    if (!agent) return
+    agent.prUrl = prUrl
+    persistAgentMeta(agentId, { prUrl: prUrl ?? '' })
+    emit({ agents: true })
+  }, [])
+
   return useMemo(() => ({
     agents,
     permissions,
@@ -2079,6 +2087,7 @@ export function useAgentStore() {
     renameAgent,
     setAgentModel,
     setLabel,
+    setPrUrl,
     selectDirectory,
     getMessagesForSession,
     getFileChangesForSession,
@@ -2090,7 +2099,7 @@ export function useAgentStore() {
     executeCommand, prepareFreshAgent, resetSession,
     respondToPermission, replyToQuestion, rejectQuestion,
     abortAgent, removeAgent, renameAgent, setAgentModel,
-    setLabel, selectDirectory,
+    setLabel, setPrUrl, selectDirectory,
     getMessagesForSession, getFileChangesForSession,
     getEventsForSession, getToolCallsForSession
   ])


### PR DESCRIPTION
PR links can now be manually added, edited, and removed. Previously they could only be auto-extracted from the Create PR agent flow.

- PR icon always visible in actions column — branded when link exists (clicks to open), subtle when empty (clicks to add)
- Context menu and detail drawer PR dropdown include View, Edit/Add Link, Remove Link, and Create PR actions
- Extract TextInputModal from RenameModal for reuse across rename and PR link entry (replaces window.prompt which is blocked in Electron)
- Add setPrUrl to agent store for manual PR URL persistence