### PR TITLE
Add custom labels with user-defined names and colors

### DIFF
--- a/src/__tests__/filter-sort.test.ts
+++ b/src/__tests__/filter-sort.test.ts
@@ -13,10 +13,8 @@ type AgentStatus =
   | 'disconnected'
   | 'stopping'
 
-type AgentLabel = 'in_review' | 'blocked' | 'done' | 'draft'
-
 type StatusFilter = 'blocked' | 'running' | 'idle' | 'errored' | 'completed'
-type LabelFilter = AgentLabel
+type LabelFilter = string
 type FilterMode = 'include' | 'exclude'
 
 interface FilterState {
@@ -35,7 +33,7 @@ interface AgentRow {
   branchName: string
   taskSummary: string
   status: AgentStatus
-  label: AgentLabel | null
+  labelId: string | null
   model: string
   lastActivityAt: number
 }
@@ -70,19 +68,19 @@ function expandStatuses(filters: Set<StatusFilter>): Set<AgentStatus> {
 }
 
 function matchesFilter(
-  agent: { status: AgentStatus; label: AgentLabel | null; projectName: string },
+  agent: { status: AgentStatus; labelId: string | null; projectName: string },
   filter: FilterState
 ): boolean {
   if (isFilterEmpty(filter)) return true
 
   // Exclude filters: reject if agent matches any excluded value
   if (filter.excludeStatuses.size > 0 && expandStatuses(filter.excludeStatuses).has(agent.status)) return false
-  if (filter.excludeLabels.size > 0 && agent.label && filter.excludeLabels.has(agent.label)) return false
+  if (filter.excludeLabels.size > 0 && agent.labelId && filter.excludeLabels.has(agent.labelId)) return false
   if (filter.excludeProjects.size > 0 && filter.excludeProjects.has(agent.projectName)) return false
 
   // Include filters: agent must match at least one value in each active include dimension
   if (filter.statuses.size > 0 && !expandStatuses(filter.statuses).has(agent.status)) return false
-  if (filter.labels.size > 0 && (!agent.label || !filter.labels.has(agent.label))) return false
+  if (filter.labels.size > 0 && (!agent.labelId || !filter.labels.has(agent.labelId))) return false
   if (filter.projects.size > 0 && !filter.projects.has(agent.projectName)) return false
 
   return true
@@ -124,7 +122,7 @@ function isBlocked(status: AgentStatus): boolean {
 }
 
 function isUrgent(agent: AgentRow): boolean {
-  return isBlocked(agent.status) || agent.status === 'errored' || agent.label === 'blocked'
+  return isBlocked(agent.status) || agent.status === 'errored' || agent.labelId === 'blocked'
 }
 
 function compareAgents(
@@ -182,7 +180,7 @@ function createAgent(overrides: Partial<AgentRow> = {}): AgentRow {
     branchName: 'main',
     taskSummary: 'Fix the login bug',
     status: 'running',
-    label: null,
+    labelId: null,
     model: 'sonnet-4',
     lastActivityAt: Date.now(),
     ...overrides
@@ -231,120 +229,120 @@ describe('matchesFilter', () => {
       'idle', 'completed', 'errored', 'disconnected', 'stopping'
     ]
     for (const status of statuses) {
-      expect(matchesFilter({ status, label: null, projectName: 'proj' }, EMPTY)).toBe(true)
+      expect(matchesFilter({ status, labelId: null, projectName: 'proj' }, EMPTY)).toBe(true)
     }
   })
 
   it('returns true for "blocked" status filter when needs_input or needs_approval', () => {
     const filter = statusFilter('blocked')
-    expect(matchesFilter({ status: 'needs_input', label: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'needs_approval', label: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'idle', label: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'errored', label: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'completed', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'needs_input', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'needs_approval', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'errored', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('returns true for "running" status filter only when running', () => {
     const filter = statusFilter('running')
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', label: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'needs_input', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'needs_input', labelId: null, projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('returns true for "idle" status filter only when idle', () => {
     const filter = statusFilter('idle')
-    expect(matchesFilter({ status: 'idle', label: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'completed', label: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'errored', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'errored', labelId: null, projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('returns true for "errored" status filter only when errored', () => {
     const filter = statusFilter('errored')
-    expect(matchesFilter({ status: 'errored', label: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'idle', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'errored', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('returns true for "completed" status filter when completed', () => {
     const filter = statusFilter('completed')
-    expect(matchesFilter({ status: 'completed', label: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', label: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'errored', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'errored', labelId: null, projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('matches by project name when project filter is set', () => {
     const filter = projectFilter('my-app')
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'my-app' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'other-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'other-app' }, filter)).toBe(false)
   })
 
   // ── Multi-select tests ──
 
   it('allows multiple statuses to be selected simultaneously', () => {
     const filter = statusFilter('running', 'idle')
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', label: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'completed', label: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'needs_input', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'needs_input', labelId: null, projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('allows multiple projects to be selected simultaneously', () => {
     const filter = projectFilter('app-a', 'app-b')
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'app-a' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'app-b' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'app-c' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'app-a' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'app-b' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'app-c' }, filter)).toBe(false)
   })
 
   it('combines status AND project filters (both must match)', () => {
     const filter = combinedFilter(['running'], ['my-app'])
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'my-app' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'other-app' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'idle', label: null, projectName: 'my-app' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'idle', label: null, projectName: 'other-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'other-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'my-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'other-app' }, filter)).toBe(false)
   })
 
   it('combines multiple statuses AND multiple projects', () => {
     const filter = combinedFilter(['running', 'blocked'], ['app-a', 'app-b'])
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'app-a' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'needs_input', label: null, projectName: 'app-b' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'needs_approval', label: null, projectName: 'app-a' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', label: null, projectName: 'app-a' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'app-c' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'app-a' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'needs_input', labelId: null, projectName: 'app-b' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'needs_approval', labelId: null, projectName: 'app-a' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'app-a' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'app-c' }, filter)).toBe(false)
   })
 
   it('status-only filter does not restrict by project', () => {
     const filter = statusFilter('running')
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'any-project' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'another-project' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'any-project' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'another-project' }, filter)).toBe(true)
   })
 
   it('project-only filter does not restrict by status', () => {
     const filter = projectFilter('my-app')
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'my-app' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', label: null, projectName: 'my-app' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'errored', label: null, projectName: 'my-app' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'completed', label: null, projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'errored', labelId: null, projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'my-app' }, filter)).toBe(true)
   })
 })
 
 describe('label filters', () => {
   it('matches agents with a specific label', () => {
     const filter = labelFilter('in_review')
-    expect(matchesFilter({ status: 'running', label: 'in_review', projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', label: 'in_review', projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', label: 'done', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: 'in_review', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelId: 'in_review', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: 'done', projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('matches multiple labels', () => {
     const filter = labelFilter('in_review', 'draft')
-    expect(matchesFilter({ status: 'running', label: 'in_review', projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', label: 'draft', projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', label: 'done', projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: 'in_review', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: 'draft', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: 'done', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('combines status AND label filters', () => {
@@ -353,52 +351,52 @@ describe('label filters', () => {
       statuses: new Set<StatusFilter>(['running']),
       labels: new Set<LabelFilter>(['in_review'])
     }
-    expect(matchesFilter({ status: 'running', label: 'in_review', projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', label: 'in_review', projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: 'in_review', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelId: 'in_review', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('label filter does not affect agents without labels when not filtering by label', () => {
     const filter = statusFilter('running')
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', label: 'done', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: 'done', projectName: 'proj' }, filter)).toBe(true)
   })
 })
 
 describe('negative (exclude) filters', () => {
   it('excludes agents matching an excluded status', () => {
     const filter = excludeStatusFilter('completed')
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', label: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'completed', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('excludes agents matching excluded "blocked" status (needs_input + needs_approval)', () => {
     const filter = excludeStatusFilter('blocked')
-    expect(matchesFilter({ status: 'needs_input', label: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'needs_approval', label: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', label: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'needs_input', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'needs_approval', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(true)
   })
 
   it('excludes agents matching multiple excluded statuses', () => {
     const filter: FilterState = { ...EMPTY, excludeStatuses: new Set<StatusFilter>(['completed', 'errored']) }
-    expect(matchesFilter({ status: 'completed', label: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'errored', label: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'errored', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
   })
 
   it('excludes agents matching an excluded label', () => {
     const filter = excludeLabelFilter('done')
-    expect(matchesFilter({ status: 'running', label: 'done', projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', label: 'in_review', projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: 'done', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: 'in_review', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
   })
 
   it('excludes agents matching an excluded project', () => {
     const filter = excludeProjectFilter('my-app')
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'my-app' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'other-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'my-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'other-app' }, filter)).toBe(true)
   })
 
   it('combines include status + exclude status (e.g. running but not errored)', () => {
@@ -407,9 +405,9 @@ describe('negative (exclude) filters', () => {
       statuses: new Set<StatusFilter>(['running', 'errored']),
       excludeStatuses: new Set<StatusFilter>(['errored'])
     }
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'errored', label: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'idle', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'errored', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('exclude takes precedence over include for same dimension', () => {
@@ -419,7 +417,7 @@ describe('negative (exclude) filters', () => {
       statuses: new Set<StatusFilter>(['running']),
       excludeStatuses: new Set<StatusFilter>(['running'])
     }
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('combines exclude status with include project', () => {
@@ -428,9 +426,9 @@ describe('negative (exclude) filters', () => {
       excludeStatuses: new Set<StatusFilter>(['completed']),
       projects: new Set(['my-app'])
     }
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'my-app' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'completed', label: null, projectName: 'my-app' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'other-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'my-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'other-app' }, filter)).toBe(false)
   })
 
   it('combines include status with exclude project', () => {
@@ -439,9 +437,9 @@ describe('negative (exclude) filters', () => {
       statuses: new Set<StatusFilter>(['running']),
       excludeProjects: new Set(['my-app'])
     }
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'other-app' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'my-app' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'idle', label: null, projectName: 'other-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'other-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'my-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'other-app' }, filter)).toBe(false)
   })
 
   it('combines exclude label with include status', () => {
@@ -450,25 +448,25 @@ describe('negative (exclude) filters', () => {
       statuses: new Set<StatusFilter>(['running']),
       excludeLabels: new Set<LabelFilter>(['done'])
     }
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', label: 'in_review', projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', label: 'done', projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'idle', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: 'in_review', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: 'done', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('excludes multiple projects', () => {
     const filter = excludeProjectFilter('app-a', 'app-b')
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'app-a' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'app-b' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'app-c' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'app-a' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'app-b' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'app-c' }, filter)).toBe(true)
   })
 
   it('exclude-only filter still passes agents not matching the exclusion', () => {
     const filter = excludeStatusFilter('idle')
-    expect(matchesFilter({ status: 'running', label: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'completed', label: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'errored', label: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', label: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'errored', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(false)
   })
 })
 
@@ -698,7 +696,7 @@ describe('sortUrgentFirst', () => {
 
   it('does not treat "done" label as urgent', () => {
     const running = createAgent({ id: 'r', status: 'running' })
-    const done = createAgent({ id: 'm', status: 'idle', label: 'done' })
+    const done = createAgent({ id: 'm', status: 'idle', labelId: 'done' })
     const blocked = createAgent({ id: 'b', status: 'needs_input' })
     const sorted = sortUrgentFirst([done, running, blocked])
     expect(sorted[0].id).toBe('b')
@@ -706,7 +704,7 @@ describe('sortUrgentFirst', () => {
 
   it('does not treat in_review label as urgent', () => {
     const running = createAgent({ id: 'r', status: 'running' })
-    const review = createAgent({ id: 'rv', status: 'idle', label: 'in_review' })
+    const review = createAgent({ id: 'rv', status: 'idle', labelId: 'in_review' })
     const blocked = createAgent({ id: 'b', status: 'needs_input' })
     const sorted = sortUrgentFirst([review, running, blocked])
     expect(sorted[0].id).toBe('b')
@@ -714,7 +712,7 @@ describe('sortUrgentFirst', () => {
 
   it('treats "blocked" label as urgent', () => {
     const running = createAgent({ id: 'r', status: 'running' })
-    const blockedLabel = createAgent({ id: 'bm', status: 'idle', label: 'blocked' })
+    const blockedLabel = createAgent({ id: 'bm', status: 'idle', labelId: 'blocked' })
     const idle = createAgent({ id: 'i', status: 'idle' })
     const sorted = sortUrgentFirst([idle, running, blockedLabel])
     expect(sorted[0].id).toBe('bm')

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -336,12 +336,13 @@ export function registerIpcHandlers(): void {
         displayName: agent.displayName,
         taskSummary: agent.taskSummary,
         persistedStatus: agent.persistedStatus,
+        labelId: agent.labelId,
         prUrl: agent.prUrl
       }))
     }
   })
 
-  ipcMain.handle('agent:update-meta', async (_event, agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; prUrl?: string }) => {
+  ipcMain.handle('agent:update-meta', async (_event, agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelId?: string; prUrl?: string }) => {
     try {
       agentController.updateAgentMeta(agentId, meta)
       return { ok: true }
@@ -608,6 +609,48 @@ export function registerIpcHandlers(): void {
       return { ok: true }
     } catch (error) {
       console.error('[IPC] db:preferences:set failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  // ── Database: Custom Labels ──
+
+  ipcMain.handle('db:labels:list', async () => {
+    try {
+      const labels = database.getAllCustomLabels()
+      return { ok: true, data: labels }
+    } catch (error) {
+      console.error('[IPC] db:labels:list failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  ipcMain.handle('db:labels:create', async (_event, options: { id: string; name: string; colorKey: string }) => {
+    try {
+      const label = database.createCustomLabel(options.id, options.name, options.colorKey)
+      return { ok: true, data: label }
+    } catch (error) {
+      console.error('[IPC] db:labels:create failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  ipcMain.handle('db:labels:update', async (_event, options: { id: string; name: string; colorKey: string }) => {
+    try {
+      const label = database.updateCustomLabel(options.id, options.name, options.colorKey)
+      return { ok: true, data: label }
+    } catch (error) {
+      console.error('[IPC] db:labels:update failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  ipcMain.handle('db:labels:delete', async (_event, labelId: string) => {
+    try {
+      const deleted = database.deleteCustomLabel(labelId)
+      return { ok: true, data: deleted }
+    } catch (error) {
+      console.error('[IPC] db:labels:delete failed:', error)
       return { ok: false, error: String(error) }
     }
   })

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -76,6 +76,7 @@ export interface AgentHandle {
   displayName: string
   taskSummary: string
   persistedStatus?: string
+  labelId?: string
   prUrl?: string
   bridge: EventBridge
 }
@@ -89,6 +90,7 @@ interface PersistedAgentHandle {
   displayName?: string
   taskSummary?: string
   persistedStatus?: string
+  labelId?: string
   prUrl?: string
 }
 
@@ -129,6 +131,7 @@ class AgentController {
           displayName: persistedAgent.displayName ?? '',
           taskSummary: persistedAgent.taskSummary ?? '',
           persistedStatus: persistedAgent.persistedStatus,
+          labelId: persistedAgent.labelId,
           prUrl: persistedAgent.prUrl,
           bridge: this.bridges.get(runtime.id)!
         }
@@ -292,13 +295,14 @@ class AgentController {
   /**
    * Update the persisted display name, task summary, and/or status for an agent.
    */
-  updateAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; prUrl?: string }): void {
+  updateAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelId?: string; prUrl?: string }): void {
     const handle = this.agents.get(agentId)
     if (!handle) return
 
     if (meta.displayName !== undefined) handle.displayName = meta.displayName
     if (meta.taskSummary !== undefined) handle.taskSummary = meta.taskSummary
     if (meta.persistedStatus !== undefined) handle.persistedStatus = meta.persistedStatus
+    if (meta.labelId !== undefined) handle.labelId = meta.labelId
     if (meta.prUrl !== undefined) handle.prUrl = meta.prUrl
     this.persistAgents()
   }
@@ -1142,6 +1146,7 @@ class AgentController {
       displayName: agent.displayName,
       taskSummary: agent.taskSummary,
       persistedStatus: agent.persistedStatus,
+      labelId: agent.labelId,
       prUrl: agent.prUrl
     }))
 

--- a/src/main/services/database.ts
+++ b/src/main/services/database.ts
@@ -20,6 +20,13 @@ export interface EventRecord {
   created_at: string
 }
 
+export interface CustomLabelRow {
+  id: string
+  name: string
+  color_key: string
+  created_at: string
+}
+
 let db: SqlJsDatabase | null = null
 let dbPath = ''
 let saveTimer: ReturnType<typeof setTimeout> | null = null
@@ -167,6 +174,15 @@ class Database {
       )
     `)
 
+    sqlDb.run(`
+      CREATE TABLE IF NOT EXISTS custom_labels (
+        id TEXT PRIMARY KEY,
+        name TEXT UNIQUE NOT NULL,
+        color_key TEXT NOT NULL DEFAULT 'blue',
+        created_at TEXT NOT NULL
+      )
+    `)
+
     saveToDisk()
   }
 
@@ -280,6 +296,38 @@ class Database {
 
   getRecentEvents(limit: number = 100): EventRecord[] {
     return this.queryAll<EventRecord>('SELECT * FROM events ORDER BY created_at DESC LIMIT ?', [limit])
+  }
+
+  // ---------------------------------------------------------------------------
+  // Custom Labels
+  // ---------------------------------------------------------------------------
+
+  getAllCustomLabels(): CustomLabelRow[] {
+    return this.queryAll<CustomLabelRow>('SELECT * FROM custom_labels ORDER BY created_at ASC')
+  }
+
+  createCustomLabel(id: string, name: string, colorKey: string): CustomLabelRow {
+    const now = new Date().toISOString()
+    this.execute(
+      'INSERT INTO custom_labels (id, name, color_key, created_at) VALUES (?, ?, ?, ?)',
+      [id, name, colorKey, now]
+    )
+    return this.queryOne<CustomLabelRow>('SELECT * FROM custom_labels WHERE id = ?', [id])!
+  }
+
+  updateCustomLabel(id: string, name: string, colorKey: string): CustomLabelRow | undefined {
+    this.execute(
+      'UPDATE custom_labels SET name = ?, color_key = ? WHERE id = ?',
+      [name, colorKey, id]
+    )
+    return this.queryOne<CustomLabelRow>('SELECT * FROM custom_labels WHERE id = ?', [id])
+  }
+
+  deleteCustomLabel(id: string): boolean {
+    const existing = this.queryOne<CustomLabelRow>('SELECT * FROM custom_labels WHERE id = ?', [id])
+    if (!existing) return false
+    this.execute('DELETE FROM custom_labels WHERE id = ?', [id])
+    return true
   }
 
   // ---------------------------------------------------------------------------

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -84,7 +84,7 @@ const api = {
   listAgents: (): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:list'),
 
-  updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string }): Promise<IpcResult> =>
+  updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelId?: string }): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:update-meta', agentId, meta),
 
   getStatuses: (): Promise<IpcResult> =>
@@ -169,6 +169,19 @@ const api = {
 
   setPreference: (key: string, value: string): Promise<IpcResult> =>
     ipcRenderer.invoke('db:preferences:set', key, value),
+
+  // ── Database: Custom Labels ──
+  listCustomLabels: (): Promise<IpcResult> =>
+    ipcRenderer.invoke('db:labels:list'),
+
+  createCustomLabel: (options: { id: string; name: string; colorKey: string }): Promise<IpcResult> =>
+    ipcRenderer.invoke('db:labels:create', options),
+
+  updateCustomLabel: (options: { id: string; name: string; colorKey: string }): Promise<IpcResult> =>
+    ipcRenderer.invoke('db:labels:update', options),
+
+  deleteCustomLabel: (labelId: string): Promise<IpcResult> =>
+    ipcRenderer.invoke('db:labels:delete', labelId),
 
   // ── Notifications ──
   getNotificationPreferences: (): Promise<IpcResult> =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -12,7 +12,8 @@ import { CommandPalette } from './components/CommandPalette'
 import { ModelPickerModal } from './components/ModelPickerModal'
 import { McpModal } from './components/McpModal'
 import { useAgentStore, setViewedAgentId, type LiveAgent } from './hooks/useAgentStore'
-import { type AgentRuntime, type Interrupt, type Message, type AgentLabel } from './types'
+import { useCustomLabels } from './hooks/useCustomLabels'
+import { type AgentRuntime, type Interrupt, type Message } from './types'
 import type { FileChange } from './components/FilesChanged'
 import type { ToolCall } from './components/ToolsUsage'
 import type { EventEntry } from './components/EventLog'
@@ -81,6 +82,7 @@ export function App() {
   const [quickLaunching, setQuickLaunching] = useState(false)
 
   const store = useAgentStore()
+  const { allLabels, createLabel, deleteLabel } = useCustomLabels()
 
   // Destructure stable callbacks (all use useCallback(fn, [])) to avoid
   // depending on the whole `store` object in downstream hooks.
@@ -268,7 +270,7 @@ export function App() {
       workspaceName: agent.workspaceName,
       taskSummary: agent.taskSummary,
       status: agent.status,
-      label: agent.label,
+      labelId: agent.labelId,
       model: agent.model,
       prUrl: agent.prUrl,
       lastActivityAt: formatTimeAgo(agent.lastActivityAt),
@@ -552,15 +554,15 @@ export function App() {
     [displayAgents]
   )
 
-  const labelCounts = useMemo(
-    () => ({
-      in_review: displayAgents.filter((agent) => agent.label === 'in_review').length,
-      blocked: displayAgents.filter((agent) => agent.label === 'blocked').length,
-      done: displayAgents.filter((agent) => agent.label === 'done').length,
-      draft: displayAgents.filter((agent) => agent.label === 'draft').length
-    }),
-    [displayAgents]
-  )
+  const labelCounts = useMemo(() => {
+    const counts: Record<string, number> = {}
+    for (const agent of displayAgents) {
+      if (agent.labelId) {
+        counts[agent.labelId] = (counts[agent.labelId] ?? 0) + 1
+      }
+    }
+    return counts
+  }, [displayAgents])
 
   const projectNames = useMemo(() => {
     const names = new Set(store.agents.map((agent) => agent.projectName))
@@ -609,9 +611,18 @@ export function App() {
     setSelectedAgentId(agentId)
   }, [])
 
-  const handleSetLabel = useCallback((agentId: string, label: AgentLabel | null) => {
-    storeSetLabel(agentId, label)
+  const handleSetLabel = useCallback((agentId: string, labelId: string | null) => {
+    storeSetLabel(agentId, labelId)
   }, [storeSetLabel])
+
+  const handleDeleteLabel = useCallback(async (labelId: string): Promise<boolean> => {
+    for (const agent of store.agents) {
+      if (agent.labelId === labelId) {
+        storeSetLabel(agent.id, null)
+      }
+    }
+    return deleteLabel(labelId)
+  }, [store.agents, storeSetLabel, deleteLabel])
 
   const handleRemoveAgent = useCallback((agentId: string) => {
     const liveAgent = findLiveAgent(agentId)
@@ -775,8 +786,8 @@ export function App() {
     setShowModelPicker(true)
   }, [selectedAgentId])
 
-  const handleDrawerSetLabel = useCallback((label: AgentLabel | null) => {
-    if (selectedAgentId) handleSetLabel(selectedAgentId, label)
+  const handleDrawerSetLabel = useCallback((labelId: string | null) => {
+    if (selectedAgentId) handleSetLabel(selectedAgentId, labelId)
   }, [selectedAgentId, handleSetLabel])
 
   const handleDrawerSetPrUrl = useCallback((prUrl: string | null) => {
@@ -1170,6 +1181,7 @@ export function App() {
         onSearchChange={setSearchQuery}
         counts={counts}
         labelCounts={labelCounts}
+        allLabels={allLabels}
         projects={projectNames}
       />
 
@@ -1193,6 +1205,9 @@ export function App() {
           setShowModelPicker(true)
         }}
         onSetLabel={handleSetLabel}
+        allLabels={allLabels}
+        onCreateLabel={createLabel}
+        onDeleteLabel={handleDeleteLabel}
       />
 
       <StatusBar
@@ -1227,6 +1242,9 @@ export function App() {
           onChangeModel={handleDrawerChangeModel}
           onOpenTerminal={handleOpenTerminalForDrawer}
           onSetLabel={handleDrawerSetLabel}
+          allLabels={allLabels}
+          onCreateLabel={createLabel}
+          onDeleteLabel={handleDeleteLabel}
         />
       )}
 

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -19,7 +19,7 @@ import {
   ArrowLineUpRight,
   Link
 } from '@phosphor-icons/react'
-import type { AgentRuntime, Message, AgentLabel } from '../types'
+import type { AgentRuntime, Message, LabelDefinition, LabelColorKey } from '../types'
 import { formatBranchLabel } from '../types'
 import type { LivePermission, LiveQuestion } from '../hooks/useAgentStore'
 import { loadSettings, SETTINGS_CHANGED_EVENT } from '../data/settings'
@@ -109,7 +109,10 @@ interface DetailDrawerProps {
   onOpenInEditor?: () => void
   onChangeModel?: () => void
   onOpenTerminal?: () => void
-  onSetLabel?: (label: AgentLabel | null) => void
+  onSetLabel?: (labelId: string | null) => void
+  allLabels?: LabelDefinition[]
+  onCreateLabel?: (name: string, colorKey: LabelColorKey) => Promise<LabelDefinition | null>
+  onDeleteLabel?: (id: string) => Promise<boolean>
 }
 
 export const DetailDrawer = memo(function DetailDrawer({
@@ -136,7 +139,10 @@ export const DetailDrawer = memo(function DetailDrawer({
   onOpenInEditor,
   onChangeModel,
   onOpenTerminal,
-  onSetLabel
+  onSetLabel,
+  allLabels = [],
+  onCreateLabel,
+  onDeleteLabel
 }: DetailDrawerProps) {
   const [inputText, setInputText] = useState('')
   const [activeTab, setActiveTab] = useState<TabKey>('transcript')
@@ -715,8 +721,11 @@ export const DetailDrawer = memo(function DetailDrawer({
           )}
           {onSetLabel && (
             <LabelDropdown
-              current={agent.label}
+              current={agent.labelId}
               onSelect={onSetLabel}
+              allLabels={allLabels}
+              onCreateLabel={onCreateLabel}
+              onDeleteLabel={onDeleteLabel}
               variant="action"
             />
           )}

--- a/src/renderer/src/components/FilterBar.tsx
+++ b/src/renderer/src/components/FilterBar.tsx
@@ -1,8 +1,9 @@
 import { MagnifyingGlass } from '@phosphor-icons/react'
-import type { AgentStatus, AgentLabel } from '../types'
+import type { AgentStatus, LabelDefinition } from '../types'
+import { LABEL_COLORS } from '../types'
 
 export type StatusFilter = 'blocked' | 'running' | 'idle' | 'errored' | 'completed'
-export type LabelFilter = AgentLabel
+export type LabelFilter = string
 
 export type FilterMode = 'include' | 'exclude'
 
@@ -139,12 +140,8 @@ interface FilterBarProps {
     errored: number
     completed: number
   }
-  labelCounts: {
-    in_review: number
-    blocked: number
-    done: number
-    draft: number
-  }
+  labelCounts: Record<string, number>
+  allLabels: LabelDefinition[]
   projects: string[]
 }
 
@@ -158,6 +155,7 @@ export function FilterBar({
   onSearchChange,
   counts,
   labelCounts,
+  allLabels,
   projects
 }: FilterBarProps) {
   const noFilters = isFilterEmpty(filter)
@@ -191,18 +189,19 @@ export function FilterBar({
       {Object.values(labelCounts).some((count) => count > 0) && (
         <>
           <div className="w-px h-5 bg-kumo-line" />
-          {labelCounts.draft > 0 && (
-            <FilterPill label={`Draft (${labelCounts.draft})`} mode={getFilterMode(filter.labels, filter.excludeLabels, 'draft')} onClick={() => onCycleLabel('draft')} variant="label" />
-          )}
-          {labelCounts.in_review > 0 && (
-            <FilterPill label={`Review (${labelCounts.in_review})`} mode={getFilterMode(filter.labels, filter.excludeLabels, 'in_review')} onClick={() => onCycleLabel('in_review')} variant="label" />
-          )}
-          {labelCounts.blocked > 0 && (
-            <FilterPill label={`Blocked (${labelCounts.blocked})`} mode={getFilterMode(filter.labels, filter.excludeLabels, 'blocked')} onClick={() => onCycleLabel('blocked')} variant="label" />
-          )}
-          {labelCounts.done > 0 && (
-            <FilterPill label={`Done (${labelCounts.done})`} mode={getFilterMode(filter.labels, filter.excludeLabels, 'done')} onClick={() => onCycleLabel('done')} variant="label" />
-          )}
+          {allLabels.map((labelDef) => {
+            const count = labelCounts[labelDef.id]
+            if (!count) return null
+            return (
+              <FilterPill
+                key={labelDef.id}
+                label={`${labelDef.name} (${count})`}
+                mode={getFilterMode(filter.labels, filter.excludeLabels, labelDef.id)}
+                onClick={() => onCycleLabel(labelDef.id)}
+                labelDef={labelDef}
+              />
+            )
+          })}
         </>
       )}
 
@@ -231,18 +230,21 @@ function FilterPill({
   label,
   mode,
   onClick,
-  variant = 'status'
+  labelDef
 }: {
   label: string
   mode: FilterMode | null
   onClick: () => void
-  variant?: 'status' | 'label'
+  labelDef?: LabelDefinition
 }) {
   let modeClass: string
   if (mode === 'include') {
-    modeClass = variant === 'label'
-      ? 'bg-kumo-brand/12 border-kumo-brand/30 text-kumo-brand'
-      : 'bg-kumo-interact/12 border-kumo-interact/30 text-kumo-link'
+    if (labelDef) {
+      const colors = LABEL_COLORS[labelDef.colorKey]
+      modeClass = `${colors.bg} ${colors.border} ${colors.text}`
+    } else {
+      modeClass = 'bg-kumo-interact/12 border-kumo-interact/30 text-kumo-link'
+    }
   } else if (mode === 'exclude') {
     modeClass = 'bg-red-500/12 border-red-500/30 text-red-400'
   } else {
@@ -280,19 +282,19 @@ function expandStatuses(filters: Set<StatusFilter>): Set<AgentStatus> {
 }
 
 export function matchesFilter(
-  agent: { status: AgentStatus; label: AgentLabel | null; projectName: string },
+  agent: { status: AgentStatus; labelId: string | null; projectName: string },
   filter: FilterState
 ): boolean {
   if (isFilterEmpty(filter)) return true
 
   // Exclude filters: reject if agent matches any excluded value
   if (filter.excludeStatuses.size > 0 && expandStatuses(filter.excludeStatuses).has(agent.status)) return false
-  if (filter.excludeLabels.size > 0 && agent.label && filter.excludeLabels.has(agent.label)) return false
+  if (filter.excludeLabels.size > 0 && agent.labelId && filter.excludeLabels.has(agent.labelId)) return false
   if (filter.excludeProjects.size > 0 && filter.excludeProjects.has(agent.projectName)) return false
 
   // Include filters: agent must match at least one value in each active include dimension
   if (filter.statuses.size > 0 && !expandStatuses(filter.statuses).has(agent.status)) return false
-  if (filter.labels.size > 0 && (!agent.label || !filter.labels.has(agent.label))) return false
+  if (filter.labels.size > 0 && (!agent.labelId || !filter.labels.has(agent.labelId))) return false
   if (filter.projects.size > 0 && !filter.projects.has(agent.projectName)) return false
 
   return true

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -16,7 +16,7 @@ import {
   Link,
   ArrowLineUpRight
 } from '@phosphor-icons/react'
-import type { AgentRuntime, AgentLabel } from '../types'
+import type { AgentRuntime, LabelDefinition, LabelColorKey } from '../types'
 import { formatBranchLabel, isUrgent } from '../types'
 import { StatusBadge } from './StatusBadge'
 import { LabelDropdown } from './LabelDropdown'
@@ -39,7 +39,10 @@ interface FleetTableProps {
   onCreatePr?: (agentId: string) => void
   onSetPrUrl?: (agentId: string, prUrl: string | null) => void
   onChangeModel?: (agentId: string) => void
-  onSetLabel?: (agentId: string, label: AgentLabel | null) => void
+  onSetLabel?: (agentId: string, labelId: string | null) => void
+  allLabels?: LabelDefinition[]
+  onCreateLabel?: (name: string, colorKey: LabelColorKey) => Promise<LabelDefinition | null>
+  onDeleteLabel?: (id: string) => Promise<boolean>
 }
 
 type SortColumn = 'agent' | 'status' | 'task' | 'branch' | 'model'
@@ -85,7 +88,10 @@ export function FleetTable({
   onCreatePr,
   onSetPrUrl,
   onChangeModel,
-  onSetLabel
+  onSetLabel,
+  allLabels = [],
+  onCreateLabel,
+  onDeleteLabel
 }: FleetTableProps) {
   const [sortColumn, setSortColumn] = useState<SortColumn | null>(null)
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
@@ -205,7 +211,10 @@ export function FleetTable({
               onOpen={onOpen ? () => onOpen(agent.id) : () => onSelect(agent.id)}
               onRemove={onRemove ? () => onRemove(agent.id) : undefined}
               onChangeModel={onChangeModel ? () => onChangeModel(agent.id) : undefined}
-              onSetLabel={onSetLabel ? (label: AgentLabel | null) => onSetLabel(agent.id, label) : undefined}
+              onSetLabel={onSetLabel ? (labelId: string | null) => onSetLabel(agent.id, labelId) : undefined}
+              allLabels={allLabels}
+              onCreateLabel={onCreateLabel}
+              onDeleteLabel={onDeleteLabel}
               onEditPrLink={() => setPrLinkState({ agentId: agent.id, currentUrl: agent.prUrl ?? '' })}
               onOpenTerminal={onOpenTerminal ? () => onOpenTerminal(agent.id) : undefined}
               onOpenInEditor={onOpenInEditor ? () => onOpenInEditor(agent.id) : undefined}
@@ -269,10 +278,13 @@ export function FleetTable({
             setPrLinkState({ agentId: contextMenu.agentId, currentUrl: agent?.prUrl ?? '' })
             closeContextMenu()
           }}
-          onSetLabel={(label: AgentLabel | null) => {
-            onSetLabel?.(contextMenu.agentId, label)
+          onSetLabel={(labelId: string | null) => {
+            onSetLabel?.(contextMenu.agentId, labelId)
             closeContextMenu()
           }}
+          allLabels={allLabels}
+          onCreateLabel={onCreateLabel}
+          onDeleteLabel={onDeleteLabel}
         />
       )}
 
@@ -322,7 +334,10 @@ function ContextMenu({
   onCreatePr,
   onRemovePrLink,
   onEditPrLink,
-  onSetLabel
+  onSetLabel,
+  allLabels,
+  onCreateLabel,
+  onDeleteLabel
 }: {
   agent: AgentRuntime
   posX: number
@@ -338,7 +353,10 @@ function ContextMenu({
   onCreatePr: () => void
   onRemovePrLink: () => void
   onEditPrLink: () => void
-  onSetLabel: (label: AgentLabel | null) => void
+  onSetLabel: (labelId: string | null) => void
+  allLabels: LabelDefinition[]
+  onCreateLabel?: (name: string, colorKey: LabelColorKey) => Promise<LabelDefinition | null>
+  onDeleteLabel?: (id: string) => Promise<boolean>
 }) {
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -420,8 +438,11 @@ function ContextMenu({
       <div className="px-2.5 py-1.5">
         <div className="text-[10px] text-kumo-subtle uppercase tracking-wide mb-1">Label</div>
         <LabelDropdown
-          current={agent.label}
+          current={agent.labelId}
           onSelect={onSetLabel}
+          allLabels={allLabels}
+          onCreateLabel={onCreateLabel}
+          onDeleteLabel={onDeleteLabel}
           variant="action"
         />
       </div>
@@ -456,6 +477,9 @@ function AgentRow({
   onRemove,
   onChangeModel,
   onSetLabel,
+  allLabels = [],
+  onCreateLabel,
+  onDeleteLabel,
   onEditPrLink,
   onOpenTerminal,
   onOpenInEditor,
@@ -474,7 +498,10 @@ function AgentRow({
   onOpen?: () => void
   onRemove?: () => void
   onChangeModel?: () => void
-  onSetLabel?: (label: AgentLabel | null) => void
+  onSetLabel?: (labelId: string | null) => void
+  allLabels?: LabelDefinition[]
+  onCreateLabel?: (name: string, colorKey: LabelColorKey) => Promise<LabelDefinition | null>
+  onDeleteLabel?: (id: string) => Promise<boolean>
   onEditPrLink?: () => void
   onOpenTerminal?: () => void
   onOpenInEditor?: () => void
@@ -568,8 +595,11 @@ function AgentRow({
             <StatusBadge status={agent.status} />
             {onSetLabel && (
               <LabelDropdown
-                current={agent.label}
+                current={agent.labelId}
                 onSelect={onSetLabel}
+                allLabels={allLabels}
+                onCreateLabel={onCreateLabel}
+                onDeleteLabel={onDeleteLabel}
                 variant="inline"
               />
             )}

--- a/src/renderer/src/components/LabelDropdown.tsx
+++ b/src/renderer/src/components/LabelDropdown.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import {
   CaretDown,
   CheckCircle,
@@ -5,40 +6,76 @@ import {
   Warning,
   PencilSimpleLine,
   XCircle,
-  Tag
+  Tag,
+  Plus,
+  X
 } from '@phosphor-icons/react'
-import type { AgentLabel } from '../types'
-import { agentLabelDisplay } from '../types'
+import { agentLabelDisplay, getLabelDefinition, LABEL_COLORS, type LabelDefinition, type LabelColorKey } from '../types'
 import { useDismiss } from '../hooks/useDismiss'
 
-const LABEL_OPTIONS: { value: AgentLabel | null; label: string; icon: React.ReactNode }[] = [
-  { value: null, label: 'None', icon: <XCircle size={12} /> },
-  { value: 'draft', label: 'Draft', icon: <PencilSimpleLine size={12} /> },
-  { value: 'in_review', label: 'In Review', icon: <Eye size={12} /> },
-  { value: 'blocked', label: 'Blocked', icon: <Warning size={12} /> },
-  { value: 'done', label: 'Done', icon: <CheckCircle size={12} /> }
+const BUILTIN_ICONS: Record<string, React.ReactNode> = {
+  draft: <PencilSimpleLine size={12} />,
+  in_review: <Eye size={12} />,
+  blocked: <Warning size={12} />,
+  done: <CheckCircle size={12} />
+}
+
+const COLOR_KEYS: LabelColorKey[] = [
+  'red', 'orange', 'amber', 'green', 'teal',
+  'blue', 'indigo', 'purple', 'pink', 'gray'
 ]
 
 interface LabelDropdownProps {
-  current: AgentLabel | null
-  onSelect: (label: AgentLabel | null) => void
+  current: string | null
+  onSelect: (labelId: string | null) => void
+  allLabels: LabelDefinition[]
+  onCreateLabel?: (name: string, colorKey: LabelColorKey) => Promise<LabelDefinition | null>
+  onDeleteLabel?: (id: string) => Promise<boolean>
   variant?: 'row' | 'action' | 'inline'
 }
 
-export function LabelDropdown({ current, onSelect, variant = 'row' }: LabelDropdownProps) {
+export function LabelDropdown({ current, onSelect, allLabels, onCreateLabel, onDeleteLabel, variant = 'row' }: LabelDropdownProps) {
   const { open, toggle, close, containerRef } = useDismiss()
+  const [creating, setCreating] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [newColor, setNewColor] = useState<LabelColorKey>('blue')
 
-  const selectAndClose = (value: AgentLabel | null) => {
+  const selectAndClose = (value: string | null) => {
     onSelect(value)
+    setCreating(false)
     close()
   }
 
   const handleToggle = (event: React.MouseEvent) => {
     event.stopPropagation()
     toggle()
+    if (open) setCreating(false)
   }
 
-  const currentLabel = agentLabelDisplay(current)
+  const handleCreate = async () => {
+    if (!onCreateLabel || !newName.trim()) return
+    const label = await onCreateLabel(newName.trim(), newColor)
+    if (label) {
+      onSelect(label.id)
+      setNewName('')
+      setNewColor('blue')
+      setCreating(false)
+      close()
+    }
+  }
+
+  const handleDelete = async (event: React.MouseEvent, labelId: string) => {
+    event.stopPropagation()
+    if (!onDeleteLabel) return
+    const deleted = await onDeleteLabel(labelId)
+    if (deleted && current === labelId) {
+      onSelect(null)
+    }
+  }
+
+  const currentLabel = agentLabelDisplay(current, allLabels)
+  const currentDef = getLabelDefinition(current, allLabels)
+  const currentColors = currentDef ? LABEL_COLORS[currentDef.colorKey] : null
 
   let menuPosition: string
   let trigger: React.ReactNode
@@ -51,7 +88,7 @@ export function LabelDropdown({ current, onSelect, variant = 'row' }: LabelDropd
           onClick={handleToggle}
           className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md border bg-kumo-control border-kumo-line text-kumo-default hover:bg-kumo-fill transition-colors"
         >
-          {LABEL_OPTIONS.find((o) => o.value === current)?.icon}
+          {(current && BUILTIN_ICONS[current]) ?? <Tag size={12} />}
           {currentLabel}
           <CaretDown size={10} className="ml-0.5" />
         </button>
@@ -63,10 +100,14 @@ export function LabelDropdown({ current, onSelect, variant = 'row' }: LabelDropd
       trigger = current ? (
         <button
           onClick={handleToggle}
-          className="inline-flex items-center px-1.5 py-px rounded text-[10px] font-medium bg-kumo-brand/10 text-kumo-brand hover:bg-kumo-brand/20 transition-colors cursor-pointer"
+          className={`inline-flex items-center px-1.5 py-px rounded text-[10px] font-medium transition-colors cursor-pointer ${
+            currentColors
+              ? `${currentColors.bg} ${currentColors.text}`
+              : 'bg-kumo-brand/10 text-kumo-brand'
+          }`}
           title="Change label"
         >
-          {agentLabelDisplay(current)}
+          {currentLabel}
         </button>
       ) : (
         <button
@@ -97,21 +138,110 @@ export function LabelDropdown({ current, onSelect, variant = 'row' }: LabelDropd
     <div ref={containerRef} className="relative inline-flex">
       {trigger}
       {open && (
-        <div className={`${menuPosition} z-[100] min-w-[140px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl`}>
-          {LABEL_OPTIONS.map((option) => (
-            <button
-              key={option.label}
-              onClick={(event) => { event.stopPropagation(); selectAndClose(option.value) }}
-              className={`flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] rounded transition-colors text-left ${
-                option.value === current
-                  ? 'bg-kumo-interact/12 text-kumo-link'
-                  : 'text-kumo-default hover:bg-kumo-fill'
-              }`}
-            >
-              {option.icon}
-              {option.label}
-            </button>
-          ))}
+        <div className={`${menuPosition} z-[100] min-w-[160px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl`}>
+          {/* None option */}
+          <button
+            onClick={(event) => { event.stopPropagation(); selectAndClose(null) }}
+            className={`flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] rounded transition-colors text-left ${
+              current === null
+                ? 'bg-kumo-interact/12 text-kumo-link'
+                : 'text-kumo-default hover:bg-kumo-fill'
+            }`}
+          >
+            <XCircle size={12} />
+            None
+          </button>
+
+          {/* All labels (built-in + custom) */}
+          {allLabels.map((label) => {
+            const colors = LABEL_COLORS[label.colorKey]
+            const isSelected = label.id === current
+            const isCustom = !label.builtIn
+            return (
+              <div key={label.id} className="group/label flex items-center">
+                <button
+                  onClick={(event) => { event.stopPropagation(); selectAndClose(label.id) }}
+                  className={`flex items-center gap-2 flex-1 min-w-0 px-2.5 py-1.5 text-[11px] rounded transition-colors text-left ${
+                    isSelected
+                      ? 'bg-kumo-interact/12 text-kumo-link'
+                      : 'text-kumo-default hover:bg-kumo-fill'
+                  }`}
+                >
+                  {BUILTIN_ICONS[label.id] ?? (
+                    <span className={`w-2.5 h-2.5 rounded-full shrink-0 ${colors.swatch}`} />
+                  )}
+                  <span className="truncate">{label.name}</span>
+                </button>
+                {isCustom && onDeleteLabel && (
+                  <button
+                    onClick={(event) => void handleDelete(event, label.id)}
+                    className="shrink-0 p-1 mr-1 rounded text-kumo-subtle hover:text-kumo-danger hover:bg-kumo-danger/10 transition-colors opacity-0 group-hover/label:opacity-100"
+                    title={`Delete ${label.name}`}
+                  >
+                    <X size={10} />
+                  </button>
+                )}
+              </div>
+            )
+          })}
+
+          {/* Create new label */}
+          {onCreateLabel && (
+            <>
+              <div className="border-t border-kumo-line my-1" />
+              {creating ? (
+                <div className="px-2 py-1.5 space-y-1.5" onClick={(e) => e.stopPropagation()}>
+                  <input
+                    autoFocus
+                    type="text"
+                    value={newName}
+                    onChange={(e) => setNewName(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === 'Enter') void handleCreate(); if (e.key === 'Escape') setCreating(false) }}
+                    placeholder="Label name..."
+                    className="w-full bg-kumo-control border border-kumo-line rounded px-2 py-1 text-[11px] text-kumo-default placeholder:text-kumo-subtle outline-none focus:border-kumo-brand/50"
+                    maxLength={30}
+                  />
+                  <div className="flex gap-1 flex-wrap">
+                    {COLOR_KEYS.map((key) => {
+                      const c = LABEL_COLORS[key]
+                      const selected = key === newColor
+                      return (
+                        <button
+                          key={key}
+                          onClick={() => setNewColor(key)}
+                          className={`w-4 h-4 rounded-full ${c.swatch} ${selected ? 'ring-2 ring-offset-1 ring-offset-kumo-elevated ring-white/50' : ''}`}
+                          title={key}
+                        />
+                      )
+                    })}
+                  </div>
+                  <div className="flex gap-1">
+                    <button
+                      onClick={() => void handleCreate()}
+                      disabled={!newName.trim()}
+                      className="flex-1 px-2 py-1 text-[10px] font-medium rounded bg-kumo-brand text-white hover:bg-kumo-brand/90 disabled:opacity-40 transition-colors"
+                    >
+                      Create
+                    </button>
+                    <button
+                      onClick={() => setCreating(false)}
+                      className="px-2 py-1 text-[10px] rounded text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill transition-colors"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <button
+                  onClick={(event) => { event.stopPropagation(); setCreating(true) }}
+                  className="flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] rounded transition-colors text-left text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill"
+                >
+                  <Plus size={12} />
+                  New label...
+                </button>
+              )}
+            </>
+          )}
         </div>
       )}
     </div>

--- a/src/renderer/src/demoApi.ts
+++ b/src/renderer/src/demoApi.ts
@@ -337,6 +337,12 @@ export function createDemoApi(): OrchestratorApi {
     ensureProject: () => ok({ id: '1', name: 'demo', repo_root: '/tmp', created_at: '', updated_at: '' }),
     deleteProject: () => ok(true),
 
+    // ── Database: Custom Labels ──
+    listCustomLabels: () => ok([]),
+    createCustomLabel: () => ok({ id: 'custom', name: 'Custom', color_key: 'blue', created_at: '' }),
+    updateCustomLabel: () => ok({ id: 'custom', name: 'Custom', color_key: 'blue', created_at: '' }),
+    deleteCustomLabel: () => ok(true),
+
     // ── Database: Preferences ──
     getPreference: () => ok(undefined),
     setPreference: noop,

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react'
-import type { AgentStatus, AgentLabel } from '../types'
+import type { AgentStatus } from '../types'
 import type {
   OpenCodeEventPayload,
   AgentLaunchedPayload,
@@ -61,7 +61,7 @@ export interface LiveAgent {
   workspaceName: string
   taskSummary: string
   status: AgentStatus
-  label: AgentLabel | null
+  labelId: string | null
   model: string
   /** The model set by the user or first top-level assistant message.
    *  Used to restore the displayed model after an invoked agent
@@ -258,7 +258,7 @@ function emitMessagesThrottled(agentChanged: boolean): void {
   }
 }
 
-function persistAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; prUrl?: string }): void {
+function persistAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelId?: string; prUrl?: string }): void {
   window.api?.updateAgentMeta(agentId, meta)
 }
 
@@ -1329,7 +1329,7 @@ function upsertAgent(payload: AgentLaunchedPayload, initialStatus?: AgentStatus)
     workspaceName: payload.workspaceName ?? existingAgent?.workspaceName ?? payload.directory.split('/').pop() ?? payload.directory,
     taskSummary: payload.taskSummary || existingAgent?.taskSummary || (hasPrompt ? payload.prompt.slice(0, 120) : 'Waiting for prompt...'),
     status: initialStatus ?? existingAgent?.status ?? (hasPrompt ? 'running' : 'idle'),
-    label: existingAgent?.label ?? null,
+    labelId: existingAgent?.labelId ?? null,
     model: existingAgent?.model ?? 'starting...',
     configuredModel: existingAgent?.configuredModel,
     prUrl: existingAgent?.prUrl ?? payload.prUrl ?? null,
@@ -1708,7 +1708,9 @@ export function useAgentStore() {
       let shouldEmit = false
 
       if (agentsResult.ok && agentsResult.data) {
-        const PERSISTED_TO_LABEL: Record<string, AgentLabel> = {
+        // Legacy: old versions stored label values in persistedStatus.
+        // Map them to labelId for backward compatibility during migration.
+        const LEGACY_PERSISTED_TO_LABEL: Record<string, string> = {
           in_review: 'in_review', blocked: 'blocked', done: 'done', draft: 'draft',
           completed_manual: 'done', blocked_manual: 'blocked'
         }
@@ -1722,12 +1724,15 @@ export function useAgentStore() {
         }
 
         for (const agent of agentsResult.data) {
-          const restoredLabel = (agent.persistedStatus && PERSISTED_TO_LABEL[agent.persistedStatus]) ?? null
           const restoredStatus: AgentStatus = (agent.persistedStatus && PERSISTED_TO_STATUS[agent.persistedStatus]) || 'idle'
           upsertAgent(agent, restoredStatus)
           const liveAgent = state.agents.get(agent.id)
-          if (liveAgent && restoredLabel) {
-            liveAgent.label = restoredLabel
+          if (liveAgent) {
+            // Prefer the new labelId field; fall back to legacy persistedStatus mapping
+            const labelId = agent.labelId
+              || (agent.persistedStatus && LEGACY_PERSISTED_TO_LABEL[agent.persistedStatus])
+              || null
+            liveAgent.labelId = labelId
           }
           shouldEmit = true
         }
@@ -1887,7 +1892,7 @@ export function useAgentStore() {
 
     const previousStatus = agent?.status
     const previousBlockedSince = agent?.blockedSince
-    const previousLabel = agent?.label ?? null
+    const previousLabelId = agent?.labelId ?? null
 
     if (agent) {
       applyOptimisticSendState(agentId, agent, text, taskSummaryOverride)
@@ -1916,7 +1921,7 @@ export function useAgentStore() {
         agentAfter.blockedSince = previousBlockedSince
         agentAfter.respondedAt = undefined
         agentAfter.lastActivityAt = Date.now()
-        agentAfter.label = previousLabel
+        agentAfter.labelId = previousLabelId
       }
       for (const [qId, q] of removedQuestions) {
         state.questions.set(qId, q)
@@ -2013,7 +2018,7 @@ export function useAgentStore() {
     const agent = state.agents.get(agentId)
     const previousStatus = agent?.status
     const previousBlockedSince = agent?.blockedSince
-    const previousLabel = agent?.label ?? null
+    const previousLabelId = agent?.labelId ?? null
     const removedPermission = state.permissions.get(permissionId)
 
     // Optimistically clear permission and set running
@@ -2038,7 +2043,7 @@ export function useAgentStore() {
         agentAfter.blockedSince = previousBlockedSince
         agentAfter.respondedAt = undefined
         agentAfter.lastActivityAt = Date.now()
-        agentAfter.label = previousLabel
+        agentAfter.labelId = previousLabelId
       }
       if (removedPermission) {
         state.permissions.set(permissionId, removedPermission)
@@ -2055,7 +2060,7 @@ export function useAgentStore() {
     const agent = state.agents.get(agentId)
     const previousStatus = agent?.status
     const previousBlockedSince = agent?.blockedSince
-    const previousLabel = agent?.label ?? null
+    const previousLabelId = agent?.labelId ?? null
     const removedQuestion = state.questions.get(requestId)
 
     // Optimistically clear question and set running
@@ -2078,7 +2083,7 @@ export function useAgentStore() {
         agentAfter.blockedSince = previousBlockedSince
         agentAfter.respondedAt = undefined
         agentAfter.lastActivityAt = Date.now()
-        agentAfter.label = previousLabel
+        agentAfter.labelId = previousLabelId
       }
       if (removedQuestion) {
         state.questions.set(requestId, removedQuestion)
@@ -2095,7 +2100,7 @@ export function useAgentStore() {
     const agent = state.agents.get(agentId)
     const previousStatus = agent?.status
     const previousBlockedSince = agent?.blockedSince
-    const previousLabel = agent?.label ?? null
+    const previousLabelId = agent?.labelId ?? null
     const removedQuestion = state.questions.get(requestId)
 
     // Optimistically clear question and set running
@@ -2118,7 +2123,7 @@ export function useAgentStore() {
         agentAfter.blockedSince = previousBlockedSince
         agentAfter.respondedAt = undefined
         agentAfter.lastActivityAt = Date.now()
-        agentAfter.label = previousLabel
+        agentAfter.labelId = previousLabelId
       }
       if (removedQuestion) {
         state.questions.set(requestId, removedQuestion)
@@ -2234,12 +2239,12 @@ export function useAgentStore() {
     emit({ agents: true })
   }, [])
 
-  const setLabel = useCallback((agentId: string, label: AgentLabel | null) => {
+  const setLabel = useCallback((agentId: string, labelId: string | null) => {
     const agent = state.agents.get(agentId)
     if (!agent) return
-    agent.label = label
+    agent.labelId = labelId
     agent.lastActivityAt = Date.now()
-    persistAgentMeta(agentId, { persistedStatus: label ?? '' })
+    persistAgentMeta(agentId, { labelId: labelId ?? '' })
     emit({ agents: true })
   }, [])
 

--- a/src/renderer/src/hooks/useCustomLabels.ts
+++ b/src/renderer/src/hooks/useCustomLabels.ts
@@ -1,0 +1,97 @@
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { BUILTIN_LABELS, BUILTIN_LABEL_IDS, type LabelDefinition, type LabelColorKey } from '../types'
+
+const RESERVED_IDS = new Set([
+  ...BUILTIN_LABEL_IDS,
+  'running', 'idle', 'completed', 'errored', 'starting',
+  'stopping', 'disconnected', 'needs_input', 'needs_approval',
+  'completed_manual', 'blocked_manual'
+])
+
+function generateLabelId(name: string): string {
+  const base = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_|_$/g, '')
+    .slice(0, 40)
+  if (!base) return `label_${Date.now()}`
+  if (RESERVED_IDS.has(base)) return `custom_${base}`
+  return base
+}
+
+export function useCustomLabels() {
+  const [customLabels, setCustomLabels] = useState<LabelDefinition[]>([])
+
+  useEffect(() => {
+    if (!window.api?.listCustomLabels) return
+    void window.api.listCustomLabels().then((result) => {
+      if (result.ok && Array.isArray(result.data)) {
+        setCustomLabels(result.data.map((row) => ({
+          id: row.id,
+          name: row.name,
+          colorKey: row.color_key as LabelColorKey,
+          builtIn: false
+        })))
+      }
+    })
+  }, [])
+
+  const allLabels = useMemo<LabelDefinition[]>(
+    () => [...BUILTIN_LABELS, ...customLabels],
+    [customLabels]
+  )
+
+  const createLabel = useCallback(async (name: string, colorKey: LabelColorKey): Promise<LabelDefinition | null> => {
+    if (!window.api?.createCustomLabel) return null
+    const trimmed = name.trim()
+    if (!trimmed) return null
+
+    const existing = customLabels.find((l) => l.name.toLowerCase() === trimmed.toLowerCase())
+    if (existing) return existing
+
+    let id = generateLabelId(trimmed)
+    const existingIds = new Set(customLabels.map((l) => l.id))
+    while (existingIds.has(id)) {
+      id = `${id}_${Date.now()}`
+    }
+
+    const result = await window.api.createCustomLabel({ id, name: trimmed, colorKey })
+    if (!result.ok || !result.data) return null
+
+    const newLabel: LabelDefinition = { id, name: trimmed, colorKey, builtIn: false }
+    setCustomLabels((prev) => [...prev, newLabel])
+    return newLabel
+  }, [customLabels])
+
+  const updateLabel = useCallback(async (id: string, name: string, colorKey: LabelColorKey): Promise<boolean> => {
+    if (!window.api?.updateCustomLabel) return false
+    const trimmed = name.trim()
+    if (!trimmed) return false
+
+    const result = await window.api.updateCustomLabel({ id, name: trimmed, colorKey })
+    if (!result.ok) return false
+
+    setCustomLabels((prev) => prev.map((l) =>
+      l.id === id ? { ...l, name: trimmed, colorKey } : l
+    ))
+    return true
+  }, [])
+
+  const deleteLabel = useCallback(async (id: string): Promise<boolean> => {
+    if (!window.api?.deleteCustomLabel) return false
+    const result = await window.api.deleteCustomLabel(id)
+    if (!result.ok) return false
+
+    setCustomLabels((prev) => prev.filter((l) => l.id !== id))
+    return true
+  }, [])
+
+  return {
+    customLabels,
+    allLabels,
+    createLabel,
+    updateLabel,
+    deleteLabel
+  }
+}

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -35,7 +35,7 @@ export interface OrchestratorApi {
   listSessions: (directory: string) => Promise<IpcResult<SessionListEntry[]>>
   resumeAgent: (options: { directory: string; sessionId: string; title?: string }) => Promise<IpcResult>
   listAgents: () => Promise<IpcResult<ListAgentsPayload>>
-  updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; prUrl?: string }) => Promise<IpcResult>
+  updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelId?: string; prUrl?: string }) => Promise<IpcResult>
   getStatuses: () => Promise<IpcResult<AgentStatusesPayload>>
   replyToQuestion: (agentId: string, requestId: string, answers: string[][]) => Promise<IpcResult>
   rejectQuestion: (agentId: string, requestId: string) => Promise<IpcResult>
@@ -64,6 +64,12 @@ export interface OrchestratorApi {
   createProject: (options: { name: string; repoRoot: string }) => Promise<IpcResult<Project>>
   ensureProject: (options: { name: string; repoRoot: string }) => Promise<IpcResult<Project>>
   deleteProject: (projectId: string) => Promise<IpcResult<boolean>>
+
+  // ── Database: Custom Labels ──
+  listCustomLabels: () => Promise<IpcResult<CustomLabelPayload[]>>
+  createCustomLabel: (options: { id: string; name: string; colorKey: string }) => Promise<IpcResult<CustomLabelPayload>>
+  updateCustomLabel: (options: { id: string; name: string; colorKey: string }) => Promise<IpcResult<CustomLabelPayload>>
+  deleteCustomLabel: (labelId: string) => Promise<IpcResult<boolean>>
 
   // ── Database: Preferences ──
   getPreference: (key: string) => Promise<IpcResult<string | undefined>>
@@ -144,6 +150,13 @@ export interface OpenCodeEventPayload {
   }
 }
 
+export interface CustomLabelPayload {
+  id: string
+  name: string
+  color_key: string
+  created_at: string
+}
+
 export interface AgentLaunchedPayload {
   id: string
   runtimeId: string
@@ -158,6 +171,7 @@ export interface AgentLaunchedPayload {
   displayName?: string
   taskSummary?: string
   persistedStatus?: string
+  labelId?: string
   prUrl?: string
 }
 

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -15,7 +15,41 @@ export type AgentStatus =
 
 // ── Labels: user-applied workflow tags ──
 
-export type AgentLabel = 'in_review' | 'blocked' | 'done' | 'draft'
+export type LabelColorKey =
+  | 'red' | 'orange' | 'amber' | 'green' | 'teal'
+  | 'blue' | 'indigo' | 'purple' | 'pink' | 'gray'
+
+export interface LabelDefinition {
+  id: string
+  name: string
+  colorKey: LabelColorKey
+  builtIn: boolean
+}
+
+export interface LabelColorClasses { bg: string; text: string; border: string; swatch: string }
+
+// Tailwind requires complete class literals — these cannot be generated dynamically.
+export const LABEL_COLORS: Record<LabelColorKey, LabelColorClasses> = {
+  red:    { bg: 'bg-red-500/12',    text: 'text-red-400',    border: 'border-red-500/30',    swatch: 'bg-red-500' },
+  orange: { bg: 'bg-orange-500/12', text: 'text-orange-400', border: 'border-orange-500/30', swatch: 'bg-orange-500' },
+  amber:  { bg: 'bg-amber-500/12',  text: 'text-amber-400',  border: 'border-amber-500/30',  swatch: 'bg-amber-500' },
+  green:  { bg: 'bg-green-500/12',  text: 'text-green-400',  border: 'border-green-500/30',  swatch: 'bg-green-500' },
+  teal:   { bg: 'bg-teal-500/12',   text: 'text-teal-400',   border: 'border-teal-500/30',   swatch: 'bg-teal-500' },
+  blue:   { bg: 'bg-blue-500/12',   text: 'text-blue-400',   border: 'border-blue-500/30',   swatch: 'bg-blue-500' },
+  indigo: { bg: 'bg-indigo-500/12', text: 'text-indigo-400', border: 'border-indigo-500/30', swatch: 'bg-indigo-500' },
+  purple: { bg: 'bg-purple-500/12', text: 'text-purple-400', border: 'border-purple-500/30', swatch: 'bg-purple-500' },
+  pink:   { bg: 'bg-pink-500/12',   text: 'text-pink-400',   border: 'border-pink-500/30',   swatch: 'bg-pink-500' },
+  gray:   { bg: 'bg-gray-500/12',   text: 'text-gray-400',   border: 'border-gray-500/30',   swatch: 'bg-gray-500' }
+}
+
+export const BUILTIN_LABELS: LabelDefinition[] = [
+  { id: 'draft',     name: 'Draft',     colorKey: 'gray',   builtIn: true },
+  { id: 'in_review', name: 'In Review', colorKey: 'blue',   builtIn: true },
+  { id: 'blocked',   name: 'Blocked',   colorKey: 'red',    builtIn: true },
+  { id: 'done',      name: 'Done',      colorKey: 'green',  builtIn: true }
+]
+
+export const BUILTIN_LABEL_IDS = new Set<string>(BUILTIN_LABELS.map((l) => l.id))
 
 export type InterruptKind =
   | 'needs_input'
@@ -42,7 +76,7 @@ export interface AgentRuntime {
   workspaceName: string
   taskSummary: string
   status: AgentStatus
-  label: AgentLabel | null
+  labelId: string | null
   model: string
   prUrl: string | null
   lastActivityAt: string
@@ -83,8 +117,8 @@ export function isBlocked(status: AgentStatus): boolean {
   return status === 'needs_input' || status === 'needs_approval'
 }
 
-export function isUrgent(agent: { status: AgentStatus; label: AgentLabel | null }): boolean {
-  return isBlocked(agent.status) || agent.status === 'errored' || agent.label === 'blocked'
+export function isUrgent(agent: { status: AgentStatus; labelId: string | null }): boolean {
+  return isBlocked(agent.status) || agent.status === 'errored' || agent.labelId === 'blocked'
 }
 
 export function formatBranchLabel(agent: Pick<AgentRuntime, 'branchName'>): string {
@@ -106,13 +140,15 @@ export function statusLabel(status: AgentStatus): string {
   return labels[status]
 }
 
-export function agentLabelDisplay(label: AgentLabel | null): string {
-  if (!label) return 'None'
-  const labels: Record<AgentLabel, string> = {
-    in_review: 'In Review',
-    blocked: 'Blocked',
-    done: 'Done',
-    draft: 'Draft'
-  }
-  return labels[label]
+export function getLabelDefinition(labelId: string | null, customLabels: LabelDefinition[] = []): LabelDefinition | null {
+  if (!labelId) return null
+  const builtin = BUILTIN_LABELS.find((l) => l.id === labelId)
+  if (builtin) return builtin
+  return customLabels.find((l) => l.id === labelId) ?? null
+}
+
+export function agentLabelDisplay(labelId: string | null, customLabels: LabelDefinition[] = []): string {
+  if (!labelId) return 'None'
+  const def = getLabelDefinition(labelId, customLabels)
+  return def?.name ?? labelId
 }


### PR DESCRIPTION
Labels were previously hardcoded to 4 values (draft, in_review, blocked, done). Users can now create custom labels with a name and color from a 10-color preset palette.

Key changes:
- New custom_labels SQLite table with CRUD operations and IPC handlers
- Separated labelId from persistedStatus to avoid field overloading, with backward-compatible migration from legacy persisted label values
- LabelDropdown supports dynamic label list, inline creation form with color picker, and delete button (X) for custom labels
- FilterBar renders dynamic label counts with per-label color styling
- Deleting a label clears it from all agents currently using it
- Duplicate name detection prevents UNIQUE constraint errors on re-create