### PR TITLE
Fix markdown table overflow in transcript view

### DIFF
--- a/src/renderer/src/app.css
+++ b/src/renderer/src/app.css
@@ -209,7 +209,8 @@ body {
 
 .markdown-body table {
   border-collapse: collapse;
-  width: 100%;
+  width: max-content;
+  min-width: 100%;
   margin: 0.5em 0;
   font-size: 0.9em;
 }

--- a/src/renderer/src/components/Markdown.tsx
+++ b/src/renderer/src/components/Markdown.tsx
@@ -23,11 +23,19 @@ function ExternalLink({ href, children, ...props }: ComponentPropsWithoutRef<'a'
   )
 }
 
+function ScrollableTable({ children, ...props }: ComponentPropsWithoutRef<'table'>) {
+  return (
+    <div className="overflow-x-auto">
+      <table {...props}>{children}</table>
+    </div>
+  )
+}
+
 // Hoist to module scope — stable references prevent ReactMarkdown from
 // re-parsing markdown on every render due to referential inequality.
 const REMARK_PLUGINS = [remarkGfm]
 const DISALLOWED_ELEMENTS = ['script', 'iframe', 'object', 'embed', 'form']
-const COMPONENTS = { a: ExternalLink }
+const COMPONENTS = { a: ExternalLink, table: ScrollableTable }
 
 export const Markdown = memo(function Markdown({ children, className }: MarkdownProps) {
   return (


### PR DESCRIPTION
Wrap table elements in a scrollable container so wide tables get a horizontal scrollbar instead of overflowing the message bubble. Adjust table width to use max-content with min-width 100% so tables expand naturally beyond the container when needed.