### PR TITLE
Fix favicon image path in TopBar by importing as module

### DIFF
--- a/src/renderer/src/components/TopBar.tsx
+++ b/src/renderer/src/components/TopBar.tsx
@@ -1,4 +1,5 @@
 import { CircleNotch, Command, GearSix, Lightning, Plus } from '@phosphor-icons/react'
+import favicon from '../../public/favicon.svg'
 
 interface TopBarProps {
   runningCount: number
@@ -26,7 +27,7 @@ export function TopBar({
       {/* Left: Logo + Settings */}
       <div className="no-drag flex items-center gap-3">
         <div className="flex items-center gap-2">
-          <img src="/favicon.svg" alt="" className="w-5 h-5" />
+          <img src={favicon} alt="" className="w-5 h-5" />
           <span className="font-bold text-sm text-kumo-strong">OC Orchestrator</span>
         </div>
         {onSettings && (


### PR DESCRIPTION
Fixes the broken image icon displayed next to "OC Orchestrator" in the title bar.

Problem: The favicon was referenced using an absolute path /favicon.svg, which doesn't work in Electron apps since they run on the file:// protocol rather than a web server. This caused the image to fail to load and display a broken image placeholder.

Solution: Import the SVG as a module so Vite properly bundles and resolves the asset path:

Added import favicon from '../../public/favicon.svg'
Changed <img src="/favicon.svg" ... /> to <img src={favicon} ... />
Testing:

 Type check passes (npm run typecheck:web)
 Build succeeds (npm run build)
 Favicon displays correctly in dev mode