### PR TITLE
Add per-project 'fetch latest from base branch' option for new worktrees

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -500,12 +500,23 @@ export function registerIpcHandlers(): void {
     repoRoot: string
     projectSlug: string
     taskSlug: string
+    baseRef?: string
   }) => {
     try {
-      const result = workspaceManager.createFreshWorktree(options.repoRoot, options.projectSlug, options.taskSlug)
+      const result = workspaceManager.createFreshWorktree(options.repoRoot, options.projectSlug, options.taskSlug, options.baseRef)
       return { ok: true, data: result }
     } catch (error) {
       console.error('[IPC] workspace:create-fresh failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  ipcMain.handle('workspace:default-branch', async (_event, repoRoot: string) => {
+    try {
+      const branch = workspaceManager.getDefaultBranch(repoRoot)
+      return { ok: true, data: branch }
+    } catch (error) {
+      console.error('[IPC] workspace:default-branch failed:', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -587,6 +598,22 @@ export function registerIpcHandlers(): void {
       return { ok: true, data: deleted }
     } catch (error) {
       console.error('[IPC] db:projects:delete failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  ipcMain.handle('db:projects:update-settings', async (_event, options: {
+    repoRoot: string
+    settings: { default_branch?: string | null; fresh_worktree?: boolean }
+  }) => {
+    try {
+      const project = database.updateProjectSettings(options.repoRoot, options.settings)
+      if (!project) {
+        return { ok: false, error: `No project found for repo root: ${options.repoRoot}` }
+      }
+      return { ok: true, data: project }
+    } catch (error) {
+      console.error('[IPC] db:projects:update-settings failed:', error)
       return { ok: false, error: String(error) }
     }
   })

--- a/src/main/services/database.ts
+++ b/src/main/services/database.ts
@@ -8,6 +8,8 @@ export interface Project {
   id: string
   name: string
   repo_root: string
+  default_branch: string | null
+  fresh_worktree: number
   created_at: string
   updated_at: string
 }
@@ -183,7 +185,20 @@ class Database {
       )
     `)
 
+    // Add per-project worktree settings columns (safe to re-run)
+    this.addColumnIfMissing('projects', 'default_branch', 'TEXT')
+    this.addColumnIfMissing('projects', 'fresh_worktree', 'INTEGER DEFAULT 0')
+
     saveToDisk()
+  }
+
+  private addColumnIfMissing(table: string, column: string, type: string): void {
+    const sqlDb = getDb()
+    try {
+      sqlDb.run(`ALTER TABLE ${table} ADD COLUMN ${column} ${type}`)
+    } catch {
+      // Column already exists — safe to ignore
+    }
   }
 
   private queryOne<T>(sql: string, params: unknown[] = []): T | undefined {
@@ -258,6 +273,21 @@ class Database {
       return this.getProject(existing.id)!
     }
     return this.createProject(name, repoRoot)
+  }
+
+  updateProjectSettings(repoRoot: string, settings: { default_branch?: string | null; fresh_worktree?: boolean }): Project | undefined {
+    const project = this.getProjectByRepoRoot(repoRoot)
+    if (!project) return undefined
+
+    const now = new Date().toISOString()
+    const branch = settings.default_branch !== undefined ? settings.default_branch : project.default_branch
+    const fresh = settings.fresh_worktree !== undefined ? (settings.fresh_worktree ? 1 : 0) : project.fresh_worktree
+
+    this.execute(
+      'UPDATE projects SET default_branch = ?, fresh_worktree = ?, updated_at = ? WHERE id = ?',
+      [branch, fresh, now, project.id]
+    )
+    return this.getProject(project.id)
   }
 
   deleteProject(projectId: string): boolean {

--- a/src/main/services/workspace-manager.ts
+++ b/src/main/services/workspace-manager.ts
@@ -1,4 +1,4 @@
-import { execSync, exec } from 'child_process'
+import { execSync, execFileSync, exec } from 'child_process'
 import { promisify } from 'util'
 import path from 'path'
 import fs from 'fs'
@@ -31,6 +31,19 @@ export interface DirectoryContext {
   branchName: string
   isWorktree: boolean
   workspaceName: string
+}
+
+// eslint-disable-next-line no-control-regex
+const GIT_REF_INVALID_CHARS = /[\x00-\x1f\x7f ~^:?*[\]\\]/
+
+function validateGitRef(ref: string): string {
+  const trimmed = ref.trim()
+  if (!trimmed) throw new Error('Git ref cannot be empty')
+  if (GIT_REF_INVALID_CHARS.test(trimmed)) throw new Error(`Invalid characters in git ref: ${trimmed}`)
+  if (trimmed.startsWith('-')) throw new Error(`Git ref cannot start with a dash: ${trimmed}`)
+  if (trimmed.includes('..')) throw new Error(`Git ref cannot contain "..": ${trimmed}`)
+  if (trimmed.endsWith('.lock') || trimmed.endsWith('.')) throw new Error(`Git ref cannot end with ".lock" or ".": ${trimmed}`)
+  return trimmed
 }
 
 /**
@@ -94,8 +107,10 @@ class WorkspaceManager {
 
   /**
    * Creates a fresh worktree based on the latest default branch from origin.
+   * Fetches first, then resolves the base ref — so the branch name is always
+   * up-to-date even when origin/HEAD has changed.
    */
-  createFreshWorktree(repoRoot: string, projectSlug: string, taskSlug: string): FreshWorktreeInfo {
+  createFreshWorktree(repoRoot: string, projectSlug: string, taskSlug: string, explicitBaseRef?: string): FreshWorktreeInfo {
     const timestamp = Date.now()
     const safeProjSlug = projectSlug.slice(0, 50)
     const safeTaskSlug = taskSlug.slice(0, 50)
@@ -109,17 +124,20 @@ class WorkspaceManager {
         fs.mkdirSync(parentDir, { recursive: true })
       }
 
-      execSync('git fetch origin --prune', {
+      execFileSync('git', ['fetch', 'origin', '--prune'], {
         cwd: repoRoot,
         encoding: 'utf-8',
         stdio: 'pipe'
       })
 
-      const baseRef = this.getDefaultBaseRef(repoRoot)
+      // Resolve after fetch so origin/HEAD reflects the latest remote state
+      const baseRef = explicitBaseRef
+        ? validateGitRef(explicitBaseRef)
+        : this.getDefaultBranch(repoRoot)
 
       console.log(`[WorkspaceManager] Creating fresh worktree at ${worktreePath} from ${baseRef}`)
 
-      execSync(`git worktree add -b "${branchName}" "${worktreePath}" "${baseRef}"`, {
+      execFileSync('git', ['worktree', 'add', '-b', branchName, worktreePath, baseRef], {
         cwd: repoRoot,
         encoding: 'utf-8',
         stdio: 'pipe'
@@ -329,7 +347,7 @@ class WorkspaceManager {
       stdio: 'pipe'
     })
 
-    const baseRef = this.getDefaultBaseRef(repoRoot)
+    const baseRef = this.getDefaultBranch(repoRoot)
     const timestamp = Date.now()
     const safeProjSlug = projectSlug.slice(0, 50)
     const safeTaskSlug = taskSlug.slice(0, 50)
@@ -351,7 +369,7 @@ class WorkspaceManager {
     return branchName
   }
 
-  private getDefaultBaseRef(repoRoot: string): string {
+  getDefaultBranch(repoRoot: string): string {
     try {
       const remoteHead = execSync('git symbolic-ref refs/remotes/origin/HEAD', {
         cwd: repoRoot,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -138,8 +138,11 @@ const api = {
   createWorktree: (options: { repoRoot: string; projectSlug: string; taskSlug: string }): Promise<IpcResult<{ worktreePath: string; branchName: string }>> =>
     ipcRenderer.invoke('workspace:create', options),
 
-  createFreshWorktree: (options: { repoRoot: string; projectSlug: string; taskSlug: string }): Promise<IpcResult<{ worktreePath: string; branchName: string; baseRef: string }>> =>
+  createFreshWorktree: (options: { repoRoot: string; projectSlug: string; taskSlug: string; baseRef?: string }): Promise<IpcResult<{ worktreePath: string; branchName: string; baseRef: string }>> =>
     ipcRenderer.invoke('workspace:create-fresh', options),
+
+  getDefaultBranch: (repoRoot: string): Promise<IpcResult<string>> =>
+    ipcRenderer.invoke('workspace:default-branch', repoRoot),
 
   removeWorktree: (options: { repoRoot: string; worktreePath: string }): Promise<IpcResult> =>
     ipcRenderer.invoke('workspace:remove', options),
@@ -162,6 +165,9 @@ const api = {
 
   deleteProject: (projectId: string): Promise<IpcResult> =>
     ipcRenderer.invoke('db:projects:delete', projectId),
+
+  updateProjectSettings: (options: { repoRoot: string; settings: { default_branch?: string | null; fresh_worktree?: boolean } }): Promise<IpcResult> =>
+    ipcRenderer.invoke('db:projects:update-settings', options),
 
   // ── Database: Preferences ──
   getPreference: (key: string): Promise<IpcResult<string | undefined>> =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -5,7 +5,7 @@ import { FilterBar, matchesFilter, EMPTY_FILTER, cycleFilter, loadPersistedFilte
 import { FleetTable } from './components/FleetTable'
 import { StatusBar } from './components/StatusBar'
 import { DetailDrawer, type ChatCommand } from './components/DetailDrawer'
-import { LaunchModal } from './components/LaunchModal'
+import { LaunchModal, type FreshWorktreeConfig } from './components/LaunchModal'
 import { SessionBrowser } from './components/SessionBrowser'
 import { SettingsModal } from './components/SettingsModal'
 import { CommandPalette } from './components/CommandPalette'
@@ -851,7 +851,8 @@ export function App() {
     title?: string,
     model?: string,
     worktreeStrategy?: string,
-    attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>
+    attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>,
+    freshWorktreeConfig?: FreshWorktreeConfig
   ) => {
     let launchDirectory = directory
 
@@ -865,11 +866,19 @@ export function App() {
       const projectSlug = sanitizeSlugSegment(directoryParts[directoryParts.length - 1] ?? 'project', 'project')
       const taskSource = title?.trim() || prompt?.trim() || 'agent'
       const taskSlug = sanitizeSlugSegment(taskSource, 'agent')
-      const worktreeResult = await window.api.createWorktree({
-        repoRoot: repoRootResult.data,
-        projectSlug,
-        taskSlug
-      })
+
+      const worktreeResult = freshWorktreeConfig?.enabled
+        ? await window.api.createFreshWorktree({
+            repoRoot: repoRootResult.data,
+            projectSlug,
+            taskSlug,
+            baseRef: freshWorktreeConfig.baseBranch || undefined
+          })
+        : await window.api.createWorktree({
+            repoRoot: repoRootResult.data,
+            projectSlug,
+            taskSlug
+          })
 
       if (!worktreeResult.ok || !worktreeResult.data) {
         throw new Error(worktreeResult.error || 'Failed to create worktree')

--- a/src/renderer/src/components/LaunchModal.tsx
+++ b/src/renderer/src/components/LaunchModal.tsx
@@ -9,6 +9,11 @@ import type { ChatCommand, AgentConfigItem } from './DetailDrawer'
 
 type WorktreeStrategy = 'new-worktree' | 'current-directory'
 
+export interface FreshWorktreeConfig {
+  enabled: boolean
+  baseBranch: string
+}
+
 function sanitizePathSegment(value: string, fallback: string): string {
   const sanitized = value
     .trim()
@@ -45,7 +50,7 @@ interface KnownDirectory {
 
 interface LaunchModalProps {
   onClose: () => void
-  onLaunch: (directory: string, prompt?: string, title?: string, model?: string, worktreeStrategy?: string, attachments?: MessageAttachment[]) => void
+  onLaunch: (directory: string, prompt?: string, title?: string, model?: string, worktreeStrategy?: string, attachments?: MessageAttachment[], freshWorktreeConfig?: FreshWorktreeConfig) => void
   onSelectDirectory: () => Promise<string | null>
   onValidateDirectory?: (dir: string) => Promise<boolean>
   knownDirectories?: KnownDirectory[]
@@ -60,6 +65,10 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
   const [model, setModel] = useState(() => loadSettings().model)
   const { options: modelOptions } = useModelOptions()
   const [worktreeStrategy, setWorktreeStrategy] = useState<WorktreeStrategy>('new-worktree')
+  const [freshWorktree, setFreshWorktree] = useState(false)
+  const [baseBranch, setBaseBranch] = useState('')
+  const [branchOverridden, setBranchOverridden] = useState(false)
+  const [detectingBranch, setDetectingBranch] = useState(false)
   const [launching, setLaunching] = useState(false)
   const [dirError, setDirError] = useState<string | null>(null)
   const [validating, setValidating] = useState(false)
@@ -204,10 +213,10 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
     }
   }, [])
 
-  const saveProject = useCallback(async (dir: string) => {
-    const name = dirDisplayName(dir)
+  const saveProject = useCallback(async (canonicalRoot: string) => {
+    const name = dirDisplayName(canonicalRoot)
     try {
-      await window.api.ensureProject({ name, repoRoot: dir })
+      await window.api.ensureProject({ name, repoRoot: canonicalRoot })
       await loadProjects()
     } catch {
       // ignore save failures
@@ -326,6 +335,48 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
     return () => clearTimeout(timer)
   }, [directory, onValidateDirectory])
 
+  // Load per-project fresh worktree settings when directory changes.
+  // Always resolves to canonical repo root first for consistent project matching.
+  useEffect(() => {
+    const dir = directory.trim()
+    if (!dir) return
+
+    let cancelled = false
+    setBranchOverridden(false)
+    setDetectingBranch(true)
+
+    const loadSettings = async () => {
+      try {
+        // Resolve canonical repo root so project lookup is consistent
+        const repoRootResult = await window.api.getRepoRoot(dir)
+        if (cancelled) return
+        const repoRoot = repoRootResult.ok && repoRootResult.data ? repoRootResult.data : dir
+
+        const matchedProject = savedProjects.find((p) => p.repo_root === repoRoot)
+        setFreshWorktree(!!matchedProject?.fresh_worktree)
+
+        if (matchedProject?.default_branch) {
+          setBaseBranch(matchedProject.default_branch)
+          return
+        }
+
+        // Auto-detect default branch from the resolved repo root
+        const branchResult = await window.api.getDefaultBranch(repoRoot)
+        if (cancelled) return
+        setBaseBranch(branchResult.ok && branchResult.data ? branchResult.data : 'origin/main')
+      } catch {
+        if (!cancelled) {
+          setFreshWorktree(false)
+          setBaseBranch('origin/main')
+        }
+      } finally {
+        if (!cancelled) setDetectingBranch(false)
+      }
+    }
+    void loadSettings()
+    return () => { cancelled = true }
+  }, [directory, savedProjects])
+
   // Close dropdown when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -341,8 +392,24 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
     if (!directory.trim() || dirError || validating) return
     setLaunching(true)
     try {
-      await onLaunch(directory, prompt || undefined, title || undefined, model, worktreeStrategy, attachments.length > 0 ? attachments : undefined)
-      await saveProject(directory.trim())
+      const freshConfig: FreshWorktreeConfig | undefined =
+        worktreeStrategy === 'new-worktree' && freshWorktree
+          ? { enabled: true, baseBranch: branchOverridden ? baseBranch : '' }
+          : undefined
+      await onLaunch(directory, prompt || undefined, title || undefined, model, worktreeStrategy, attachments.length > 0 ? attachments : undefined, freshConfig)
+      // Resolve canonical repo root for consistent project identity
+      const repoRootResult = await window.api.getRepoRoot(directory.trim())
+      const canonicalRoot = repoRootResult.ok && repoRootResult.data ? repoRootResult.data : directory.trim()
+      await saveProject(canonicalRoot)
+      if (worktreeStrategy === 'new-worktree') {
+        const settingsResult = await window.api.updateProjectSettings({
+          repoRoot: canonicalRoot,
+          settings: { fresh_worktree: freshWorktree, default_branch: baseBranch || null }
+        })
+        if (!settingsResult.ok) {
+          console.warn('Failed to persist worktree settings:', settingsResult.error)
+        }
+      }
       clearAttachments()
       onClose()
     } catch (error) {
@@ -507,6 +574,29 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
               <p className="text-[11px] text-kumo-subtle font-mono truncate" title={estimatedWorktreePath}>
                 Worktree path: {estimatedWorktreePath}
               </p>
+            )}
+            {worktreeStrategy === 'new-worktree' && (
+              <div className="flex flex-col gap-1.5 mt-1">
+                <label className="flex items-center gap-2 text-xs text-kumo-default cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={freshWorktree}
+                    onChange={(e) => setFreshWorktree(e.target.checked)}
+                    className="rounded border-kumo-line bg-kumo-control text-kumo-accent focus:ring-kumo-ring h-3.5 w-3.5"
+                  />
+                  Fetch latest from base branch
+                </label>
+                {freshWorktree && (
+                  <input
+                    type="text"
+                    value={baseBranch}
+                    onChange={(e) => { setBaseBranch(e.target.value); setBranchOverridden(true) }}
+                    placeholder={detectingBranch ? 'Detecting...' : 'origin/main'}
+                    disabled={detectingBranch}
+                    className="w-full rounded-md border border-kumo-line bg-kumo-control px-2.5 py-1.5 text-xs text-kumo-default font-mono placeholder:text-kumo-subtle outline-none transition-colors focus:border-kumo-ring disabled:opacity-50"
+                  />
+                )}
+              </div>
             )}
           </div>
 

--- a/src/renderer/src/demoApi.ts
+++ b/src/renderer/src/demoApi.ts
@@ -327,15 +327,17 @@ export function createDemoApi(): OrchestratorApi {
     getCommonRepoRoot: () => ok('/tmp/repo'),
     createWorktree: () => ok({ worktreePath: '/tmp/wt', branchName: 'demo' }),
     createFreshWorktree: () => ok({ worktreePath: '/tmp/wt', branchName: 'demo', baseRef: 'main' }),
+    getDefaultBranch: () => ok('origin/main'),
     removeWorktree: noop,
     listWorktrees: () => ok([]),
     getWorktreeStatus: () => ok({ dirty: false, changedFiles: 0 }),
 
     // ── Database: Projects ──
     listProjects: () => ok([]),
-    createProject: () => ok({ id: '1', name: 'demo', repo_root: '/tmp', created_at: '', updated_at: '' }),
-    ensureProject: () => ok({ id: '1', name: 'demo', repo_root: '/tmp', created_at: '', updated_at: '' }),
+    createProject: () => ok({ id: '1', name: 'demo', repo_root: '/tmp', default_branch: null, fresh_worktree: 0, created_at: '', updated_at: '' }),
+    ensureProject: () => ok({ id: '1', name: 'demo', repo_root: '/tmp', default_branch: null, fresh_worktree: 0, created_at: '', updated_at: '' }),
     deleteProject: () => ok(true),
+    updateProjectSettings: () => ok({ id: '1', name: 'demo', repo_root: '/tmp', default_branch: null, fresh_worktree: 0, created_at: '', updated_at: '' }),
 
     // ── Database: Custom Labels ──
     listCustomLabels: () => ok([]),

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -54,7 +54,8 @@ export interface OrchestratorApi {
   getRepoRoot: (directory: string) => Promise<IpcResult<string>>
   getCommonRepoRoot: (directory: string) => Promise<IpcResult<string>>
   createWorktree: (options: { repoRoot: string; projectSlug: string; taskSlug: string }) => Promise<IpcResult<{ worktreePath: string; branchName: string }>>
-  createFreshWorktree: (options: { repoRoot: string; projectSlug: string; taskSlug: string }) => Promise<IpcResult<{ worktreePath: string; branchName: string; baseRef: string }>>
+  createFreshWorktree: (options: { repoRoot: string; projectSlug: string; taskSlug: string; baseRef?: string }) => Promise<IpcResult<{ worktreePath: string; branchName: string; baseRef: string }>>
+  getDefaultBranch: (repoRoot: string) => Promise<IpcResult<string>>
   removeWorktree: (options: { repoRoot: string; worktreePath: string }) => Promise<IpcResult>
   listWorktrees: (repoRoot: string) => Promise<IpcResult<WorktreeListEntry[]>>
   getWorktreeStatus: (worktreePath: string) => Promise<IpcResult<WorktreeStatus>>
@@ -64,6 +65,7 @@ export interface OrchestratorApi {
   createProject: (options: { name: string; repoRoot: string }) => Promise<IpcResult<Project>>
   ensureProject: (options: { name: string; repoRoot: string }) => Promise<IpcResult<Project>>
   deleteProject: (projectId: string) => Promise<IpcResult<boolean>>
+  updateProjectSettings: (options: { repoRoot: string; settings: { default_branch?: string | null; fresh_worktree?: boolean } }) => Promise<IpcResult<Project>>
 
   // ── Database: Custom Labels ──
   listCustomLabels: () => Promise<IpcResult<CustomLabelPayload[]>>
@@ -122,6 +124,8 @@ export interface Project {
   id: string
   name: string
   repo_root: string
+  default_branch: string | null
+  fresh_worktree: number
   created_at: string
   updated_at: string
 }


### PR DESCRIPTION
When creating a new worktree, users can now opt in to fetching from a configurable base branch (e.g. origin/main) instead of branching off HEAD. The setting is remembered per project and the base branch is auto-detected via origin/HEAD on first use.

Key design choices:
- Uses execFileSync with arg arrays to avoid shell injection from user-provided branch refs, plus validateGitRef for defence in depth
- Base ref is resolved after git fetch (in main process), not from a stale renderer snapshot, unless the user explicitly overrides
- Project settings are keyed by canonical repo root to avoid mismatches from trailing slashes or subdirectory paths
- IPC returns ok:false when the project is missing, so callers can detect save failures instead of silently dropping data