### PR TITLE
Add Linux support: remove darwin-only rollup dep, add linux targets

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -19,3 +19,12 @@ mac:
       arch:
         - arm64
         - x64
+linux:
+  target:
+    - target: AppImage
+      arch:
+        - x64
+    - target: deb
+      arch:
+        - x64
+  category: Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@opencode-ai/sdk": "1.3.3",
         "@phosphor-icons/react": "^2.1.7",
-        "@rollup/rollup-darwin-arm64": "4.60.0",
         "electron": "41.1.0",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
@@ -1741,7 +1740,9 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "darwin"
       ]

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@opencode-ai/sdk": "1.3.3",
     "@phosphor-icons/react": "^2.1.7",
-    "@rollup/rollup-darwin-arm64": "4.60.0",
     "electron": "41.1.0",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",


### PR DESCRIPTION
Remove the hard-coded @rollup/rollup-darwin-arm64 dependency that blocked npm install on non-darwin platforms. Rollup resolves its platform-specific bindings automatically via optionalDependencies. Add Linux build targets (AppImage + deb) to electron-builder.yml.