### PR TITLE
Fix inconsistent row heights in FleetTable across agent statuses

### DIFF
--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -773,7 +773,7 @@ function RowActions({
   const isStopping = agent.status === 'stopping'
 
   return (
-    <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+    <div className="hidden gap-1 group-hover:flex">
       {agent.status === 'needs_approval' && (
         <button
           className={buttonBase}


### PR DESCRIPTION
RowActions used opacity-0 to hide action buttons until hover. Running agents render 3 buttons vs 1 for idle agents, and opacity-0 elements still occupy layout space. The extra buttons overflowed the 96px actions column, causing flex wrap and taller rows for active agents.

Switch to hidden/group-hover:flex so buttons take zero space until hover.