### PR TITLE
Fix action icons layout shift on row hover

### DIFF
--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -229,7 +229,7 @@ export function FleetTable({
             <col style={{ width: '26%' }} />
             <col style={{ width: '12%' }} />
             <col style={{ width: '10%' }} />
-            <col style={{ width: 96 }} />
+            <col style={{ width: 140 }} />
             <col style={{ width: 40 }} />
           </colgroup>
           <thead className="sticky top-0 z-10">
@@ -773,7 +773,7 @@ function RowActions({
   const isStopping = agent.status === 'stopping'
 
   return (
-    <div className="hidden gap-1 group-hover:flex">
+    <div className="flex gap-1 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity">
       {agent.status === 'needs_approval' && (
         <button
           className={buttonBase}


### PR DESCRIPTION
RowActions used display:none/flex toggle (hidden/group-hover:flex), causing PR and settings icons to shift when hover revealed pause/stop/ remove buttons. Switched to opacity+pointer-events so action buttons always reserve space. Widened actions column from 96px to 140px to fit the full button set without overflow.