### PR TITLE
Persist filter state and search query across restarts, fix PR link restoration

### DIFF
--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -129,6 +129,7 @@ class AgentController {
           displayName: persistedAgent.displayName ?? '',
           taskSummary: persistedAgent.taskSummary ?? '',
           persistedStatus: persistedAgent.persistedStatus,
+          prUrl: persistedAgent.prUrl,
           bridge: this.bridges.get(runtime.id)!
         }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import { TopBar } from './components/TopBar'
 import { InterruptBanner } from './components/InterruptBanner'
-import { FilterBar, matchesFilter, EMPTY_FILTER, cycleFilter, type FilterState, type StatusFilter } from './components/FilterBar'
+import { FilterBar, matchesFilter, EMPTY_FILTER, cycleFilter, loadPersistedFilter, persistFilter, loadPersistedSearch, persistSearch, type FilterState, type StatusFilter } from './components/FilterBar'
 import { FleetTable } from './components/FleetTable'
 import { StatusBar } from './components/StatusBar'
 import { DetailDrawer, type ChatCommand } from './components/DetailDrawer'
@@ -43,8 +43,22 @@ function mapToolState(toolState?: string): ToolCall['state'] {
 }
 
 export function App() {
-  const [filter, setFilter] = useState<FilterState>(EMPTY_FILTER)
-  const [searchQuery, setSearchQuery] = useState('')
+  const [filter, setFilterRaw] = useState<FilterState>(loadPersistedFilter)
+  const [searchQuery, setSearchQueryRaw] = useState(loadPersistedSearch)
+
+  const setFilter = useCallback((value: FilterState | ((prev: FilterState) => FilterState)) => {
+    setFilterRaw((prev) => {
+      const next = typeof value === 'function' ? value(prev) : value
+      persistFilter(next)
+      return next
+    })
+  }, [])
+
+  const setSearchQuery = useCallback((value: string) => {
+    setSearchQueryRaw(value)
+    persistSearch(value)
+  }, [])
+
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
   const [showLaunchModal, setShowLaunchModal] = useState(false)
   const [showSettings, setShowSettings] = useState(false)

--- a/src/renderer/src/components/FilterBar.tsx
+++ b/src/renderer/src/components/FilterBar.tsx
@@ -24,6 +24,68 @@ export const EMPTY_FILTER: FilterState = {
   excludeProjects: new Set()
 }
 
+const FILTER_STORAGE_KEY = 'oc-orchestrator:filter'
+const SEARCH_STORAGE_KEY = 'oc-orchestrator:search'
+
+interface SerializedFilterState {
+  statuses: StatusFilter[]
+  labels: LabelFilter[]
+  projects: string[]
+  excludeStatuses: StatusFilter[]
+  excludeLabels: LabelFilter[]
+  excludeProjects: string[]
+}
+
+function serializeFilter(filter: FilterState): string {
+  const obj: SerializedFilterState = {
+    statuses: [...filter.statuses],
+    labels: [...filter.labels],
+    projects: [...filter.projects],
+    excludeStatuses: [...filter.excludeStatuses],
+    excludeLabels: [...filter.excludeLabels],
+    excludeProjects: [...filter.excludeProjects]
+  }
+  return JSON.stringify(obj)
+}
+
+function deserializeFilter(json: string): FilterState {
+  const obj = JSON.parse(json) as SerializedFilterState
+  return {
+    statuses: new Set(obj.statuses ?? []),
+    labels: new Set(obj.labels ?? []),
+    projects: new Set(obj.projects ?? []),
+    excludeStatuses: new Set(obj.excludeStatuses ?? []),
+    excludeLabels: new Set(obj.excludeLabels ?? []),
+    excludeProjects: new Set(obj.excludeProjects ?? [])
+  }
+}
+
+export function loadPersistedFilter(): FilterState {
+  try {
+    const stored = localStorage.getItem(FILTER_STORAGE_KEY)
+    if (!stored) return EMPTY_FILTER
+    return deserializeFilter(stored)
+  } catch {
+    return EMPTY_FILTER
+  }
+}
+
+export function persistFilter(filter: FilterState): void {
+  localStorage.setItem(FILTER_STORAGE_KEY, serializeFilter(filter))
+}
+
+export function loadPersistedSearch(): string {
+  try {
+    return localStorage.getItem(SEARCH_STORAGE_KEY) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+export function persistSearch(query: string): void {
+  localStorage.setItem(SEARCH_STORAGE_KEY, query)
+}
+
 export function isFilterEmpty(filter: FilterState): boolean {
   return (
     filter.statuses.size === 0 &&


### PR DESCRIPTION
Filter and search state was lost on every app restart because it was held purely in React useState. Serialize FilterState (Set-based) to localStorage on every change and restore on mount, matching the existing settings pattern.

Also fix PR links not surviving restarts — prUrl was already persisted in the active_agents preference but was not assigned to the AgentHandle during restorePersistedAgents().