### PR TITLE
Support multiple labels per agent with dedicated sortable column

### DIFF
--- a/src/__tests__/filter-sort.test.ts
+++ b/src/__tests__/filter-sort.test.ts
@@ -33,7 +33,7 @@ interface AgentRow {
   branchName: string
   taskSummary: string
   status: AgentStatus
-  labelId: string | null
+  labelIds: string[]
   model: string
   lastActivityAt: number
 }
@@ -68,19 +68,19 @@ function expandStatuses(filters: Set<StatusFilter>): Set<AgentStatus> {
 }
 
 function matchesFilter(
-  agent: { status: AgentStatus; labelId: string | null; projectName: string },
+  agent: { status: AgentStatus; labelIds: string[]; projectName: string },
   filter: FilterState
 ): boolean {
   if (isFilterEmpty(filter)) return true
 
   // Exclude filters: reject if agent matches any excluded value
   if (filter.excludeStatuses.size > 0 && expandStatuses(filter.excludeStatuses).has(agent.status)) return false
-  if (filter.excludeLabels.size > 0 && agent.labelId && filter.excludeLabels.has(agent.labelId)) return false
+  if (filter.excludeLabels.size > 0 && agent.labelIds.some((id) => filter.excludeLabels.has(id))) return false
   if (filter.excludeProjects.size > 0 && filter.excludeProjects.has(agent.projectName)) return false
 
   // Include filters: agent must match at least one value in each active include dimension
   if (filter.statuses.size > 0 && !expandStatuses(filter.statuses).has(agent.status)) return false
-  if (filter.labels.size > 0 && (!agent.labelId || !filter.labels.has(agent.labelId))) return false
+  if (filter.labels.size > 0 && !agent.labelIds.some((id) => filter.labels.has(id))) return false
   if (filter.projects.size > 0 && !filter.projects.has(agent.projectName)) return false
 
   return true
@@ -122,7 +122,7 @@ function isBlocked(status: AgentStatus): boolean {
 }
 
 function isUrgent(agent: AgentRow): boolean {
-  return isBlocked(agent.status) || agent.status === 'errored' || agent.labelId === 'blocked'
+  return isBlocked(agent.status) || agent.status === 'errored' || agent.labelIds.includes('blocked')
 }
 
 function compareAgents(
@@ -180,7 +180,7 @@ function createAgent(overrides: Partial<AgentRow> = {}): AgentRow {
     branchName: 'main',
     taskSummary: 'Fix the login bug',
     status: 'running',
-    labelId: null,
+    labelIds: [],
     model: 'sonnet-4',
     lastActivityAt: Date.now(),
     ...overrides
@@ -229,120 +229,120 @@ describe('matchesFilter', () => {
       'idle', 'completed', 'errored', 'disconnected', 'stopping'
     ]
     for (const status of statuses) {
-      expect(matchesFilter({ status, labelId: null, projectName: 'proj' }, EMPTY)).toBe(true)
+      expect(matchesFilter({ status, labelIds: [], projectName: 'proj' }, EMPTY)).toBe(true)
     }
   })
 
   it('returns true for "blocked" status filter when needs_input or needs_approval', () => {
     const filter = statusFilter('blocked')
-    expect(matchesFilter({ status: 'needs_input', labelId: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'needs_approval', labelId: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'errored', labelId: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'needs_input', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'needs_approval', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'errored', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'completed', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('returns true for "running" status filter only when running', () => {
     const filter = statusFilter('running')
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'needs_input', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'needs_input', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('returns true for "idle" status filter only when idle', () => {
     const filter = statusFilter('idle')
-    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'errored', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'errored', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('returns true for "errored" status filter only when errored', () => {
     const filter = statusFilter('errored')
-    expect(matchesFilter({ status: 'errored', labelId: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'errored', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('returns true for "completed" status filter when completed', () => {
     const filter = statusFilter('completed')
-    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'errored', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'completed', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'errored', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('matches by project name when project filter is set', () => {
     const filter = projectFilter('my-app')
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'my-app' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'other-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'other-app' }, filter)).toBe(false)
   })
 
   // ── Multi-select tests ──
 
   it('allows multiple statuses to be selected simultaneously', () => {
     const filter = statusFilter('running', 'idle')
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'needs_input', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'needs_input', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('allows multiple projects to be selected simultaneously', () => {
     const filter = projectFilter('app-a', 'app-b')
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'app-a' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'app-b' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'app-c' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'app-a' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'app-b' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'app-c' }, filter)).toBe(false)
   })
 
   it('combines status AND project filters (both must match)', () => {
     const filter = combinedFilter(['running'], ['my-app'])
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'my-app' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'other-app' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'my-app' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'other-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'other-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', labelIds: [], projectName: 'my-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', labelIds: [], projectName: 'other-app' }, filter)).toBe(false)
   })
 
   it('combines multiple statuses AND multiple projects', () => {
     const filter = combinedFilter(['running', 'blocked'], ['app-a', 'app-b'])
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'app-a' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'needs_input', labelId: null, projectName: 'app-b' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'needs_approval', labelId: null, projectName: 'app-a' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'app-a' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'app-c' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'app-a' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'needs_input', labelIds: [], projectName: 'app-b' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'needs_approval', labelIds: [], projectName: 'app-a' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelIds: [], projectName: 'app-a' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'app-c' }, filter)).toBe(false)
   })
 
   it('status-only filter does not restrict by project', () => {
     const filter = statusFilter('running')
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'any-project' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'another-project' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'any-project' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'another-project' }, filter)).toBe(true)
   })
 
   it('project-only filter does not restrict by status', () => {
     const filter = projectFilter('my-app')
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'my-app' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'my-app' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'errored', labelId: null, projectName: 'my-app' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelIds: [], projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'errored', labelIds: [], projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', labelIds: [], projectName: 'my-app' }, filter)).toBe(true)
   })
 })
 
 describe('label filters', () => {
   it('matches agents with a specific label', () => {
     const filter = labelFilter('in_review')
-    expect(matchesFilter({ status: 'running', labelId: 'in_review', projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', labelId: 'in_review', projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', labelId: 'done', projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: ['in_review'], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelIds: ['in_review'], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: ['done'], projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('matches multiple labels', () => {
     const filter = labelFilter('in_review', 'draft')
-    expect(matchesFilter({ status: 'running', labelId: 'in_review', projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', labelId: 'draft', projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', labelId: 'done', projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: ['in_review'], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: ['draft'], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: ['done'], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('combines status AND label filters', () => {
@@ -351,52 +351,71 @@ describe('label filters', () => {
       statuses: new Set<StatusFilter>(['running']),
       labels: new Set<LabelFilter>(['in_review'])
     }
-    expect(matchesFilter({ status: 'running', labelId: 'in_review', projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', labelId: 'in_review', projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: ['in_review'], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelIds: ['in_review'], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('label filter does not affect agents without labels when not filtering by label', () => {
     const filter = statusFilter('running')
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', labelId: 'done', projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: ['done'], projectName: 'proj' }, filter)).toBe(true)
+  })
+
+  it('matches agent with multiple labels when filter matches any', () => {
+    const filter = labelFilter('in_review')
+    expect(matchesFilter({ status: 'running', labelIds: ['in_review', 'draft'], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: ['draft', 'done'], projectName: 'proj' }, filter)).toBe(false)
+  })
+
+  it('matches agent with multiple labels against multiple label filters', () => {
+    const filter = labelFilter('in_review', 'done')
+    expect(matchesFilter({ status: 'running', labelIds: ['in_review', 'draft'], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: ['done'], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: ['blocked'], projectName: 'proj' }, filter)).toBe(false)
   })
 })
 
 describe('negative (exclude) filters', () => {
   it('excludes agents matching an excluded status', () => {
     const filter = excludeStatusFilter('completed')
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('excludes agents matching excluded "blocked" status (needs_input + needs_approval)', () => {
     const filter = excludeStatusFilter('blocked')
-    expect(matchesFilter({ status: 'needs_input', labelId: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'needs_approval', labelId: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'needs_input', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'needs_approval', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
   })
 
   it('excludes agents matching multiple excluded statuses', () => {
     const filter: FilterState = { ...EMPTY, excludeStatuses: new Set<StatusFilter>(['completed', 'errored']) }
-    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'errored', labelId: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'errored', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
   })
 
   it('excludes agents matching an excluded label', () => {
     const filter = excludeLabelFilter('done')
-    expect(matchesFilter({ status: 'running', labelId: 'done', projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', labelId: 'in_review', projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: ['done'], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: ['in_review'], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+  })
+
+  it('excludes agent with multiple labels if any label is excluded', () => {
+    const filter = excludeLabelFilter('done')
+    expect(matchesFilter({ status: 'running', labelIds: ['done', 'in_review'], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: ['in_review', 'draft'], projectName: 'proj' }, filter)).toBe(true)
   })
 
   it('excludes agents matching an excluded project', () => {
     const filter = excludeProjectFilter('my-app')
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'my-app' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'other-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'my-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'other-app' }, filter)).toBe(true)
   })
 
   it('combines include status + exclude status (e.g. running but not errored)', () => {
@@ -405,9 +424,9 @@ describe('negative (exclude) filters', () => {
       statuses: new Set<StatusFilter>(['running', 'errored']),
       excludeStatuses: new Set<StatusFilter>(['errored'])
     }
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'errored', labelId: null, projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'errored', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('exclude takes precedence over include for same dimension', () => {
@@ -417,7 +436,7 @@ describe('negative (exclude) filters', () => {
       statuses: new Set<StatusFilter>(['running']),
       excludeStatuses: new Set<StatusFilter>(['running'])
     }
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('combines exclude status with include project', () => {
@@ -426,9 +445,9 @@ describe('negative (exclude) filters', () => {
       excludeStatuses: new Set<StatusFilter>(['completed']),
       projects: new Set(['my-app'])
     }
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'my-app' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'my-app' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'other-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'my-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', labelIds: [], projectName: 'my-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'other-app' }, filter)).toBe(false)
   })
 
   it('combines include status with exclude project', () => {
@@ -437,9 +456,9 @@ describe('negative (exclude) filters', () => {
       statuses: new Set<StatusFilter>(['running']),
       excludeProjects: new Set(['my-app'])
     }
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'other-app' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'my-app' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'other-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'other-app' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'my-app' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', labelIds: [], projectName: 'other-app' }, filter)).toBe(false)
   })
 
   it('combines exclude label with include status', () => {
@@ -448,25 +467,25 @@ describe('negative (exclude) filters', () => {
       statuses: new Set<StatusFilter>(['running']),
       excludeLabels: new Set<LabelFilter>(['done'])
     }
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', labelId: 'in_review', projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'running', labelId: 'done', projectName: 'proj' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: ['in_review'], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: ['done'], projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'idle', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
   })
 
   it('excludes multiple projects', () => {
     const filter = excludeProjectFilter('app-a', 'app-b')
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'app-a' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'app-b' }, filter)).toBe(false)
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'app-c' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'app-a' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'app-b' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'app-c' }, filter)).toBe(true)
   })
 
   it('exclude-only filter still passes agents not matching the exclusion', () => {
     const filter = excludeStatusFilter('idle')
-    expect(matchesFilter({ status: 'running', labelId: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'completed', labelId: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'errored', labelId: null, projectName: 'proj' }, filter)).toBe(true)
-    expect(matchesFilter({ status: 'idle', labelId: null, projectName: 'proj' }, filter)).toBe(false)
+    expect(matchesFilter({ status: 'running', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'completed', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'errored', labelIds: [], projectName: 'proj' }, filter)).toBe(true)
+    expect(matchesFilter({ status: 'idle', labelIds: [], projectName: 'proj' }, filter)).toBe(false)
   })
 })
 
@@ -696,7 +715,7 @@ describe('sortUrgentFirst', () => {
 
   it('does not treat "done" label as urgent', () => {
     const running = createAgent({ id: 'r', status: 'running' })
-    const done = createAgent({ id: 'm', status: 'idle', labelId: 'done' })
+    const done = createAgent({ id: 'm', status: 'idle', labelIds: ['done'] })
     const blocked = createAgent({ id: 'b', status: 'needs_input' })
     const sorted = sortUrgentFirst([done, running, blocked])
     expect(sorted[0].id).toBe('b')
@@ -704,7 +723,7 @@ describe('sortUrgentFirst', () => {
 
   it('does not treat in_review label as urgent', () => {
     const running = createAgent({ id: 'r', status: 'running' })
-    const review = createAgent({ id: 'rv', status: 'idle', labelId: 'in_review' })
+    const review = createAgent({ id: 'rv', status: 'idle', labelIds: ['in_review'] })
     const blocked = createAgent({ id: 'b', status: 'needs_input' })
     const sorted = sortUrgentFirst([review, running, blocked])
     expect(sorted[0].id).toBe('b')
@@ -712,7 +731,7 @@ describe('sortUrgentFirst', () => {
 
   it('treats "blocked" label as urgent', () => {
     const running = createAgent({ id: 'r', status: 'running' })
-    const blockedLabel = createAgent({ id: 'bm', status: 'idle', labelId: 'blocked' })
+    const blockedLabel = createAgent({ id: 'bm', status: 'idle', labelIds: ['blocked'] })
     const idle = createAgent({ id: 'i', status: 'idle' })
     const sorted = sortUrgentFirst([idle, running, blockedLabel])
     expect(sorted[0].id).toBe('bm')

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -336,13 +336,13 @@ export function registerIpcHandlers(): void {
         displayName: agent.displayName,
         taskSummary: agent.taskSummary,
         persistedStatus: agent.persistedStatus,
-        labelId: agent.labelId,
+        labelIds: agent.labelIds ?? [],
         prUrl: agent.prUrl
       }))
     }
   })
 
-  ipcMain.handle('agent:update-meta', async (_event, agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelId?: string; prUrl?: string }) => {
+  ipcMain.handle('agent:update-meta', async (_event, agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelIds?: string[]; prUrl?: string }) => {
     try {
       agentController.updateAgentMeta(agentId, meta)
       return { ok: true }

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -76,6 +76,8 @@ export interface AgentHandle {
   displayName: string
   taskSummary: string
   persistedStatus?: string
+  labelIds?: string[]
+  /** @deprecated Use labelIds instead. Kept for reading legacy persisted data. */
   labelId?: string
   prUrl?: string
   bridge: EventBridge
@@ -90,6 +92,8 @@ interface PersistedAgentHandle {
   displayName?: string
   taskSummary?: string
   persistedStatus?: string
+  labelIds?: string[]
+  /** @deprecated Use labelIds instead. Kept for reading legacy persisted data. */
   labelId?: string
   prUrl?: string
 }
@@ -131,7 +135,7 @@ class AgentController {
           displayName: persistedAgent.displayName ?? '',
           taskSummary: persistedAgent.taskSummary ?? '',
           persistedStatus: persistedAgent.persistedStatus,
-          labelId: persistedAgent.labelId,
+          labelIds: persistedAgent.labelIds ?? (persistedAgent.labelId ? [persistedAgent.labelId] : []),
           prUrl: persistedAgent.prUrl,
           bridge: this.bridges.get(runtime.id)!
         }
@@ -300,14 +304,14 @@ class AgentController {
   /**
    * Update the persisted display name, task summary, and/or status for an agent.
    */
-  updateAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelId?: string; prUrl?: string }): void {
+  updateAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelIds?: string[]; prUrl?: string }): void {
     const handle = this.agents.get(agentId)
     if (!handle) return
 
     if (meta.displayName !== undefined) handle.displayName = meta.displayName
     if (meta.taskSummary !== undefined) handle.taskSummary = meta.taskSummary
     if (meta.persistedStatus !== undefined) handle.persistedStatus = meta.persistedStatus
-    if (meta.labelId !== undefined) handle.labelId = meta.labelId
+    if (meta.labelIds !== undefined) handle.labelIds = meta.labelIds
     if (meta.prUrl !== undefined) handle.prUrl = meta.prUrl
     this.persistAgents()
   }
@@ -1151,7 +1155,7 @@ class AgentController {
       displayName: agent.displayName,
       taskSummary: agent.taskSummary,
       persistedStatus: agent.persistedStatus,
-      labelId: agent.labelId,
+      labelIds: agent.labelIds,
       prUrl: agent.prUrl
     }))
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -84,7 +84,7 @@ const api = {
   listAgents: (): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:list'),
 
-  updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelId?: string }): Promise<IpcResult> =>
+  updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelIds?: string[] }): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:update-meta', agentId, meta),
 
   getStatuses: (): Promise<IpcResult> =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -101,7 +101,8 @@ export function App() {
     removeAgent: storeRemoveAgent,
     setAgentModel: storeSetAgentModel,
     executeCommand: storeExecuteCommand,
-    setLabel: storeSetLabel,
+    toggleLabel: storeToggleLabel,
+    clearLabels: storeClearLabels,
     renameAgent: storeRenameAgent,
     setPrUrl: storeSetPrUrl
   } = store
@@ -266,7 +267,7 @@ export function App() {
       workspaceName: agent.workspaceName,
       taskSummary: agent.taskSummary,
       status: agent.status,
-      labelId: agent.labelId,
+      labelIds: agent.labelIds,
       model: agent.model,
       prUrl: agent.prUrl,
       lastActivityAt: formatTimeAgo(agent.lastActivityAt),
@@ -553,8 +554,8 @@ export function App() {
   const labelCounts = useMemo(() => {
     const counts: Record<string, number> = {}
     for (const agent of displayAgents) {
-      if (agent.labelId) {
-        counts[agent.labelId] = (counts[agent.labelId] ?? 0) + 1
+      for (const id of agent.labelIds) {
+        counts[id] = (counts[id] ?? 0) + 1
       }
     }
     return counts
@@ -607,18 +608,22 @@ export function App() {
     setSelectedAgentId(agentId)
   }, [])
 
-  const handleSetLabel = useCallback((agentId: string, labelId: string | null) => {
-    storeSetLabel(agentId, labelId)
-  }, [storeSetLabel])
+  const handleToggleLabel = useCallback((agentId: string, labelId: string) => {
+    storeToggleLabel(agentId, labelId)
+  }, [storeToggleLabel])
+
+  const handleClearLabels = useCallback((agentId: string) => {
+    storeClearLabels(agentId)
+  }, [storeClearLabels])
 
   const handleDeleteLabel = useCallback(async (labelId: string): Promise<boolean> => {
     for (const agent of store.agents) {
-      if (agent.labelId === labelId) {
-        storeSetLabel(agent.id, null)
+      if (agent.labelIds.includes(labelId)) {
+        storeToggleLabel(agent.id, labelId)
       }
     }
     return deleteLabel(labelId)
-  }, [store.agents, storeSetLabel, deleteLabel])
+  }, [store.agents, storeToggleLabel, deleteLabel])
 
   const handleRemoveAgent = useCallback((agentId: string) => {
     const liveAgent = findLiveAgent(agentId)
@@ -782,9 +787,13 @@ export function App() {
     setShowModelPicker(true)
   }, [selectedAgentId])
 
-  const handleDrawerSetLabel = useCallback((labelId: string | null) => {
-    if (selectedAgentId) handleSetLabel(selectedAgentId, labelId)
-  }, [selectedAgentId, handleSetLabel])
+  const handleDrawerToggleLabel = useCallback((labelId: string) => {
+    if (selectedAgentId) handleToggleLabel(selectedAgentId, labelId)
+  }, [selectedAgentId, handleToggleLabel])
+
+  const handleDrawerClearLabels = useCallback(() => {
+    if (selectedAgentId) handleClearLabels(selectedAgentId)
+  }, [selectedAgentId, handleClearLabels])
 
   const handleDrawerSetPrUrl = useCallback((prUrl: string | null) => {
     if (selectedAgentId) storeSetPrUrl(selectedAgentId, prUrl)
@@ -794,9 +803,9 @@ export function App() {
     if (!selectedAgentId) return
     const result = await storeSendMessage(selectedAgentId, loadSettings().createPrPrompt, undefined, undefined, 'Create PR')
     if (result?.ok) {
-      storeSetLabel(selectedAgentId, 'in_review')
+      storeToggleLabel(selectedAgentId, 'in_review')
     }
-  }, [selectedAgentId, storeSendMessage, storeSetLabel])
+  }, [selectedAgentId, storeSendMessage, storeToggleLabel])
 
   const handleOpenInEditor = useCallback(() => {
     if (!selectedAgentId) return
@@ -817,7 +826,7 @@ export function App() {
   const handleCreatePrForAgent = useCallback(async (agentId: string) => {
     const result = await store.sendMessage(agentId, loadSettings().createPrPrompt, undefined, undefined, 'Create PR')
     if (result?.ok) {
-      store.setLabel(agentId, 'in_review')
+      store.toggleLabel(agentId, 'in_review')
     }
   }, [store])
 
@@ -1200,7 +1209,8 @@ export function App() {
           setModelPickerAgentId(agentId)
           setShowModelPicker(true)
         }}
-        onSetLabel={handleSetLabel}
+        onToggleLabel={handleToggleLabel}
+        onClearLabels={handleClearLabels}
         allLabels={allLabels}
         onCreateLabel={createLabel}
         onDeleteLabel={handleDeleteLabel}
@@ -1237,7 +1247,8 @@ export function App() {
            onOpenInEditor={handleOpenInEditor}
           onChangeModel={handleDrawerChangeModel}
           onOpenTerminal={handleOpenTerminalForDrawer}
-          onSetLabel={handleDrawerSetLabel}
+          onToggleLabel={handleDrawerToggleLabel}
+          onClearLabels={handleDrawerClearLabels}
           allLabels={allLabels}
           onCreateLabel={createLabel}
           onDeleteLabel={handleDeleteLabel}

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -109,7 +109,8 @@ interface DetailDrawerProps {
   onOpenInEditor?: () => void
   onChangeModel?: () => void
   onOpenTerminal?: () => void
-  onSetLabel?: (labelId: string | null) => void
+  onToggleLabel?: (labelId: string) => void
+  onClearLabels?: () => void
   allLabels?: LabelDefinition[]
   onCreateLabel?: (name: string, colorKey: LabelColorKey) => Promise<LabelDefinition | null>
   onDeleteLabel?: (id: string) => Promise<boolean>
@@ -139,7 +140,8 @@ export const DetailDrawer = memo(function DetailDrawer({
   onOpenInEditor,
   onChangeModel,
   onOpenTerminal,
-  onSetLabel,
+  onToggleLabel,
+  onClearLabels,
   allLabels = [],
   onCreateLabel,
   onDeleteLabel
@@ -719,10 +721,11 @@ export const DetailDrawer = memo(function DetailDrawer({
           {onAbort && (agent.status === 'running' || agent.status === 'needs_approval' || agent.status === 'needs_input' || agent.status === 'stopping') && (
             <ActionButton icon={<Square size={12} weight="fill" />} label={agent.status === 'stopping' ? 'Stopping…' : 'Stop'} onClick={onAbort} disabled={agent.status === 'stopping'} />
           )}
-          {onSetLabel && (
+          {onToggleLabel && onClearLabels && (
             <LabelDropdown
-              current={agent.labelId}
-              onSelect={onSetLabel}
+              current={agent.labelIds}
+              onToggle={onToggleLabel}
+              onClear={onClearLabels}
               allLabels={allLabels}
               onCreateLabel={onCreateLabel}
               onDeleteLabel={onDeleteLabel}

--- a/src/renderer/src/components/FilterBar.tsx
+++ b/src/renderer/src/components/FilterBar.tsx
@@ -282,19 +282,19 @@ function expandStatuses(filters: Set<StatusFilter>): Set<AgentStatus> {
 }
 
 export function matchesFilter(
-  agent: { status: AgentStatus; labelId: string | null; projectName: string },
+  agent: { status: AgentStatus; labelIds: string[]; projectName: string },
   filter: FilterState
 ): boolean {
   if (isFilterEmpty(filter)) return true
 
   // Exclude filters: reject if agent matches any excluded value
   if (filter.excludeStatuses.size > 0 && expandStatuses(filter.excludeStatuses).has(agent.status)) return false
-  if (filter.excludeLabels.size > 0 && agent.labelId && filter.excludeLabels.has(agent.labelId)) return false
+  if (filter.excludeLabels.size > 0 && agent.labelIds.some((id) => filter.excludeLabels.has(id))) return false
   if (filter.excludeProjects.size > 0 && filter.excludeProjects.has(agent.projectName)) return false
 
   // Include filters: agent must match at least one value in each active include dimension
   if (filter.statuses.size > 0 && !expandStatuses(filter.statuses).has(agent.status)) return false
-  if (filter.labels.size > 0 && (!agent.labelId || !filter.labels.has(agent.labelId))) return false
+  if (filter.labels.size > 0 && !agent.labelIds.some((id) => filter.labels.has(id))) return false
   if (filter.projects.size > 0 && !filter.projects.has(agent.projectName)) return false
 
   return true

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -19,7 +19,7 @@ import {
   ArrowLineUpRight
 } from '@phosphor-icons/react'
 import type { AgentRuntime, LabelDefinition, LabelColorKey } from '../types'
-import { formatBranchLabel, isUrgent } from '../types'
+import { formatBranchLabel, isUrgent, labelSortKey } from '../types'
 import { StatusBadge } from './StatusBadge'
 import { LabelDropdown } from './LabelDropdown'
 import { TextInputModal } from './TextInputModal'
@@ -41,13 +41,14 @@ interface FleetTableProps {
   onCreatePr?: (agentId: string) => void
   onSetPrUrl?: (agentId: string, prUrl: string | null) => void
   onChangeModel?: (agentId: string) => void
-  onSetLabel?: (agentId: string, labelId: string | null) => void
+  onToggleLabel?: (agentId: string, labelId: string) => void
+  onClearLabels?: (agentId: string) => void
   allLabels?: LabelDefinition[]
   onCreateLabel?: (name: string, colorKey: LabelColorKey) => Promise<LabelDefinition | null>
   onDeleteLabel?: (id: string) => Promise<boolean>
 }
 
-type SortColumn = 'agent' | 'status' | 'task' | 'branch' | 'model'
+type SortColumn = 'agent' | 'status' | 'label' | 'task' | 'branch' | 'model'
 type SortDirection = 'asc' | 'desc'
 
 const SCROLL_STEP = 200
@@ -55,6 +56,7 @@ const SCROLL_STEP = 200
 const SORTABLE_COLUMNS: { key: SortColumn; label: string }[] = [
   { key: 'agent', label: 'Agent' },
   { key: 'status', label: 'Status' },
+  { key: 'label', label: 'Label' },
   { key: 'task', label: 'Task' },
   { key: 'branch', label: 'Branch' },
   { key: 'model', label: 'Model' }
@@ -92,7 +94,8 @@ export function FleetTable({
   onCreatePr,
   onSetPrUrl,
   onChangeModel,
-  onSetLabel,
+  onToggleLabel,
+  onClearLabels,
   allLabels = [],
   onCreateLabel,
   onDeleteLabel
@@ -166,6 +169,10 @@ export function FleetTable({
           leftVal = left.status
           rightVal = right.status
           break
+        case 'label':
+          leftVal = labelSortKey(left.labelIds, allLabels)
+          rightVal = labelSortKey(right.labelIds, allLabels)
+          break
         case 'task':
           leftVal = (left.taskSummary || '').toLowerCase()
           rightVal = (right.taskSummary || '').toLowerCase()
@@ -188,7 +195,7 @@ export function FleetTable({
     })
 
     return sorted
-  }, [agents, sortColumn, sortDirection])
+  }, [agents, sortColumn, sortDirection, allLabels])
 
   const headerCellClass = 'px-3 py-2 text-left font-medium text-[11px] uppercase tracking-wide text-kumo-subtle bg-kumo-overlay border-b border-kumo-line cursor-pointer hover:text-kumo-default select-none'
 
@@ -212,13 +219,14 @@ export function FleetTable({
   return (
     <div className="flex-1 relative overflow-hidden flex flex-col" onClick={closeContextMenu}>
       <div ref={scrollContainerRef} className="flex-1 overflow-auto">
-        <table className="w-full border-collapse text-xs" style={{ tableLayout: 'fixed', minWidth: 700 }}>
+        <table className="w-full border-collapse text-xs" style={{ tableLayout: 'fixed', minWidth: 800 }}>
           <colgroup>
-            <col style={{ width: '18%' }} />
             <col style={{ width: '16%' }} />
-            <col style={{ width: '28%' }} />
-            <col style={{ width: '14%' }} />
             <col style={{ width: '12%' }} />
+            <col style={{ width: '12%' }} />
+            <col style={{ width: '26%' }} />
+            <col style={{ width: '12%' }} />
+            <col style={{ width: '10%' }} />
             <col style={{ width: 96 }} />
             <col style={{ width: 40 }} />
           </colgroup>
@@ -252,7 +260,8 @@ export function FleetTable({
                 onOpen={onOpen ? () => onOpen(agent.id) : () => onSelect(agent.id)}
                 onRemove={onRemove ? () => onRemove(agent.id) : undefined}
                 onChangeModel={onChangeModel ? () => onChangeModel(agent.id) : undefined}
-                onSetLabel={onSetLabel ? (labelId: string | null) => onSetLabel(agent.id, labelId) : undefined}
+                onToggleLabel={onToggleLabel ? (labelId: string) => onToggleLabel(agent.id, labelId) : undefined}
+                onClearLabels={onClearLabels ? () => onClearLabels(agent.id) : undefined}
                 allLabels={allLabels}
                 onCreateLabel={onCreateLabel}
                 onDeleteLabel={onDeleteLabel}
@@ -327,8 +336,11 @@ export function FleetTable({
             setPrLinkState({ agentId: contextMenu.agentId, currentUrl: agent?.prUrl ?? '' })
             closeContextMenu()
           }}
-          onSetLabel={(labelId: string | null) => {
-            onSetLabel?.(contextMenu.agentId, labelId)
+          onToggleLabel={(labelId: string) => {
+            onToggleLabel?.(contextMenu.agentId, labelId)
+          }}
+          onClearLabels={() => {
+            onClearLabels?.(contextMenu.agentId)
             closeContextMenu()
           }}
           allLabels={allLabels}
@@ -383,7 +395,8 @@ function ContextMenu({
   onCreatePr,
   onRemovePrLink,
   onEditPrLink,
-  onSetLabel,
+  onToggleLabel,
+  onClearLabels,
   allLabels,
   onCreateLabel,
   onDeleteLabel
@@ -402,7 +415,8 @@ function ContextMenu({
   onCreatePr: () => void
   onRemovePrLink: () => void
   onEditPrLink: () => void
-  onSetLabel: (labelId: string | null) => void
+  onToggleLabel: (labelId: string) => void
+  onClearLabels: () => void
   allLabels: LabelDefinition[]
   onCreateLabel?: (name: string, colorKey: LabelColorKey) => Promise<LabelDefinition | null>
   onDeleteLabel?: (id: string) => Promise<boolean>
@@ -487,8 +501,9 @@ function ContextMenu({
       <div className="px-2.5 py-1.5">
         <div className="text-[10px] text-kumo-subtle uppercase tracking-wide mb-1">Label</div>
         <LabelDropdown
-          current={agent.labelId}
-          onSelect={onSetLabel}
+          current={agent.labelIds}
+          onToggle={onToggleLabel}
+          onClear={onClearLabels}
           allLabels={allLabels}
           onCreateLabel={onCreateLabel}
           onDeleteLabel={onDeleteLabel}
@@ -525,7 +540,8 @@ function AgentRow({
   onOpen,
   onRemove,
   onChangeModel,
-  onSetLabel,
+  onToggleLabel,
+  onClearLabels,
   allLabels = [],
   onCreateLabel,
   onDeleteLabel,
@@ -547,7 +563,8 @@ function AgentRow({
   onOpen?: () => void
   onRemove?: () => void
   onChangeModel?: () => void
-  onSetLabel?: (labelId: string | null) => void
+  onToggleLabel?: (labelId: string) => void
+  onClearLabels?: () => void
   allLabels?: LabelDefinition[]
   onCreateLabel?: (name: string, colorKey: LabelColorKey) => Promise<LabelDefinition | null>
   onDeleteLabel?: (id: string) => Promise<boolean>
@@ -640,23 +657,24 @@ function AgentRow({
       </td>
       <td className="px-3 py-2 overflow-hidden">
         <div className="flex flex-col gap-0.5">
-          <div className="flex items-center gap-1.5 min-w-0">
-            <StatusBadge status={agent.status} />
-            {onSetLabel && (
-              <LabelDropdown
-                current={agent.labelId}
-                onSelect={onSetLabel}
-                allLabels={allLabels}
-                onCreateLabel={onCreateLabel}
-                onDeleteLabel={onDeleteLabel}
-                variant="inline"
-              />
-            )}
-          </div>
+          <StatusBadge status={agent.status} />
           <span className={`font-mono text-[10px] ${isStale ? 'text-kumo-danger font-medium' : 'text-kumo-subtle'}`}>
             {agent.lastActivityAt}
           </span>
         </div>
+      </td>
+      <td className="px-3 py-2">
+        {onToggleLabel && onClearLabels && (
+          <LabelDropdown
+            current={agent.labelIds}
+            onToggle={onToggleLabel}
+            onClear={onClearLabels}
+            allLabels={allLabels}
+            onCreateLabel={onCreateLabel}
+            onDeleteLabel={onDeleteLabel}
+            variant="inline"
+          />
+        )}
       </td>
       <td className="px-3 py-2 truncate text-kumo-default" title={agent.taskSummary || undefined}>
         {agent.taskSummary}

--- a/src/renderer/src/components/LabelDropdown.tsx
+++ b/src/renderer/src/components/LabelDropdown.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import {
   CaretDown,
+  Check,
   CheckCircle,
   Eye,
   Warning,
@@ -10,7 +11,7 @@ import {
   Plus,
   X
 } from '@phosphor-icons/react'
-import { agentLabelDisplay, getLabelDefinition, LABEL_COLORS, type LabelDefinition, type LabelColorKey } from '../types'
+import { getLabelDefinition, LABEL_COLORS, type LabelDefinition, type LabelColorKey } from '../types'
 import { useDismiss } from '../hooks/useDismiss'
 
 const BUILTIN_ICONS: Record<string, React.ReactNode> = {
@@ -26,25 +27,22 @@ const COLOR_KEYS: LabelColorKey[] = [
 ]
 
 interface LabelDropdownProps {
-  current: string | null
-  onSelect: (labelId: string | null) => void
+  current: string[]
+  onToggle: (labelId: string) => void
+  onClear: () => void
   allLabels: LabelDefinition[]
   onCreateLabel?: (name: string, colorKey: LabelColorKey) => Promise<LabelDefinition | null>
   onDeleteLabel?: (id: string) => Promise<boolean>
   variant?: 'row' | 'action' | 'inline'
 }
 
-export function LabelDropdown({ current, onSelect, allLabels, onCreateLabel, onDeleteLabel, variant = 'row' }: LabelDropdownProps) {
+export function LabelDropdown({ current, onToggle, onClear, allLabels, onCreateLabel, onDeleteLabel, variant = 'row' }: LabelDropdownProps) {
   const { open, toggle, close, containerRef } = useDismiss()
   const [creating, setCreating] = useState(false)
   const [newName, setNewName] = useState('')
   const [newColor, setNewColor] = useState<LabelColorKey>('blue')
 
-  const selectAndClose = (value: string | null) => {
-    onSelect(value)
-    setCreating(false)
-    close()
-  }
+  const currentSet = new Set(current)
 
   const handleToggle = (event: React.MouseEvent) => {
     event.stopPropagation()
@@ -56,26 +54,32 @@ export function LabelDropdown({ current, onSelect, allLabels, onCreateLabel, onD
     if (!onCreateLabel || !newName.trim()) return
     const label = await onCreateLabel(newName.trim(), newColor)
     if (label) {
-      onSelect(label.id)
+      onToggle(label.id)
       setNewName('')
       setNewColor('blue')
       setCreating(false)
-      close()
     }
   }
 
   const handleDelete = async (event: React.MouseEvent, labelId: string) => {
     event.stopPropagation()
     if (!onDeleteLabel) return
-    const deleted = await onDeleteLabel(labelId)
-    if (deleted && current === labelId) {
-      onSelect(null)
-    }
+    await onDeleteLabel(labelId)
   }
 
-  const currentLabel = agentLabelDisplay(current, allLabels)
-  const currentDef = getLabelDefinition(current, allLabels)
-  const currentColors = currentDef ? LABEL_COLORS[currentDef.colorKey] : null
+  const sortedCurrent = current
+    .map((id) => getLabelDefinition(id, allLabels))
+    .filter((def): def is LabelDefinition => def !== null)
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+  let displayLabel: string
+  if (sortedCurrent.length === 0) {
+    displayLabel = 'Label'
+  } else if (sortedCurrent.length === 1) {
+    displayLabel = sortedCurrent[0].name
+  } else {
+    displayLabel = `${sortedCurrent.length} labels`
+  }
 
   let menuPosition: string
   let trigger: React.ReactNode
@@ -88,8 +92,8 @@ export function LabelDropdown({ current, onSelect, allLabels, onCreateLabel, onD
           onClick={handleToggle}
           className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md border bg-kumo-control border-kumo-line text-kumo-default hover:bg-kumo-fill transition-colors"
         >
-          {(current && BUILTIN_ICONS[current]) ?? <Tag size={12} />}
-          {currentLabel}
+          {(current.length === 1 && BUILTIN_ICONS[current[0]]) || <Tag size={12} />}
+          {displayLabel}
           <CaretDown size={10} className="ml-0.5" />
         </button>
       )
@@ -97,18 +101,21 @@ export function LabelDropdown({ current, onSelect, allLabels, onCreateLabel, onD
 
     case 'inline':
       menuPosition = 'absolute top-full left-0 mt-1'
-      trigger = current ? (
-        <button
-          onClick={handleToggle}
-          className={`inline-flex items-center px-1.5 py-px rounded text-[10px] font-medium transition-colors cursor-pointer ${
-            currentColors
-              ? `${currentColors.bg} ${currentColors.text}`
-              : 'bg-kumo-brand/10 text-kumo-brand'
-          }`}
-          title="Change label"
-        >
-          {currentLabel}
-        </button>
+      trigger = current.length > 0 ? (
+        <div className="inline-flex items-center gap-0.5" onClick={handleToggle}>
+          {sortedCurrent.map((def) => {
+            const colors = LABEL_COLORS[def.colorKey]
+            return (
+              <span
+                key={def.id}
+                className={`inline-flex items-center px-1.5 py-px rounded text-[10px] font-medium cursor-pointer ${colors.bg} ${colors.text}`}
+                title={def.name}
+              >
+                {def.name}
+              </span>
+            )
+          })}
+        </div>
       ) : (
         <button
           onClick={handleToggle}
@@ -126,7 +133,7 @@ export function LabelDropdown({ current, onSelect, allLabels, onCreateLabel, onD
         <button
           onClick={handleToggle}
           className="w-6 h-6 flex items-center justify-center bg-kumo-fill border border-kumo-line rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors cursor-pointer"
-          title={`Label: ${currentLabel}`}
+          title={`Labels: ${displayLabel}`}
         >
           <CaretDown size={10} />
         </button>
@@ -139,11 +146,11 @@ export function LabelDropdown({ current, onSelect, allLabels, onCreateLabel, onD
       {trigger}
       {open && (
         <div className={`${menuPosition} z-[100] min-w-[160px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl`}>
-          {/* None option */}
+          {/* Clear all option */}
           <button
-            onClick={(event) => { event.stopPropagation(); selectAndClose(null) }}
+            onClick={(event) => { event.stopPropagation(); onClear(); close() }}
             className={`flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] rounded transition-colors text-left ${
-              current === null
+              current.length === 0
                 ? 'bg-kumo-interact/12 text-kumo-link'
                 : 'text-kumo-default hover:bg-kumo-fill'
             }`}
@@ -152,21 +159,24 @@ export function LabelDropdown({ current, onSelect, allLabels, onCreateLabel, onD
             None
           </button>
 
-          {/* All labels (built-in + custom) */}
+          {/* All labels (built-in + custom) — multi-select with checkmarks */}
           {allLabels.map((label) => {
             const colors = LABEL_COLORS[label.colorKey]
-            const isSelected = label.id === current
+            const isSelected = currentSet.has(label.id)
             const isCustom = !label.builtIn
             return (
               <div key={label.id} className="group/label flex items-center">
                 <button
-                  onClick={(event) => { event.stopPropagation(); selectAndClose(label.id) }}
+                  onClick={(event) => { event.stopPropagation(); onToggle(label.id) }}
                   className={`flex items-center gap-2 flex-1 min-w-0 px-2.5 py-1.5 text-[11px] rounded transition-colors text-left ${
                     isSelected
                       ? 'bg-kumo-interact/12 text-kumo-link'
                       : 'text-kumo-default hover:bg-kumo-fill'
                   }`}
                 >
+                  <span className="w-3 shrink-0 flex items-center justify-center">
+                    {isSelected ? <Check size={10} weight="bold" /> : null}
+                  </span>
                   {BUILTIN_ICONS[label.id] ?? (
                     <span className={`w-2.5 h-2.5 rounded-full shrink-0 ${colors.swatch}`} />
                   )}

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -61,7 +61,7 @@ export interface LiveAgent {
   workspaceName: string
   taskSummary: string
   status: AgentStatus
-  labelId: string | null
+  labelIds: string[]
   model: string
   /** The model set by the user or first top-level assistant message.
    *  Used to restore the displayed model after an invoked agent
@@ -258,7 +258,7 @@ function emitMessagesThrottled(agentChanged: boolean): void {
   }
 }
 
-function persistAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelId?: string; prUrl?: string }): void {
+function persistAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelIds?: string[]; prUrl?: string }): void {
   window.api?.updateAgentMeta(agentId, meta)
 }
 
@@ -1329,7 +1329,7 @@ function upsertAgent(payload: AgentLaunchedPayload, initialStatus?: AgentStatus)
     workspaceName: payload.workspaceName ?? existingAgent?.workspaceName ?? payload.directory.split('/').pop() ?? payload.directory,
     taskSummary: payload.taskSummary || existingAgent?.taskSummary || (hasPrompt ? payload.prompt.slice(0, 120) : 'Waiting for prompt...'),
     status: initialStatus ?? existingAgent?.status ?? (hasPrompt ? 'running' : 'idle'),
-    labelId: existingAgent?.labelId ?? null,
+    labelIds: existingAgent?.labelIds ?? [],
     model: existingAgent?.model ?? 'starting...',
     configuredModel: existingAgent?.configuredModel,
     prUrl: existingAgent?.prUrl ?? payload.prUrl ?? null,
@@ -1709,7 +1709,7 @@ export function useAgentStore() {
 
       if (agentsResult.ok && agentsResult.data) {
         // Legacy: old versions stored label values in persistedStatus.
-        // Map them to labelId for backward compatibility during migration.
+        // Map them to labelIds for backward compatibility during migration.
         const LEGACY_PERSISTED_TO_LABEL: Record<string, string> = {
           in_review: 'in_review', blocked: 'blocked', done: 'done', draft: 'draft',
           completed_manual: 'done', blocked_manual: 'blocked'
@@ -1728,11 +1728,15 @@ export function useAgentStore() {
           upsertAgent(agent, restoredStatus)
           const liveAgent = state.agents.get(agent.id)
           if (liveAgent) {
-            // Prefer the new labelId field; fall back to legacy persistedStatus mapping
-            const labelId = agent.labelId
-              || (agent.persistedStatus && LEGACY_PERSISTED_TO_LABEL[agent.persistedStatus])
-              || null
-            liveAgent.labelId = labelId
+            // Prefer labelIds; fall back to legacy labelId; fall back to legacy persistedStatus mapping
+            if (agent.labelIds) {
+              liveAgent.labelIds = agent.labelIds
+            } else if (agent.labelId) {
+              liveAgent.labelIds = [agent.labelId]
+            } else {
+              const legacyLabel = agent.persistedStatus && LEGACY_PERSISTED_TO_LABEL[agent.persistedStatus]
+              liveAgent.labelIds = legacyLabel ? [legacyLabel] : []
+            }
           }
           shouldEmit = true
         }
@@ -1892,7 +1896,7 @@ export function useAgentStore() {
 
     const previousStatus = agent?.status
     const previousBlockedSince = agent?.blockedSince
-    const previousLabelId = agent?.labelId ?? null
+    const previousLabelIds = agent?.labelIds ? [...agent.labelIds] : []
 
     if (agent) {
       applyOptimisticSendState(agentId, agent, text, taskSummaryOverride)
@@ -1921,7 +1925,7 @@ export function useAgentStore() {
         agentAfter.blockedSince = previousBlockedSince
         agentAfter.respondedAt = undefined
         agentAfter.lastActivityAt = Date.now()
-        agentAfter.labelId = previousLabelId
+        agentAfter.labelIds = previousLabelIds
       }
       for (const [qId, q] of removedQuestions) {
         state.questions.set(qId, q)
@@ -2018,7 +2022,7 @@ export function useAgentStore() {
     const agent = state.agents.get(agentId)
     const previousStatus = agent?.status
     const previousBlockedSince = agent?.blockedSince
-    const previousLabelId = agent?.labelId ?? null
+    const previousLabelIds = agent?.labelIds ? [...agent.labelIds] : []
     const removedPermission = state.permissions.get(permissionId)
 
     // Optimistically clear permission and set running
@@ -2043,7 +2047,7 @@ export function useAgentStore() {
         agentAfter.blockedSince = previousBlockedSince
         agentAfter.respondedAt = undefined
         agentAfter.lastActivityAt = Date.now()
-        agentAfter.labelId = previousLabelId
+        agentAfter.labelIds = previousLabelIds
       }
       if (removedPermission) {
         state.permissions.set(permissionId, removedPermission)
@@ -2060,7 +2064,7 @@ export function useAgentStore() {
     const agent = state.agents.get(agentId)
     const previousStatus = agent?.status
     const previousBlockedSince = agent?.blockedSince
-    const previousLabelId = agent?.labelId ?? null
+    const previousLabelIds = agent?.labelIds ? [...agent.labelIds] : []
     const removedQuestion = state.questions.get(requestId)
 
     // Optimistically clear question and set running
@@ -2083,7 +2087,7 @@ export function useAgentStore() {
         agentAfter.blockedSince = previousBlockedSince
         agentAfter.respondedAt = undefined
         agentAfter.lastActivityAt = Date.now()
-        agentAfter.labelId = previousLabelId
+        agentAfter.labelIds = previousLabelIds
       }
       if (removedQuestion) {
         state.questions.set(requestId, removedQuestion)
@@ -2100,7 +2104,7 @@ export function useAgentStore() {
     const agent = state.agents.get(agentId)
     const previousStatus = agent?.status
     const previousBlockedSince = agent?.blockedSince
-    const previousLabelId = agent?.labelId ?? null
+    const previousLabelIds = agent?.labelIds ? [...agent.labelIds] : []
     const removedQuestion = state.questions.get(requestId)
 
     // Optimistically clear question and set running
@@ -2123,7 +2127,7 @@ export function useAgentStore() {
         agentAfter.blockedSince = previousBlockedSince
         agentAfter.respondedAt = undefined
         agentAfter.lastActivityAt = Date.now()
-        agentAfter.labelId = previousLabelId
+        agentAfter.labelIds = previousLabelIds
       }
       if (removedQuestion) {
         state.questions.set(requestId, removedQuestion)
@@ -2239,12 +2243,24 @@ export function useAgentStore() {
     emit({ agents: true })
   }, [])
 
-  const setLabel = useCallback((agentId: string, labelId: string | null) => {
+  const toggleLabel = useCallback((agentId: string, labelId: string) => {
     const agent = state.agents.get(agentId)
     if (!agent) return
-    agent.labelId = labelId
+    const has = agent.labelIds.includes(labelId)
+    agent.labelIds = has
+      ? agent.labelIds.filter((id) => id !== labelId)
+      : [...agent.labelIds, labelId]
     agent.lastActivityAt = Date.now()
-    persistAgentMeta(agentId, { labelId: labelId ?? '' })
+    persistAgentMeta(agentId, { labelIds: agent.labelIds })
+    emit({ agents: true })
+  }, [])
+
+  const clearLabels = useCallback((agentId: string) => {
+    const agent = state.agents.get(agentId)
+    if (!agent) return
+    agent.labelIds = []
+    agent.lastActivityAt = Date.now()
+    persistAgentMeta(agentId, { labelIds: [] })
     emit({ agents: true })
   }, [])
 
@@ -2275,7 +2291,8 @@ export function useAgentStore() {
     removeAgent,
     renameAgent,
     setAgentModel,
-    setLabel,
+    toggleLabel,
+    clearLabels,
     setPrUrl,
     selectDirectory,
     getMessagesForSession,
@@ -2288,7 +2305,7 @@ export function useAgentStore() {
     executeCommand, prepareFreshAgent, resetSession,
     respondToPermission, replyToQuestion, rejectQuestion,
     abortAgent, removeAgent, renameAgent, setAgentModel,
-    setLabel, setPrUrl, selectDirectory,
+    toggleLabel, clearLabels, setPrUrl, selectDirectory,
     getMessagesForSession, getFileChangesForSession,
     getEventsForSession, getToolCallsForSession
   ])

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -35,7 +35,7 @@ export interface OrchestratorApi {
   listSessions: (directory: string) => Promise<IpcResult<SessionListEntry[]>>
   resumeAgent: (options: { directory: string; sessionId: string; title?: string }) => Promise<IpcResult>
   listAgents: () => Promise<IpcResult<ListAgentsPayload>>
-  updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelId?: string; prUrl?: string }) => Promise<IpcResult>
+  updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelIds?: string[]; prUrl?: string }) => Promise<IpcResult>
   getStatuses: () => Promise<IpcResult<AgentStatusesPayload>>
   replyToQuestion: (agentId: string, requestId: string, answers: string[][]) => Promise<IpcResult>
   rejectQuestion: (agentId: string, requestId: string) => Promise<IpcResult>
@@ -171,6 +171,8 @@ export interface AgentLaunchedPayload {
   displayName?: string
   taskSummary?: string
   persistedStatus?: string
+  labelIds?: string[]
+  /** @deprecated Use labelIds. Kept for reading legacy persisted data. */
   labelId?: string
   prUrl?: string
 }

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -76,7 +76,7 @@ export interface AgentRuntime {
   workspaceName: string
   taskSummary: string
   status: AgentStatus
-  labelId: string | null
+  labelIds: string[]
   model: string
   prUrl: string | null
   lastActivityAt: string
@@ -117,8 +117,8 @@ export function isBlocked(status: AgentStatus): boolean {
   return status === 'needs_input' || status === 'needs_approval'
 }
 
-export function isUrgent(agent: { status: AgentStatus; labelId: string | null }): boolean {
-  return isBlocked(agent.status) || agent.status === 'errored' || agent.labelId === 'blocked'
+export function isUrgent(agent: { status: AgentStatus; labelIds: string[] }): boolean {
+  return isBlocked(agent.status) || agent.status === 'errored' || agent.labelIds.includes('blocked')
 }
 
 export function formatBranchLabel(agent: Pick<AgentRuntime, 'branchName'>): string {
@@ -151,4 +151,20 @@ export function agentLabelDisplay(labelId: string | null, customLabels: LabelDef
   if (!labelId) return 'None'
   const def = getLabelDefinition(labelId, customLabels)
   return def?.name ?? labelId
+}
+
+function resolveNames(labelIds: string[], allLabels: LabelDefinition[]): string[] {
+  return labelIds
+    .map((id) => getLabelDefinition(id, allLabels)?.name ?? id)
+    .sort((a, b) => a.localeCompare(b))
+}
+
+export function agentLabelsDisplay(labelIds: string[], customLabels: LabelDefinition[] = []): string {
+  if (labelIds.length === 0) return 'None'
+  return resolveNames(labelIds, customLabels).join(', ')
+}
+
+export function labelSortKey(labelIds: string[], allLabels: LabelDefinition[] = []): string {
+  if (labelIds.length === 0) return '\uffff'
+  return resolveNames(labelIds, allLabels).join(',').toLowerCase()
 }


### PR DESCRIPTION
Agents can now have more than one label applied simultaneously. Labels live in their own table column (sortable alphabetically) instead of being inlined in the status cell. The LabelDropdown uses checkmark-based multi-select, and the filter bar handles multi-label include/exclude correctly.

Backward-compatible: persisted single labelId is migrated to labelIds[] on restore.