### PR TITLE
Add column visibility toggle, Last Message column, and resizable columns

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -13,13 +13,12 @@ import { ModelPickerModal } from './components/ModelPickerModal'
 import { McpModal } from './components/McpModal'
 import { useAgentStore, setViewedAgentId, type LiveAgent } from './hooks/useAgentStore'
 import { useCustomLabels } from './hooks/useCustomLabels'
-import { type AgentRuntime, type Interrupt, type Message } from './types'
+import { type AgentRuntime, type Interrupt, type Message, type ColumnKey, type ColumnWidths, loadColumnVisibility, saveColumnVisibility, loadColumnWidths, saveColumnWidths } from './types'
 import type { FileChange } from './components/FilesChanged'
 import type { ToolCall } from './components/ToolsUsage'
 import type { EventEntry } from './components/EventLog'
 import { loadSettings } from './data/settings'
 
-type SortColumn = 'agent' | 'status' | 'task' | 'branch' | 'model'
 type SortDirection = 'asc' | 'desc'
 
 const NEW_AGENT_COMMAND = '/new'
@@ -41,6 +40,18 @@ function mapToolState(toolState?: string): ToolCall['state'] {
   if (toolState === 'completed') return 'completed'
   if (toolState === 'error' || toolState === 'failed') return 'failed'
   return 'running'
+}
+
+function extractLastAssistantMessage(messages: { role: string; parts: { type: string; text?: string }[] }[]): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role !== 'assistant') continue
+    const text = messages[i].parts
+      .filter((p) => p.type === 'text' && p.text)
+      .map((p) => p.text!)
+      .join(' ')
+    if (text) return text.slice(0, 200)
+  }
+  return undefined
 }
 
 export function App() {
@@ -66,7 +77,7 @@ export function App() {
   const [showCommandPalette, setShowCommandPalette] = useState(false)
   const [showSessionBrowser, setShowSessionBrowser] = useState(false)
 
-  const [sortColumn, setSortColumn] = useState<SortColumn | null>(null)
+  const [sortColumn, setSortColumn] = useState<ColumnKey | null>(null)
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
   const [tick, setTick] = useState(0)
   const [agentCommands, setAgentCommands] = useState<ChatCommand[]>([])
@@ -80,6 +91,33 @@ export function App() {
   const [launchCommands, setLaunchCommands] = useState<ChatCommand[]>([])
   const [launchAgentConfigs, setLaunchAgentConfigs] = useState<Array<{ name: string; description?: string }>>([])
   const [quickLaunching, setQuickLaunching] = useState(false)
+  const [visibleColumns, setVisibleColumnsRaw] = useState<Set<ColumnKey>>(loadColumnVisibility)
+  const [columnWidths, setColumnWidthsRaw] = useState<ColumnWidths>(loadColumnWidths)
+
+  const setVisibleColumns = useCallback((value: Set<ColumnKey> | ((prev: Set<ColumnKey>) => Set<ColumnKey>)) => {
+    setVisibleColumnsRaw((prev) => {
+      const next = typeof value === 'function' ? value(prev) : value
+      saveColumnVisibility(next)
+      return next
+    })
+  }, [])
+
+  const handleColumnResize = useCallback((key: ColumnKey, width: number) => {
+    setColumnWidthsRaw((prev) => {
+      const next = { ...prev, [key]: width }
+      saveColumnWidths(next)
+      return next
+    })
+  }, [])
+
+  const handleColumnResetWidth = useCallback((key: ColumnKey) => {
+    setColumnWidthsRaw((prev) => {
+      const next = { ...prev }
+      delete next[key]
+      saveColumnWidths(next)
+      return next
+    })
+  }, [])
 
   const store = useAgentStore()
   const { allLabels, createLabel, deleteLabel } = useCustomLabels()
@@ -258,25 +296,30 @@ export function App() {
 
   // ── Convert live agents to AgentRuntime shape ──
   const liveAgentsAsRuntimes: AgentRuntime[] = useMemo(() => {
-    return store.agents.map((agent): AgentRuntime => ({
-      id: agent.id,
-      name: agent.name,
-      projectId: agent.directory,
-      projectName: agent.projectName,
-      branchName: agent.branchName,
-      isWorktree: agent.isWorktree,
-      workspaceName: agent.workspaceName,
-      taskSummary: agent.taskSummary,
-      status: agent.status,
-      labelIds: agent.labelIds,
-      model: agent.model,
-      prUrl: agent.prUrl,
-      lastActivityAt: formatTimeAgo(agent.lastActivityAt),
-      lastActivityAtMs: agent.lastActivityAt,
-      blockedSince: agent.blockedSince ? formatTimeAgo(agent.blockedSince) : undefined,
-      blockedSinceMs: agent.blockedSince
-    }))
-  }, [store.agents, tick])
+    return store.agents.map((agent): AgentRuntime => {
+      const lastMessage = extractLastAssistantMessage(getMessagesForSession(agent.sessionId))
+
+      return {
+        id: agent.id,
+        name: agent.name,
+        projectId: agent.directory,
+        projectName: agent.projectName,
+        branchName: agent.branchName,
+        isWorktree: agent.isWorktree,
+        workspaceName: agent.workspaceName,
+        taskSummary: agent.taskSummary,
+        status: agent.status,
+        labelIds: agent.labelIds,
+        model: agent.model,
+        prUrl: agent.prUrl,
+        lastActivityAt: formatTimeAgo(agent.lastActivityAt),
+        lastActivityAtMs: agent.lastActivityAt,
+        blockedSince: agent.blockedSince ? formatTimeAgo(agent.blockedSince) : undefined,
+        blockedSinceMs: agent.blockedSince,
+        lastMessage
+      }
+    })
+  }, [store.agents, tick, getMessagesForSession])
 
   // ── Convert live permissions + needs_input agents to Interrupt shape ──
   const liveInterrupts: Interrupt[] = useMemo(() => {
@@ -348,7 +391,8 @@ export function App() {
           agent.name.toLowerCase().includes(query) ||
           agent.projectName.toLowerCase().includes(query) ||
           agent.taskSummary.toLowerCase().includes(query) ||
-          agent.branchName.toLowerCase().includes(query)
+          agent.branchName.toLowerCase().includes(query) ||
+          (agent.lastMessage ?? '').toLowerCase().includes(query)
       )
     }
 
@@ -384,6 +428,14 @@ export function App() {
           case 'model':
             leftVal = (left.model || '').toLowerCase()
             rightVal = (right.model || '').toLowerCase()
+            break
+          case 'lastMessage':
+            leftVal = (left.lastMessage || '').toLowerCase()
+            rightVal = (right.lastMessage || '').toLowerCase()
+            break
+          case 'label':
+            leftVal = left.labelIds.join(',').toLowerCase()
+            rightVal = right.labelIds.join(',').toLowerCase()
             break
         }
 
@@ -585,7 +637,7 @@ export function App() {
 
   // ── Sort handler ──
   const handleSort = useCallback((column: string, direction: 'asc' | 'desc') => {
-    setSortColumn(column as SortColumn)
+    setSortColumn(column as ColumnKey)
     setSortDirection(direction)
   }, [])
 
@@ -1196,6 +1248,18 @@ export function App() {
         labelCounts={labelCounts}
         allLabels={allLabels}
         projects={projectNames}
+        visibleColumns={visibleColumns}
+        onToggleColumn={(key) => {
+          setVisibleColumns((prev) => {
+            const next = new Set(prev)
+            if (next.has(key)) {
+              if (next.size > 1) next.delete(key)
+            } else {
+              next.add(key)
+            }
+            return next
+          })
+        }}
       />
 
       <FleetTable
@@ -1223,6 +1287,10 @@ export function App() {
         allLabels={allLabels}
         onCreateLabel={createLabel}
         onDeleteLabel={handleDeleteLabel}
+        visibleColumns={visibleColumns}
+        columnWidths={columnWidths}
+        onColumnResize={handleColumnResize}
+        onColumnResetWidth={handleColumnResetWidth}
       />
 
       <StatusBar

--- a/src/renderer/src/components/FilterBar.tsx
+++ b/src/renderer/src/components/FilterBar.tsx
@@ -1,6 +1,7 @@
-import { MagnifyingGlass } from '@phosphor-icons/react'
-import type { AgentStatus, LabelDefinition } from '../types'
-import { LABEL_COLORS } from '../types'
+import { useState, useRef, useEffect } from 'react'
+import { MagnifyingGlass, Columns, Check } from '@phosphor-icons/react'
+import type { AgentStatus, LabelDefinition, ColumnKey } from '../types'
+import { LABEL_COLORS, ALL_COLUMNS } from '../types'
 
 export type StatusFilter = 'blocked' | 'running' | 'idle' | 'errored' | 'completed'
 export type LabelFilter = string
@@ -143,6 +144,8 @@ interface FilterBarProps {
   labelCounts: Record<string, number>
   allLabels: LabelDefinition[]
   projects: string[]
+  visibleColumns: Set<ColumnKey>
+  onToggleColumn: (key: ColumnKey) => void
 }
 
 export function FilterBar({
@@ -156,7 +159,9 @@ export function FilterBar({
   counts,
   labelCounts,
   allLabels,
-  projects
+  projects,
+  visibleColumns,
+  onToggleColumn
 }: FilterBarProps) {
   const noFilters = isFilterEmpty(filter)
 
@@ -216,6 +221,9 @@ export function FilterBar({
           onClick={() => onCycleProject(project)}
         />
       ))}
+
+      <div className="flex-1" />
+      <ColumnToggle visibleColumns={visibleColumns} onToggle={onToggleColumn} />
     </div>
   )
 }
@@ -262,6 +270,72 @@ function FilterPill({
       {mode === 'exclude' && <span aria-hidden="true" className="text-[9px] leading-none">−</span>}
       {label}
     </button>
+  )
+}
+
+function ColumnToggle({
+  visibleColumns,
+  onToggle
+}: {
+  visibleColumns: Set<ColumnKey>
+  onToggle: (key: ColumnKey) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const handleClickOutside = (event: MouseEvent): void => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    const handleEscape = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleEscape)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleEscape)
+    }
+  }, [open])
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        onClick={() => setOpen((prev) => !prev)}
+        title="Toggle columns"
+        className={`flex items-center gap-1 px-2 py-1 rounded text-[11px] border transition-colors cursor-pointer ${
+          open
+            ? 'bg-kumo-interact/12 border-kumo-interact/30 text-kumo-link'
+            : 'bg-kumo-control border-kumo-line text-kumo-subtle hover:border-kumo-fill-hover hover:text-kumo-default'
+        }`}
+      >
+        <Columns size={13} />
+        <span>Columns</span>
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full mt-1 z-[100] min-w-[160px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl">
+          {ALL_COLUMNS.map((col) => {
+            const isVisible = visibleColumns.has(col.key)
+            return (
+              <button
+                key={col.key}
+                onClick={() => onToggle(col.key)}
+                className="flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] text-kumo-default rounded hover:bg-kumo-fill transition-colors text-left cursor-pointer"
+              >
+                <span className={`w-3.5 h-3.5 flex items-center justify-center rounded border ${isVisible ? 'bg-kumo-interact/20 border-kumo-interact/40 text-kumo-link' : 'border-kumo-line text-transparent'}`}>
+                  {isVisible && <Check size={10} weight="bold" />}
+                </span>
+                {col.label}
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -18,8 +18,8 @@ import {
   Link,
   ArrowLineUpRight
 } from '@phosphor-icons/react'
-import type { AgentRuntime, LabelDefinition, LabelColorKey } from '../types'
-import { formatBranchLabel, isUrgent, labelSortKey } from '../types'
+import type { AgentRuntime, LabelDefinition, LabelColorKey, ColumnKey, ColumnWidths } from '../types'
+import { formatBranchLabel, isUrgent, labelSortKey, ALL_COLUMNS } from '../types'
 import { StatusBadge } from './StatusBadge'
 import { LabelDropdown } from './LabelDropdown'
 import { TextInputModal } from './TextInputModal'
@@ -47,21 +47,15 @@ interface FleetTableProps {
   allLabels?: LabelDefinition[]
   onCreateLabel?: (name: string, colorKey: LabelColorKey) => Promise<LabelDefinition | null>
   onDeleteLabel?: (id: string) => Promise<boolean>
+  visibleColumns: Set<ColumnKey>
+  columnWidths: ColumnWidths
+  onColumnResize?: (key: ColumnKey, width: number) => void
+  onColumnResetWidth?: (key: ColumnKey) => void
 }
 
-type SortColumn = 'agent' | 'status' | 'label' | 'task' | 'branch' | 'model'
 type SortDirection = 'asc' | 'desc'
 
 const SCROLL_STEP = 200
-
-const SORTABLE_COLUMNS: { key: SortColumn; label: string }[] = [
-  { key: 'agent', label: 'Agent' },
-  { key: 'status', label: 'Status' },
-  { key: 'label', label: 'Label' },
-  { key: 'task', label: 'Task' },
-  { key: 'branch', label: 'Branch' },
-  { key: 'model', label: 'Model' }
-]
 
 interface ContextMenuState {
   agentId: string
@@ -100,9 +94,13 @@ export function FleetTable({
   onReplaceLabel,
   allLabels = [],
   onCreateLabel,
-  onDeleteLabel
+  onDeleteLabel,
+  visibleColumns,
+  columnWidths,
+  onColumnResize,
+  onColumnResetWidth
 }: FleetTableProps) {
-  const [sortColumn, setSortColumn] = useState<SortColumn | null>(null)
+  const [sortColumn, setSortColumn] = useState<ColumnKey | null>(null)
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
   const [renameState, setRenameState] = useState<RenameState | null>(null)
@@ -113,8 +111,67 @@ export function FleetTable({
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const [canScrollLeft, setCanScrollLeft] = useState(false)
   const [canScrollRight, setCanScrollRight] = useState(false)
+  const tableRef = useRef<HTMLTableElement>(null)
 
-  const handleSort = useCallback((column: SortColumn) => {
+  const activeColumns = useMemo(() => {
+    const cols = ALL_COLUMNS.filter((col) => visibleColumns.has(col.key))
+    const flexCols = cols.filter((col) => columnWidths[col.key] == null)
+    const totalFlex = flexCols.reduce((sum, col) => sum + col.flex, 0)
+
+    return cols.map((col) => {
+      const customPx = columnWidths[col.key]
+      const width = customPx != null
+        ? `${customPx}px`
+        : `${((col.flex / totalFlex) * 100).toFixed(1)}%`
+      return { ...col, width }
+    })
+  }, [visibleColumns, columnWidths])
+
+  // ── Column resize via drag ──
+  const resizeState = useRef<{
+    key: ColumnKey
+    startX: number
+    startWidth: number
+  } | null>(null)
+
+  const handleResizeStart = useCallback((event: React.MouseEvent, colKey: ColumnKey, colIndex: number) => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    const thElements = tableRef.current?.querySelectorAll('thead th')
+    if (!thElements || !thElements[colIndex]) return
+    const startWidth = (thElements[colIndex] as HTMLElement).getBoundingClientRect().width
+
+    resizeState.current = { key: colKey, startX: event.clientX, startWidth }
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+
+    const handleMouseMove = (moveEvent: MouseEvent): void => {
+      if (!resizeState.current) return
+      const delta = moveEvent.clientX - resizeState.current.startX
+      const newWidth = Math.max(60, resizeState.current.startWidth + delta)
+      onColumnResize?.(resizeState.current.key, Math.round(newWidth))
+    }
+
+    const handleMouseUp = (): void => {
+      resizeState.current = null
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+    }
+
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+  }, [onColumnResize])
+
+  const handleResizeDoubleClick = useCallback((event: React.MouseEvent, colKey: ColumnKey) => {
+    event.preventDefault()
+    event.stopPropagation()
+    onColumnResetWidth?.(colKey)
+  }, [onColumnResetWidth])
+
+  const handleSort = useCallback((column: ColumnKey) => {
     let nextDirection: SortDirection = 'asc'
     if (sortColumn === column) {
       nextDirection = sortDirection === 'asc' ? 'desc' : 'asc'
@@ -198,6 +255,10 @@ export function FleetTable({
           leftVal = (left.model || '').toLowerCase()
           rightVal = (right.model || '').toLowerCase()
           break
+        case 'lastMessage':
+          leftVal = (left.lastMessage || '').toLowerCase()
+          rightVal = (right.lastMessage || '').toLowerCase()
+          break
         default:
           return 0
       }
@@ -220,9 +281,9 @@ export function FleetTable({
     setLabelDropdownOpen(open)
   }, [])
 
-  const headerCellClass = 'px-3 py-2 text-left font-medium text-[11px] uppercase tracking-wide text-kumo-subtle bg-kumo-overlay border-b border-kumo-line cursor-pointer hover:text-kumo-default select-none'
+  const headerCellClass = 'relative px-3 py-2 text-left font-medium text-[11px] uppercase tracking-wide text-kumo-subtle bg-kumo-overlay border-b border-kumo-line cursor-pointer hover:text-kumo-default select-none'
 
-  const renderSortIndicator = (column: SortColumn) => {
+  const renderSortIndicator = (column: ColumnKey) => {
     if (sortColumn !== column) return null
     return sortDirection === 'asc'
       ? <CaretUp size={10} weight="bold" className="inline ml-0.5" />
@@ -242,20 +303,17 @@ export function FleetTable({
   return (
     <div className="flex-1 relative overflow-hidden flex flex-col" onClick={closeContextMenu}>
       <div ref={scrollContainerRef} className="flex-1 overflow-auto">
-        <table className="w-full border-collapse text-xs" style={{ tableLayout: 'fixed', minWidth: 800 }}>
+        <table ref={tableRef} className="w-full border-collapse text-xs" style={{ tableLayout: 'fixed', minWidth: 800 }}>
           <colgroup>
-            <col style={{ width: '16%' }} />
-            <col style={{ width: '12%' }} />
-            <col style={{ width: '12%' }} />
-            <col style={{ width: '26%' }} />
-            <col style={{ width: '12%' }} />
-            <col style={{ width: '10%' }} />
+            {activeColumns.map((col) => (
+              <col key={col.key} style={{ width: col.width }} />
+            ))}
             <col style={{ width: 140 }} />
             <col style={{ width: 40 }} />
           </colgroup>
           <thead className="sticky top-0 z-10">
             <tr>
-              {SORTABLE_COLUMNS.map((col) => (
+              {activeColumns.map((col, index) => (
                 <th
                   key={col.key}
                   className={headerCellClass}
@@ -263,6 +321,12 @@ export function FleetTable({
                 >
                   {col.label}
                   {renderSortIndicator(col.key)}
+                  <div
+                    className="absolute right-0 top-0 bottom-0 w-1.5 cursor-col-resize hover:bg-kumo-interact/30 active:bg-kumo-interact/50 transition-colors z-10"
+                    onMouseDown={(event) => handleResizeStart(event, col.key, index)}
+                    onDoubleClick={(event) => handleResizeDoubleClick(event, col.key)}
+                    onClick={(event) => event.stopPropagation()}
+                  />
                 </th>
               ))}
               <th className="px-3 py-2 bg-kumo-overlay border-b border-kumo-line" />
@@ -275,6 +339,7 @@ export function FleetTable({
                 key={agent.id}
                 agent={agent}
                 selected={agent.id === selectedId}
+                visibleColumns={visibleColumns}
                 onSelect={() => onSelect(agent.id)}
                 onContextMenu={(event) => handleContextMenu(event, agent.id)}
                 onApprove={onApprove ? () => onApprove(agent.id) : undefined}
@@ -561,6 +626,7 @@ function ContextMenu({
 function AgentRow({
   agent,
   selected,
+  visibleColumns,
   onSelect,
   onContextMenu,
   onApprove,
@@ -586,6 +652,7 @@ function AgentRow({
 }: {
   agent: AgentRuntime
   selected: boolean
+  visibleColumns: Set<ColumnKey>
   onSelect: () => void
   onContextMenu: (event: React.MouseEvent) => void
   onApprove?: () => void
@@ -647,6 +714,8 @@ function AgentRow({
     }
   }
 
+  const show = (key: ColumnKey): boolean => visibleColumns.has(key)
+
   return (
     <tr
       onClick={onSelect}
@@ -659,75 +728,85 @@ function AgentRow({
             : 'hover:bg-kumo-control'
       }`}
     >
-      <td className="px-3 py-2 overflow-hidden">
-        {isInlineEditing ? (
-          <input
-            ref={inlineInputRef}
-            value={inlineValue}
-            onChange={(event) => setInlineValue(event.target.value)}
-            onKeyDown={handleInlineKeyDown}
-            onBlur={handleInlineSubmit}
-            onClick={(event) => event.stopPropagation()}
-            className="font-semibold text-kumo-strong bg-kumo-control border border-kumo-ring rounded px-1.5 py-0.5 text-xs outline-none w-full max-w-[200px]"
-          />
-        ) : (
-          <div
-            onClick={(event) => { event.stopPropagation(); onStartInlineEdit() }}
-            className="font-semibold text-kumo-strong rounded px-1.5 py-0.5 -mx-1.5 -my-0.5 cursor-text outline outline-1 outline-transparent hover:outline-kumo-subtle/40 transition-[outline-color] truncate"
-            title={agent.name}
-          >
-            {agent.name}
-          </div>
-        )}
-        <div className="flex items-center gap-1 text-[11px] text-kumo-subtle">
-          {agent.isWorktree && (
-            <span className="shrink-0 px-1 py-px rounded bg-kumo-brand/10 text-kumo-brand text-[9px] font-medium leading-tight">
-              WT
-            </span>
+      {show('agent') && (
+        <td className="px-3 py-2 overflow-hidden">
+          {isInlineEditing ? (
+            <input
+              ref={inlineInputRef}
+              value={inlineValue}
+              onChange={(event) => setInlineValue(event.target.value)}
+              onKeyDown={handleInlineKeyDown}
+              onBlur={handleInlineSubmit}
+              onClick={(event) => event.stopPropagation()}
+              className="font-semibold text-kumo-strong bg-kumo-control border border-kumo-ring rounded px-1.5 py-0.5 text-xs outline-none w-full max-w-[200px]"
+            />
+          ) : (
+            <div
+              onClick={(event) => { event.stopPropagation(); onStartInlineEdit() }}
+              className="font-semibold text-kumo-strong rounded px-1.5 py-0.5 -mx-1.5 -my-0.5 cursor-text outline outline-1 outline-transparent hover:outline-kumo-subtle/40 transition-[outline-color] truncate"
+              title={agent.name}
+            >
+              {agent.name}
+            </div>
           )}
           <span className="truncate">{agent.projectName}</span>
-        </div>
-      </td>
-      <td className="px-3 py-2 overflow-hidden">
-        <div className="flex flex-col gap-0.5">
-          <StatusBadge status={agent.status} />
-          <span className={`font-mono text-[10px] ${isStale ? 'text-kumo-danger font-medium' : 'text-kumo-subtle'}`}>
-            {agent.lastActivityAt}
-          </span>
-        </div>
-      </td>
-      <td className="px-3 py-2">
-        {onToggleLabel && onClearLabels && (
-          <LabelDropdown
-            current={agent.labelIds}
-            onToggle={onToggleLabel}
-            onClear={onClearLabels}
-            onReplace={onReplaceLabel}
-            allLabels={allLabels}
-            onCreateLabel={onCreateLabel}
-            onDeleteLabel={onDeleteLabel}
-            variant="inline"
-            onOpenChange={onLabelDropdownChange}
-          />
-        )}
-      </td>
-      <td className="px-3 py-2 truncate text-kumo-default" title={agent.taskSummary || undefined}>
-        {agent.taskSummary}
-      </td>
-      <td className="px-3 py-2 font-mono text-[11px] text-kumo-subtle truncate" title={formatBranchLabel(agent)}>
-        {formatBranchLabel(agent)}
-      </td>
-      <td className="px-3 py-2 overflow-hidden">
-        {agent.model && agent.model !== 'starting...' && (
-          <button
-            onClick={(event) => { event.stopPropagation(); onChangeModel?.() }}
-            className="font-mono text-[10px] px-1.5 py-0.5 bg-kumo-fill rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors max-w-full truncate block cursor-pointer"
-            title={agent.model}
-          >
-            {agent.model}
-          </button>
-        )}
-      </td>
+        </td>
+      )}
+      {show('status') && (
+        <td className="px-3 py-2 overflow-hidden">
+          <div className="flex flex-col gap-0.5">
+            <StatusBadge status={agent.status} />
+            <span className={`font-mono text-[10px] ${isStale ? 'text-kumo-danger font-medium' : 'text-kumo-subtle'}`}>
+              {agent.lastActivityAt}
+            </span>
+          </div>
+        </td>
+      )}
+      {show('label') && (
+        <td className="px-3 py-2">
+          {onToggleLabel && onClearLabels && (
+            <LabelDropdown
+              current={agent.labelIds}
+              onToggle={onToggleLabel}
+              onClear={onClearLabels}
+              onReplace={onReplaceLabel}
+              allLabels={allLabels}
+              onCreateLabel={onCreateLabel}
+              onDeleteLabel={onDeleteLabel}
+              variant="inline"
+              onOpenChange={onLabelDropdownChange}
+            />
+          )}
+        </td>
+      )}
+      {show('task') && (
+        <td className="px-3 py-2 truncate text-kumo-default" title={agent.taskSummary || undefined}>
+          {agent.taskSummary}
+        </td>
+      )}
+      {show('lastMessage') && (
+        <td className="px-3 py-2 truncate text-kumo-subtle text-[11px]" title={agent.lastMessage || undefined}>
+          {agent.lastMessage || <span className="text-kumo-muted italic">--</span>}
+        </td>
+      )}
+      {show('branch') && (
+        <td className="px-3 py-2 font-mono text-[11px] text-kumo-subtle truncate" title={formatBranchLabel(agent)}>
+          {formatBranchLabel(agent)}
+        </td>
+      )}
+      {show('model') && (
+        <td className="px-3 py-2 overflow-hidden">
+          {agent.model && agent.model !== 'starting...' && (
+            <button
+              onClick={(event) => { event.stopPropagation(); onChangeModel?.() }}
+              className="font-mono text-[10px] px-1.5 py-0.5 bg-kumo-fill rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors max-w-full truncate block cursor-pointer"
+              title={agent.model}
+            >
+              {agent.model}
+            </button>
+          )}
+        </td>
+      )}
       <td className="px-3 py-2 overflow-hidden">
         <div className="flex items-center justify-end gap-1">
           <RowActions

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -83,6 +83,67 @@ export interface AgentRuntime {
   lastActivityAtMs: number
   blockedSince?: string
   blockedSinceMs?: number
+  lastMessage?: string
+}
+
+// ── Column visibility ──
+
+export type ColumnKey = 'agent' | 'status' | 'label' | 'task' | 'branch' | 'model' | 'lastMessage'
+
+export interface ColumnDef {
+  key: ColumnKey
+  label: string
+  defaultVisible: boolean
+  /** Relative flex weight — percentages are computed from visible columns at render time. */
+  flex: number
+}
+
+export const ALL_COLUMNS: ColumnDef[] = [
+  { key: 'agent',       label: 'Agent',        defaultVisible: true,  flex: 3 },
+  { key: 'status',      label: 'Status',       defaultVisible: true,  flex: 2 },
+  { key: 'label',       label: 'Label',        defaultVisible: true,  flex: 2 },
+  { key: 'task',        label: 'Task',         defaultVisible: true,  flex: 4 },
+  { key: 'lastMessage', label: 'Last Message', defaultVisible: true,  flex: 4 },
+  { key: 'branch',      label: 'Branch',       defaultVisible: true,  flex: 2 },
+  { key: 'model',       label: 'Model',        defaultVisible: true,  flex: 2 },
+]
+
+const COLUMN_VIS_KEY = 'oc-orchestrator:column-visibility'
+const COLUMN_WIDTHS_KEY = 'oc-orchestrator:column-widths'
+
+const DEFAULT_VISIBLE_COLUMNS = new Set<ColumnKey>(
+  ALL_COLUMNS.filter((c) => c.defaultVisible).map((c) => c.key)
+)
+
+export function loadColumnVisibility(): Set<ColumnKey> {
+  try {
+    const stored = localStorage.getItem(COLUMN_VIS_KEY)
+    if (!stored) return new Set(DEFAULT_VISIBLE_COLUMNS)
+    return new Set(JSON.parse(stored) as ColumnKey[])
+  } catch {
+    return new Set(DEFAULT_VISIBLE_COLUMNS)
+  }
+}
+
+export function saveColumnVisibility(visible: Set<ColumnKey>): void {
+  localStorage.setItem(COLUMN_VIS_KEY, JSON.stringify([...visible]))
+}
+
+/** User-specified pixel widths per column. Missing keys fall back to flex-based sizing. */
+export type ColumnWidths = Partial<Record<ColumnKey, number>>
+
+export function loadColumnWidths(): ColumnWidths {
+  try {
+    const stored = localStorage.getItem(COLUMN_WIDTHS_KEY)
+    if (!stored) return {}
+    return JSON.parse(stored) as ColumnWidths
+  } catch {
+    return {}
+  }
+}
+
+export function saveColumnWidths(widths: ColumnWidths): void {
+  localStorage.setItem(COLUMN_WIDTHS_KEY, JSON.stringify(widths))
 }
 
 export interface Interrupt {


### PR DESCRIPTION
Add a configurable column system to the fleet table dashboard:

- Column visibility toggle in the FilterBar lets users show/hide any column
- New 'Last Message' column shows the last assistant message per agent
- Columns are resizable via drag handles on header borders (double-click resets)
- Column visibility and custom widths persist to localStorage across sessions
- Columns use flex-weight proportions that redistribute when columns are hidden
- Last Message is searchable via the filter text input and sortable