### PR TITLE
Fix base branch detection, per-project persistence, and modal close timing

### DIFF
--- a/src/main/services/workspace-manager.ts
+++ b/src/main/services/workspace-manager.ts
@@ -370,17 +370,42 @@ class WorkspaceManager {
   }
 
   getDefaultBranch(repoRoot: string): string {
-    try {
-      const remoteHead = execSync('git symbolic-ref refs/remotes/origin/HEAD', {
-        cwd: repoRoot,
-        encoding: 'utf-8',
-        stdio: 'pipe'
-      }).trim()
+    const gitOpts = { cwd: repoRoot, encoding: 'utf-8' as const, stdio: 'pipe' as const }
 
-      return remoteHead.replace('refs/remotes/', '')
-    } catch {
-      return 'origin/main'
+    const readOriginHead = (): string | null => {
+      try {
+        return execSync('git symbolic-ref refs/remotes/origin/HEAD', gitOpts)
+          .trim()
+          .replace('refs/remotes/', '')
+      } catch {
+        return null
+      }
     }
+
+    // Fast path: local symbolic-ref already cached
+    const cached = readOriginHead()
+    if (cached) return cached
+
+    // Query the remote and cache locally
+    try {
+      execSync('git remote set-head origin --auto', { ...gitOpts, timeout: 10_000 })
+      const resolved = readOriginHead()
+      if (resolved) return resolved
+    } catch {
+      // Network unavailable or remote doesn't support it
+    }
+
+    // Last resort: probe for common branch names
+    for (const name of ['main', 'master', 'staging', 'develop']) {
+      try {
+        execSync(`git rev-parse --verify origin/${name}`, gitOpts)
+        return `origin/${name}`
+      } catch {
+        continue
+      }
+    }
+
+    return 'origin/main'
   }
 
   /**

--- a/src/renderer/src/components/LaunchModal.tsx
+++ b/src/renderer/src/components/LaunchModal.tsx
@@ -67,7 +67,6 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
   const [worktreeStrategy, setWorktreeStrategy] = useState<WorktreeStrategy>('new-worktree')
   const [freshWorktree, setFreshWorktree] = useState(false)
   const [baseBranch, setBaseBranch] = useState('')
-  const [branchOverridden, setBranchOverridden] = useState(false)
   const [detectingBranch, setDetectingBranch] = useState(false)
   const [launching, setLaunching] = useState(false)
   const [dirError, setDirError] = useState<string | null>(null)
@@ -342,7 +341,6 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
     if (!dir) return
 
     let cancelled = false
-    setBranchOverridden(false)
     setDetectingBranch(true)
 
     const loadSettings = async () => {
@@ -388,30 +386,38 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
+  const persistProjectSettings = async (dir: string) => {
+    try {
+      const repoRootResult = await window.api.getRepoRoot(dir)
+      const canonicalRoot = repoRootResult.ok && repoRootResult.data ? repoRootResult.data : dir
+      await saveProject(canonicalRoot)
+      const settingsResult = await window.api.updateProjectSettings({
+        repoRoot: canonicalRoot,
+        settings: { fresh_worktree: freshWorktree, default_branch: baseBranch || null }
+      })
+      if (!settingsResult.ok) {
+        console.warn('Failed to persist worktree settings:', settingsResult.error)
+      }
+    } catch (err) {
+      console.warn('Failed to persist project settings:', err)
+    }
+  }
+
   const handleLaunch = async () => {
     if (!directory.trim() || dirError || validating) return
     setLaunching(true)
     try {
       const freshConfig: FreshWorktreeConfig | undefined =
         worktreeStrategy === 'new-worktree' && freshWorktree
-          ? { enabled: true, baseBranch: branchOverridden ? baseBranch : '' }
+          ? { enabled: true, baseBranch }
           : undefined
       await onLaunch(directory, prompt || undefined, title || undefined, model, worktreeStrategy, attachments.length > 0 ? attachments : undefined, freshConfig)
-      // Resolve canonical repo root for consistent project identity
-      const repoRootResult = await window.api.getRepoRoot(directory.trim())
-      const canonicalRoot = repoRootResult.ok && repoRootResult.data ? repoRootResult.data : directory.trim()
-      await saveProject(canonicalRoot)
-      if (worktreeStrategy === 'new-worktree') {
-        const settingsResult = await window.api.updateProjectSettings({
-          repoRoot: canonicalRoot,
-          settings: { fresh_worktree: freshWorktree, default_branch: baseBranch || null }
-        })
-        if (!settingsResult.ok) {
-          console.warn('Failed to persist worktree settings:', settingsResult.error)
-        }
-      }
+
       clearAttachments()
       onClose()
+
+      // Fire-and-forget: persist project and worktree settings after modal closes
+      void persistProjectSettings(directory.trim())
     } catch (error) {
       console.error('Launch failed:', error)
       setLaunching(false)
@@ -590,7 +596,7 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
                   <input
                     type="text"
                     value={baseBranch}
-                    onChange={(e) => { setBaseBranch(e.target.value); setBranchOverridden(true) }}
+                    onChange={(e) => setBaseBranch(e.target.value)}
                     placeholder={detectingBranch ? 'Detecting...' : 'origin/main'}
                     disabled={detectingBranch}
                     className="w-full rounded-md border border-kumo-line bg-kumo-control px-2.5 py-1.5 text-xs text-kumo-default font-mono placeholder:text-kumo-subtle outline-none transition-colors focus:border-kumo-ring disabled:opacity-50"


### PR DESCRIPTION
getDefaultBranch fell back to origin/main when refs/remotes/origin/HEAD was missing. It now queries the remote with 'git remote set-head --auto' and probes common branch names (main, master, staging, develop) before falling back.

The launch modal persisted worktree settings only when the new-worktree strategy was selected and blocked the UI on the persistence calls. Settings are now saved regardless of strategy, and onClose fires immediately after a successful launch with persistence running fire-and-forget.