### PR TITLE
Fix inline label interactions in FleetTable

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -103,6 +103,7 @@ export function App() {
     executeCommand: storeExecuteCommand,
     toggleLabel: storeToggleLabel,
     clearLabels: storeClearLabels,
+    replaceLabel: storeReplaceLabel,
     renameAgent: storeRenameAgent,
     setPrUrl: storeSetPrUrl
   } = store
@@ -615,6 +616,10 @@ export function App() {
   const handleClearLabels = useCallback((agentId: string) => {
     storeClearLabels(agentId)
   }, [storeClearLabels])
+
+  const handleReplaceLabel = useCallback((agentId: string, oldLabelId: string, newLabelId: string) => {
+    storeReplaceLabel(agentId, oldLabelId, newLabelId)
+  }, [storeReplaceLabel])
 
   const handleDeleteLabel = useCallback(async (labelId: string): Promise<boolean> => {
     for (const agent of store.agents) {
@@ -1211,6 +1216,7 @@ export function App() {
         }}
         onToggleLabel={handleToggleLabel}
         onClearLabels={handleClearLabels}
+        onReplaceLabel={handleReplaceLabel}
         allLabels={allLabels}
         onCreateLabel={createLabel}
         onDeleteLabel={handleDeleteLabel}

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -43,6 +43,7 @@ interface FleetTableProps {
   onChangeModel?: (agentId: string) => void
   onToggleLabel?: (agentId: string, labelId: string) => void
   onClearLabels?: (agentId: string) => void
+  onReplaceLabel?: (agentId: string, oldLabelId: string, newLabelId: string) => void
   allLabels?: LabelDefinition[]
   onCreateLabel?: (name: string, colorKey: LabelColorKey) => Promise<LabelDefinition | null>
   onDeleteLabel?: (id: string) => Promise<boolean>
@@ -96,6 +97,7 @@ export function FleetTable({
   onChangeModel,
   onToggleLabel,
   onClearLabels,
+  onReplaceLabel,
   allLabels = [],
   onCreateLabel,
   onDeleteLabel
@@ -262,6 +264,7 @@ export function FleetTable({
                 onChangeModel={onChangeModel ? () => onChangeModel(agent.id) : undefined}
                 onToggleLabel={onToggleLabel ? (labelId: string) => onToggleLabel(agent.id, labelId) : undefined}
                 onClearLabels={onClearLabels ? () => onClearLabels(agent.id) : undefined}
+                onReplaceLabel={onReplaceLabel ? (oldId: string, newId: string) => onReplaceLabel(agent.id, oldId, newId) : undefined}
                 allLabels={allLabels}
                 onCreateLabel={onCreateLabel}
                 onDeleteLabel={onDeleteLabel}
@@ -542,6 +545,7 @@ function AgentRow({
   onChangeModel,
   onToggleLabel,
   onClearLabels,
+  onReplaceLabel,
   allLabels = [],
   onCreateLabel,
   onDeleteLabel,
@@ -565,6 +569,7 @@ function AgentRow({
   onChangeModel?: () => void
   onToggleLabel?: (labelId: string) => void
   onClearLabels?: () => void
+  onReplaceLabel?: (oldLabelId: string, newLabelId: string) => void
   allLabels?: LabelDefinition[]
   onCreateLabel?: (name: string, colorKey: LabelColorKey) => Promise<LabelDefinition | null>
   onDeleteLabel?: (id: string) => Promise<boolean>
@@ -669,6 +674,7 @@ function AgentRow({
             current={agent.labelIds}
             onToggle={onToggleLabel}
             onClear={onClearLabels}
+            onReplace={onReplaceLabel}
             allLabels={allLabels}
             onCreateLabel={onCreateLabel}
             onDeleteLabel={onDeleteLabel}

--- a/src/renderer/src/components/LabelDropdown.tsx
+++ b/src/renderer/src/components/LabelDropdown.tsx
@@ -30,34 +30,55 @@ interface LabelDropdownProps {
   current: string[]
   onToggle: (labelId: string) => void
   onClear: () => void
+  onReplace?: (oldLabelId: string, newLabelId: string) => void
   allLabels: LabelDefinition[]
   onCreateLabel?: (name: string, colorKey: LabelColorKey) => Promise<LabelDefinition | null>
   onDeleteLabel?: (id: string) => Promise<boolean>
   variant?: 'row' | 'action' | 'inline'
 }
 
-export function LabelDropdown({ current, onToggle, onClear, allLabels, onCreateLabel, onDeleteLabel, variant = 'row' }: LabelDropdownProps) {
+export function LabelDropdown({ current, onToggle, onClear, onReplace, allLabels, onCreateLabel, onDeleteLabel, variant = 'row' }: LabelDropdownProps) {
   const { open, toggle, close, containerRef } = useDismiss()
   const [creating, setCreating] = useState(false)
   const [newName, setNewName] = useState('')
   const [newColor, setNewColor] = useState<LabelColorKey>('blue')
+  const [replacingLabelId, setReplacingLabelId] = useState<string | null>(null)
 
   const currentSet = new Set(current)
 
-  const handleToggle = (event: React.MouseEvent) => {
+  const handleOpen = (event: React.MouseEvent) => {
     event.stopPropagation()
+    setReplacingLabelId(null)
     toggle()
     if (open) setCreating(false)
+  }
+
+  const handlePillClick = (event: React.MouseEvent, labelId: string) => {
+    event.stopPropagation()
+    if (open && replacingLabelId === labelId) {
+      close()
+      setReplacingLabelId(null)
+    } else {
+      setReplacingLabelId(labelId)
+      setCreating(false)
+      if (!open) toggle()
+    }
   }
 
   const handleCreate = async () => {
     if (!onCreateLabel || !newName.trim()) return
     const label = await onCreateLabel(newName.trim(), newColor)
     if (label) {
-      onToggle(label.id)
+      if (replacingLabelId && onReplace) {
+        onReplace(replacingLabelId, label.id)
+      } else {
+        onToggle(label.id)
+      }
       setNewName('')
       setNewColor('blue')
       setCreating(false)
+      setReplacingLabelId(null)
+      close()
     }
   }
 
@@ -81,6 +102,9 @@ export function LabelDropdown({ current, onToggle, onClear, allLabels, onCreateL
     displayLabel = `${sortedCurrent.length} labels`
   }
 
+  const isReplacing = replacingLabelId !== null
+  const replacingDef = replacingLabelId ? getLabelDefinition(replacingLabelId, allLabels) : null
+
   let menuPosition: string
   let trigger: React.ReactNode
 
@@ -89,7 +113,7 @@ export function LabelDropdown({ current, onToggle, onClear, allLabels, onCreateL
       menuPosition = 'absolute bottom-full left-0 mb-1'
       trigger = (
         <button
-          onClick={handleToggle}
+          onClick={handleOpen}
           className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md border bg-kumo-control border-kumo-line text-kumo-default hover:bg-kumo-fill transition-colors"
         >
           {(current.length === 1 && BUILTIN_ICONS[current[0]]) || <Tag size={12} />}
@@ -101,29 +125,30 @@ export function LabelDropdown({ current, onToggle, onClear, allLabels, onCreateL
 
     case 'inline':
       menuPosition = 'absolute top-full left-0 mt-1'
-      trigger = current.length > 0 ? (
-        <div className="inline-flex items-center gap-0.5" onClick={handleToggle}>
+      trigger = (
+        <div className="inline-flex items-center gap-0.5">
           {sortedCurrent.map((def) => {
             const colors = LABEL_COLORS[def.colorKey]
+            const isBeingReplaced = open && replacingLabelId === def.id
             return (
               <span
                 key={def.id}
-                className={`inline-flex items-center px-1.5 py-px rounded text-[10px] font-medium cursor-pointer ${colors.bg} ${colors.text}`}
+                className={`inline-flex items-center px-1.5 py-px rounded text-[10px] font-medium cursor-pointer ${colors.bg} ${colors.text} ${isBeingReplaced ? 'ring-1 ring-white/40' : ''}`}
                 title={def.name}
+                onClick={(event) => handlePillClick(event, def.id)}
               >
                 {def.name}
               </span>
             )
           })}
+          <button
+            onClick={handleOpen}
+            className={`inline-flex items-center justify-center w-4 h-4 rounded text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill transition-colors cursor-pointer ${current.length === 0 ? 'opacity-0 group-hover:opacity-100' : 'opacity-0 group-hover:opacity-70'}`}
+            title="Add label"
+          >
+            <Plus size={10} />
+          </button>
         </div>
-      ) : (
-        <button
-          onClick={handleToggle}
-          className="inline-flex items-center gap-0.5 px-1 py-px rounded text-[10px] text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill transition-colors cursor-pointer opacity-0 group-hover:opacity-100"
-          title="Add label"
-        >
-          <Tag size={10} />
-        </button>
       )
       break
 
@@ -131,7 +156,7 @@ export function LabelDropdown({ current, onToggle, onClear, allLabels, onCreateL
       menuPosition = 'absolute top-full right-0 mt-1'
       trigger = (
         <button
-          onClick={handleToggle}
+          onClick={handleOpen}
           className="w-6 h-6 flex items-center justify-center bg-kumo-fill border border-kumo-line rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors cursor-pointer"
           title={`Labels: ${displayLabel}`}
         >
@@ -141,42 +166,51 @@ export function LabelDropdown({ current, onToggle, onClear, allLabels, onCreateL
       break
   }
 
-  return (
-    <div ref={containerRef} className="relative inline-flex">
-      {trigger}
-      {open && (
+  const renderMenu = () => {
+    if (isReplacing && replacingDef) {
+      // Replace mode: pick a replacement for the clicked label, or remove it
+      const otherLabels = allLabels.filter((l) => l.id !== replacingLabelId)
+      return (
         <div className={`${menuPosition} z-[100] min-w-[160px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl`}>
-          {/* Clear all option */}
+          <div className="px-2.5 py-1 text-[10px] text-kumo-subtle font-medium">
+            Replace {replacingDef.name}
+          </div>
+
           <button
-            onClick={(event) => { event.stopPropagation(); onClear(); close() }}
-            className={`flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] rounded transition-colors text-left ${
-              current.length === 0
-                ? 'bg-kumo-interact/12 text-kumo-link'
-                : 'text-kumo-default hover:bg-kumo-fill'
-            }`}
+            onClick={(event) => { event.stopPropagation(); onToggle(replacingLabelId); setReplacingLabelId(null); close() }}
+            className="flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] rounded transition-colors text-left text-kumo-default hover:bg-kumo-fill"
           >
             <XCircle size={12} />
-            None
+            Remove
           </button>
 
-          {/* All labels (built-in + custom) — multi-select with checkmarks */}
-          {allLabels.map((label) => {
+          <div className="border-t border-kumo-line my-1" />
+
+          {otherLabels.map((label) => {
             const colors = LABEL_COLORS[label.colorKey]
-            const isSelected = currentSet.has(label.id)
+            const alreadyApplied = currentSet.has(label.id)
             const isCustom = !label.builtIn
             return (
               <div key={label.id} className="group/label flex items-center">
                 <button
-                  onClick={(event) => { event.stopPropagation(); onToggle(label.id) }}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    if (onReplace) {
+                      onReplace(replacingLabelId, label.id)
+                    } else {
+                      onToggle(replacingLabelId)
+                      onToggle(label.id)
+                    }
+                    setReplacingLabelId(null)
+                    close()
+                  }}
+                  disabled={alreadyApplied}
                   className={`flex items-center gap-2 flex-1 min-w-0 px-2.5 py-1.5 text-[11px] rounded transition-colors text-left ${
-                    isSelected
-                      ? 'bg-kumo-interact/12 text-kumo-link'
+                    alreadyApplied
+                      ? 'text-kumo-subtle opacity-50 cursor-not-allowed'
                       : 'text-kumo-default hover:bg-kumo-fill'
                   }`}
                 >
-                  <span className="w-3 shrink-0 flex items-center justify-center">
-                    {isSelected ? <Check size={10} weight="bold" /> : null}
-                  </span>
                   {BUILTIN_ICONS[label.id] ?? (
                     <span className={`w-2.5 h-2.5 rounded-full shrink-0 ${colors.swatch}`} />
                   )}
@@ -195,7 +229,6 @@ export function LabelDropdown({ current, onToggle, onClear, allLabels, onCreateL
             )
           })}
 
-          {/* Create new label */}
           {onCreateLabel && (
             <>
               <div className="border-t border-kumo-line my-1" />
@@ -253,7 +286,121 @@ export function LabelDropdown({ current, onToggle, onClear, allLabels, onCreateL
             </>
           )}
         </div>
-      )}
+      )
+    }
+
+    // Normal multi-select mode
+    return (
+      <div className={`${menuPosition} z-[100] min-w-[160px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl`}>
+        {current.length > 0 && (
+          <button
+            onClick={(event) => { event.stopPropagation(); onClear(); close() }}
+            className="flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] rounded transition-colors text-left text-kumo-default hover:bg-kumo-fill"
+          >
+            <XCircle size={12} />
+            Clear all
+          </button>
+        )}
+
+        {allLabels.map((label) => {
+          const colors = LABEL_COLORS[label.colorKey]
+          const isSelected = currentSet.has(label.id)
+          const isCustom = !label.builtIn
+          return (
+            <div key={label.id} className="group/label flex items-center">
+              <button
+                onClick={(event) => { event.stopPropagation(); onToggle(label.id) }}
+                className={`flex items-center gap-2 flex-1 min-w-0 px-2.5 py-1.5 text-[11px] rounded transition-colors text-left ${
+                  isSelected
+                    ? 'bg-kumo-interact/12 text-kumo-link'
+                    : 'text-kumo-default hover:bg-kumo-fill'
+                }`}
+              >
+                <span className="w-3 shrink-0 flex items-center justify-center">
+                  {isSelected ? <Check size={10} weight="bold" /> : null}
+                </span>
+                {BUILTIN_ICONS[label.id] ?? (
+                  <span className={`w-2.5 h-2.5 rounded-full shrink-0 ${colors.swatch}`} />
+                )}
+                <span className="truncate">{label.name}</span>
+              </button>
+              {isCustom && onDeleteLabel && (
+                <button
+                  onClick={(event) => void handleDelete(event, label.id)}
+                  className="shrink-0 p-1 mr-1 rounded text-kumo-subtle hover:text-kumo-danger hover:bg-kumo-danger/10 transition-colors opacity-0 group-hover/label:opacity-100"
+                  title={`Delete ${label.name}`}
+                >
+                  <X size={10} />
+                </button>
+              )}
+            </div>
+          )
+        })}
+
+        {onCreateLabel && (
+          <>
+            <div className="border-t border-kumo-line my-1" />
+            {creating ? (
+              <div className="px-2 py-1.5 space-y-1.5" onClick={(e) => e.stopPropagation()}>
+                <input
+                  autoFocus
+                  type="text"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') void handleCreate(); if (e.key === 'Escape') setCreating(false) }}
+                  placeholder="Label name..."
+                  className="w-full bg-kumo-control border border-kumo-line rounded px-2 py-1 text-[11px] text-kumo-default placeholder:text-kumo-subtle outline-none focus:border-kumo-brand/50"
+                  maxLength={30}
+                />
+                <div className="flex gap-1 flex-wrap">
+                  {COLOR_KEYS.map((key) => {
+                    const c = LABEL_COLORS[key]
+                    const selected = key === newColor
+                    return (
+                      <button
+                        key={key}
+                        onClick={() => setNewColor(key)}
+                        className={`w-4 h-4 rounded-full ${c.swatch} ${selected ? 'ring-2 ring-offset-1 ring-offset-kumo-elevated ring-white/50' : ''}`}
+                        title={key}
+                      />
+                    )
+                  })}
+                </div>
+                <div className="flex gap-1">
+                  <button
+                    onClick={() => void handleCreate()}
+                    disabled={!newName.trim()}
+                    className="flex-1 px-2 py-1 text-[10px] font-medium rounded bg-kumo-brand text-white hover:bg-kumo-brand/90 disabled:opacity-40 transition-colors"
+                  >
+                    Create
+                  </button>
+                  <button
+                    onClick={() => setCreating(false)}
+                    className="px-2 py-1 text-[10px] rounded text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                onClick={(event) => { event.stopPropagation(); setCreating(true) }}
+                className="flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] rounded transition-colors text-left text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill"
+              >
+                <Plus size={12} />
+                New label...
+              </button>
+            )}
+          </>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div ref={containerRef} className="relative inline-flex">
+      {trigger}
+      {open && renderMenu()}
     </div>
   )
 }

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -2264,6 +2264,15 @@ export function useAgentStore() {
     emit({ agents: true })
   }, [])
 
+  const replaceLabel = useCallback((agentId: string, oldLabelId: string, newLabelId: string) => {
+    const agent = state.agents.get(agentId)
+    if (!agent) return
+    agent.labelIds = agent.labelIds.map((id) => id === oldLabelId ? newLabelId : id)
+    agent.lastActivityAt = Date.now()
+    persistAgentMeta(agentId, { labelIds: agent.labelIds })
+    emit({ agents: true })
+  }, [])
+
   const setPrUrl = useCallback((agentId: string, prUrl: string | null) => {
     const agent = state.agents.get(agentId)
     if (!agent) return
@@ -2293,6 +2302,7 @@ export function useAgentStore() {
     setAgentModel,
     toggleLabel,
     clearLabels,
+    replaceLabel,
     setPrUrl,
     selectDirectory,
     getMessagesForSession,


### PR DESCRIPTION
Clicking an individual label pill now opens a scoped 'Replace' picker to swap or remove just that label. The '+' button opens the normal multi-select for adding labels. 'None' replaced with 'Clear all' that only shows when labels are assigned. Drawer behavior is unchanged.