### PR TITLE
Set explicit application menu to suppress macOS representedObject war…

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, shell, BrowserWindow, nativeImage } from 'electron'
+import { app, shell, BrowserWindow, nativeImage, Menu } from 'electron'
 import { join } from 'path'
 import { registerIpcHandlers } from './ipc'
 import { agentController } from './services/agent-controller'
@@ -96,6 +96,13 @@ function createWindow(): BrowserWindow {
 }
 
 app.whenReady().then(async () => {
+  // Explicit menu suppresses macOS representedObject warnings from Electron's default
+  Menu.setApplicationMenu(Menu.buildFromTemplate([
+    { role: 'appMenu' },
+    { role: 'editMenu' },
+    { role: 'windowMenu' },
+  ]))
+
   // Set dock icon (macOS dev mode)
   const appIcon = getAppIcon()
   if (appIcon && process.platform === 'darwin' && app.dock) {


### PR DESCRIPTION
…nings

Electron's auto-generated default menu triggers repeated 'representedObject is not a WeakPtrToElectronMenuModelAsNSObject' warnings on macOS. Setting a minimal explicit menu (appMenu, editMenu, windowMenu) avoids the internal code paths that produce this noise while preserving clipboard and window shortcuts.