### PR TITLE
Add session import: fork past sessions into new worktrees

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -290,6 +290,29 @@ export function registerIpcHandlers(): void {
     }
   })
 
+  ipcMain.handle('session:list-by-project', async (_event, projectDirectory: string) => {
+    try {
+      const sessions = await agentController.listSessionsByProject(projectDirectory)
+      return { ok: true, data: sessions }
+    } catch (error) {
+      console.error('[IPC] session:list-by-project failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  ipcMain.handle('session:fork', async (_event, options: {
+    sourceSessionId: string
+    targetDirectory: string
+  }) => {
+    try {
+      const result = await agentController.forkSession(options)
+      return { ok: true, data: result }
+    } catch (error) {
+      console.error('[IPC] session:fork failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
   ipcMain.handle('agent:resume', async (_event, options: {
     directory: string
     sessionId: string

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -303,6 +303,7 @@ class AgentController {
 
   /**
    * Update the persisted display name, task summary, and/or status for an agent.
+   * When displayName changes, also syncs the title to the OpenCode session.
    */
   updateAgentMeta(agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelIds?: string[]; prUrl?: string }): void {
     const handle = this.agents.get(agentId)
@@ -314,6 +315,19 @@ class AgentController {
     if (meta.labelIds !== undefined) handle.labelIds = meta.labelIds
     if (meta.prUrl !== undefined) handle.prUrl = meta.prUrl
     this.persistAgents()
+
+    // Sync display name to the OpenCode session title so it's findable
+    // when browsing sessions later (e.g. for import/restore).
+    if (meta.displayName && handle.sessionId) {
+      const runtime = runtimeManager.getRuntime(handle.runtimeId)
+      if (runtime) {
+        runtime.client.session.update({
+          sessionID: handle.sessionId,
+          directory: handle.directory,
+          title: meta.displayName
+        }).catch(() => { /* best-effort */ })
+      }
+    }
   }
 
   /**
@@ -843,6 +857,12 @@ class AgentController {
     return result.data
   }
 
+  private getActiveSessionIds(): Set<string> {
+    return new Set(
+      Array.from(this.agents.values()).map((agent) => agent.sessionId)
+    )
+  }
+
   /**
    * List existing OpenCode sessions for a directory.
    * Spins up a temporary runtime if needed, then queries the SDK.
@@ -868,10 +888,7 @@ class AgentController {
       time?: { created?: number; updated?: number }
     }>
 
-    // Filter out sessions that are already managed by an active agent
-    const activeSessionIds = new Set(
-      Array.from(this.agents.values()).map((agent) => agent.sessionId)
-    )
+    const activeSessionIds = this.getActiveSessionIds()
 
     return sessions
       .filter((session) => !activeSessionIds.has(session.id))
@@ -881,6 +898,78 @@ class AgentController {
         createdAt: session.time?.created ?? 0,
         updatedAt: session.time?.updated ?? 0
       }))
+  }
+
+  /**
+   * List all root sessions for a project directory (across all worktrees).
+   * Uses session.list without a directory filter, then excludes active
+   * and subagent sessions.
+   */
+  async listSessionsByProject(projectDirectory: string): Promise<Array<{
+    id: string
+    title: string
+    directory: string
+    createdAt: number
+    updatedAt: number
+  }>> {
+    const runtime = await this.ensureBridgeForDirectory(projectDirectory)
+    runtimeManager.touchRuntimeActivity(runtime.id)
+
+    const result = await runtime.client.session.list({
+      roots: true,
+      limit: 100
+    })
+
+    if (!result.data) return []
+
+    const sessions = result.data as Array<{
+      id: string
+      title?: string
+      directory?: string
+      parentID?: string
+      time?: { created?: number; updated?: number }
+    }>
+
+    const activeSessionIds = this.getActiveSessionIds()
+
+    return sessions
+      .filter((session) => !activeSessionIds.has(session.id) && !session.parentID)
+      .map((session) => ({
+        id: session.id,
+        title: session.title ?? session.id,
+        directory: session.directory ?? projectDirectory,
+        createdAt: session.time?.created ?? 0,
+        updatedAt: session.time?.updated ?? 0
+      }))
+  }
+
+  /**
+   * Fork an existing session into a target directory.
+   * Creates a copy of the session's messages in the new directory context.
+   */
+  async forkSession(options: {
+    sourceSessionId: string
+    targetDirectory: string
+  }): Promise<{ sessionId: string; title: string }> {
+    const { sourceSessionId, targetDirectory } = options
+
+    const runtime = await this.ensureBridgeForDirectory(targetDirectory)
+    runtimeManager.touchRuntimeActivity(runtime.id)
+
+    const result = await runtime.client.session.fork({
+      sessionID: sourceSessionId,
+      directory: targetDirectory
+    })
+
+    const session = result.data as { id: string; title?: string } | undefined
+    if (!session) {
+      throw new Error('Failed to fork session')
+    }
+
+    return {
+      sessionId: session.id,
+      title: session.title ?? `fork-${sourceSessionId.slice(0, 8)}`
+    }
   }
 
   /**

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -78,6 +78,12 @@ const api = {
   listSessions: (directory: string): Promise<IpcResult<Array<{ id: string; title: string; createdAt: number; updatedAt: number }>>> =>
     ipcRenderer.invoke('session:list', directory),
 
+  listSessionsByProject: (projectDirectory: string): Promise<IpcResult<Array<{ id: string; title: string; directory: string; createdAt: number; updatedAt: number }>>> =>
+    ipcRenderer.invoke('session:list-by-project', projectDirectory),
+
+  forkSession: (options: { sourceSessionId: string; targetDirectory: string }): Promise<IpcResult<{ sessionId: string; title: string }>> =>
+    ipcRenderer.invoke('session:fork', options),
+
   resumeAgent: (options: { directory: string; sessionId: string; title?: string }): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:resume', options),
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -5,7 +5,7 @@ import { FilterBar, matchesFilter, EMPTY_FILTER, cycleFilter, loadPersistedFilte
 import { FleetTable } from './components/FleetTable'
 import { StatusBar } from './components/StatusBar'
 import { DetailDrawer, type ChatCommand } from './components/DetailDrawer'
-import { LaunchModal, type FreshWorktreeConfig } from './components/LaunchModal'
+import { LaunchModal, type FreshWorktreeConfig, type ImportSessionConfig } from './components/LaunchModal'
 import { SessionBrowser } from './components/SessionBrowser'
 import { SettingsModal } from './components/SettingsModal'
 import { CommandPalette } from './components/CommandPalette'
@@ -903,7 +903,8 @@ export function App() {
     model?: string,
     worktreeStrategy?: string,
     attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>,
-    freshWorktreeConfig?: FreshWorktreeConfig
+    freshWorktreeConfig?: FreshWorktreeConfig,
+    importSession?: ImportSessionConfig
   ) => {
     let launchDirectory = directory
 
@@ -915,7 +916,7 @@ export function App() {
 
       const directoryParts = directory.replace(/\/$/, '').split('/').filter(Boolean)
       const projectSlug = sanitizeSlugSegment(directoryParts[directoryParts.length - 1] ?? 'project', 'project')
-      const taskSource = title?.trim() || prompt?.trim() || 'agent'
+      const taskSource = title?.trim() || prompt?.trim() || (importSession ? importSession.sessionTitle : 'agent')
       const taskSlug = sanitizeSlugSegment(taskSource, 'agent')
 
       const worktreeResult = freshWorktreeConfig?.enabled
@@ -936,6 +937,46 @@ export function App() {
       }
 
       launchDirectory = worktreeResult.data.worktreePath
+    }
+
+    // If importing a session, fork it into the new directory and resume
+    if (importSession) {
+      const forkResult = await window.api.forkSession({
+        sourceSessionId: importSession.sessionId,
+        targetDirectory: launchDirectory
+      })
+
+      if (!forkResult.ok || !forkResult.data) {
+        throw new Error(forkResult.error || 'Failed to fork session')
+      }
+
+      const resumeResult = await window.api.resumeAgent({
+        directory: launchDirectory,
+        sessionId: forkResult.data.sessionId,
+        title: title || forkResult.data.title
+      })
+
+      if (!resumeResult?.ok) {
+        throw new Error('Failed to resume forked session')
+      }
+
+      if (!resumeResult.data) return
+
+      const agentId = (resumeResult.data as { id: string }).id
+      setSelectedAgentId(agentId)
+
+      if (model && model !== 'auto') {
+        store.setAgentModel(agentId, model)
+        try { await window.api.updateConfig(agentId, { model }) }
+        catch { /* best-effort */ }
+      }
+
+      if (prompt?.trim()) {
+        try { await store.sendMessage(agentId, prompt.trim(), undefined, attachments) }
+        catch (error) { console.error('[App] Post-fork prompt failed:', error) }
+      }
+
+      return
     }
 
     // Detect leading @agent mentions and /commands in the prompt.

--- a/src/renderer/src/components/LaunchModal.tsx
+++ b/src/renderer/src/components/LaunchModal.tsx
@@ -1,17 +1,23 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
-import { X, FolderOpen, CaretDown, Warning, Trash, Paperclip } from '@phosphor-icons/react'
+import { X, FolderOpen, CaretDown, Warning, Trash, Paperclip, ClockCounterClockwise, CircleNotch, ChatCircleDots, Play } from '@phosphor-icons/react'
 import { SelectField } from './SelectField'
 import { useModelOptions } from '../hooks/useModelOptions'
 import { useImageAttachments } from '../hooks/useImageAttachments'
 import { loadSettings } from '../data/settings'
-import type { Project, MessageAttachment } from '../types/api'
+import type { Project, MessageAttachment, ProjectSessionEntry } from '../types/api'
 import type { ChatCommand, AgentConfigItem } from './DetailDrawer'
 
 type WorktreeStrategy = 'new-worktree' | 'current-directory'
+type ModalTab = 'new' | 'import'
 
 export interface FreshWorktreeConfig {
   enabled: boolean
   baseBranch: string
+}
+
+export interface ImportSessionConfig {
+  sessionId: string
+  sessionTitle: string
 }
 
 function sanitizePathSegment(value: string, fallback: string): string {
@@ -42,6 +48,38 @@ function dirDisplayName(path: string): string {
   return parts.length > 0 ? parts[parts.length - 1] : path
 }
 
+function formatTimestamp(ms: number): string {
+  if (!ms) return 'unknown'
+  const date = new Date(ms)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / 60_000)
+  const diffHours = Math.floor(diffMins / 60)
+  const diffDays = Math.floor(diffHours / 24)
+
+  if (diffMins < 1) return 'just now'
+  if (diffMins < 60) return `${diffMins}m ago`
+  if (diffHours < 24) return `${diffHours}h ago`
+  if (diffDays < 7) return `${diffDays}d ago`
+  return date.toLocaleDateString()
+}
+
+function worktreeLabel(sessionDir: string, projectDir: string): string | null {
+  if (!sessionDir || sessionDir === projectDir) return null
+  const parts = sessionDir.replace(/\/$/, '').split('/')
+  return parts[parts.length - 1] ?? null
+}
+
+function deriveForkedName(title: string): string {
+  const match = title.match(/^(.*?)\s*\(fork(?:\s*#(\d+))?\)\s*$/)
+  if (match) {
+    const base = match[1]
+    const num = match[2] ? parseInt(match[2], 10) + 1 : 2
+    return `${base} (fork #${num})`
+  }
+  return `${title} (fork)`
+}
+
 interface KnownDirectory {
   name: string
   directory: string
@@ -50,7 +88,7 @@ interface KnownDirectory {
 
 interface LaunchModalProps {
   onClose: () => void
-  onLaunch: (directory: string, prompt?: string, title?: string, model?: string, worktreeStrategy?: string, attachments?: MessageAttachment[], freshWorktreeConfig?: FreshWorktreeConfig) => void
+  onLaunch: (directory: string, prompt?: string, title?: string, model?: string, worktreeStrategy?: string, attachments?: MessageAttachment[], freshWorktreeConfig?: FreshWorktreeConfig, importSession?: ImportSessionConfig) => void
   onSelectDirectory: () => Promise<string | null>
   onValidateDirectory?: (dir: string) => Promise<boolean>
   knownDirectories?: KnownDirectory[]
@@ -59,6 +97,7 @@ interface LaunchModalProps {
 }
 
 export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDirectory, knownDirectories, commands = [], agentConfigs = [] }: LaunchModalProps) {
+  const [activeTab, setActiveTab] = useState<ModalTab>('new')
   const [directory, setDirectory] = useState('')
   const [prompt, setPrompt] = useState('')
   const [title, setTitle] = useState('')
@@ -86,6 +125,17 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
   const [agentPickerDismissed, setAgentPickerDismissed] = useState(false)
   const [agentPickerIndex, setAgentPickerIndex] = useState(0)
   const [commandPickerIndex, setCommandPickerIndex] = useState(0)
+
+  // Import tab state
+  const [importSessions, setImportSessions] = useState<ProjectSessionEntry[]>([])
+  const [importLoading, setImportLoading] = useState(false)
+  const [importError, setImportError] = useState<string | null>(null)
+  const [selectedSession, setSelectedSession] = useState<ProjectSessionEntry | null>(null)
+  const [importSearch, setImportSearch] = useState('')
+  const [importName, setImportName] = useState('')
+  const [importPrompt, setImportPrompt] = useState('')
+  const [showSessionDropdown, setShowSessionDropdown] = useState(false)
+  const sessionDropdownRef = useRef<HTMLDivElement>(null)
 
   const trimmedPrompt = prompt.trim().toLowerCase()
 
@@ -132,7 +182,7 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
     const before = prompt.slice(0, agentMention.start)
     const after = prompt.slice(agentMention.end)
     const newText = `${before}@${agentName} ${after}`
-    const newCursorPos = agentMention.start + agentName.length + 2 // @ + name + space
+    const newCursorPos = agentMention.start + agentName.length + 2
     setPrompt(newText)
     setCursorPos(newCursorPos)
     setAgentPickerDismissed(false)
@@ -149,51 +199,27 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
 
   const handlePromptKeyDown = (event: React.KeyboardEvent) => {
     if (showAgentPicker) {
-      if (event.key === 'Escape') {
-        event.preventDefault()
-        setAgentPickerDismissed(true)
-        return
-      }
+      if (event.key === 'Escape') { event.preventDefault(); setAgentPickerDismissed(true); return }
       if (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey)) {
         event.preventDefault()
         const selected = matchingAgents[agentPickerIndex]
         if (selected) insertAgentMention(selected.name)
         return
       }
-      if (event.key === 'ArrowDown') {
-        event.preventDefault()
-        setAgentPickerIndex((prev) => (prev + 1) % matchingAgents.length)
-        return
-      }
-      if (event.key === 'ArrowUp') {
-        event.preventDefault()
-        setAgentPickerIndex((prev) => (prev - 1 + matchingAgents.length) % matchingAgents.length)
-        return
-      }
+      if (event.key === 'ArrowDown') { event.preventDefault(); setAgentPickerIndex((prev) => (prev + 1) % matchingAgents.length); return }
+      if (event.key === 'ArrowUp') { event.preventDefault(); setAgentPickerIndex((prev) => (prev - 1 + matchingAgents.length) % matchingAgents.length); return }
     }
 
     if (showCommandAutocomplete) {
-      if (event.key === 'Escape') {
-        event.preventDefault()
-        setPrompt('')
-        return
-      }
+      if (event.key === 'Escape') { event.preventDefault(); setPrompt(''); return }
       if (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey)) {
         event.preventDefault()
         const selected = matchingCommands[commandPickerIndex]
         if (selected) setPrompt(`${selected.command} `)
         return
       }
-      if (event.key === 'ArrowDown') {
-        event.preventDefault()
-        setCommandPickerIndex((prev) => (prev + 1) % matchingCommands.length)
-        return
-      }
-      if (event.key === 'ArrowUp') {
-        event.preventDefault()
-        setCommandPickerIndex((prev) => (prev - 1 + matchingCommands.length) % matchingCommands.length)
-        return
-      }
+      if (event.key === 'ArrowDown') { event.preventDefault(); setCommandPickerIndex((prev) => (prev + 1) % matchingCommands.length); return }
+      if (event.key === 'ArrowUp') { event.preventDefault(); setCommandPickerIndex((prev) => (prev - 1 + matchingCommands.length) % matchingCommands.length); return }
     }
   }
 
@@ -208,24 +234,11 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
       if (result.ok && result.data) {
         setSavedProjects(result.data)
       }
-    } catch {
-      // ignore
-    }
+    } catch { /* ignore */ }
   }, [])
 
-  const saveProject = useCallback(async (canonicalRoot: string) => {
-    const name = dirDisplayName(canonicalRoot)
-    try {
-      await window.api.ensureProject({ name, repoRoot: canonicalRoot })
-      await loadProjects()
-    } catch {
-      // ignore save failures
-    }
-  }, [loadProjects])
-
   // Seed projects from running agents, load the full list, then restore
-  // the last-used directory — sequential so the project list is complete
-  // before restore runs.
+  // the last-used directory.
   useEffect(() => {
     let cancelled = false
 
@@ -237,18 +250,13 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
           let dir = known.directory
           if (known.isWorktree) {
             const result = await window.api.getCommonRepoRoot(known.directory)
-            if (result.ok && result.data) {
-              dir = result.data
-            } else {
-              continue
-            }
+            if (result.ok && result.data) dir = result.data
+            else continue
           }
           if (seen.has(dir)) continue
           seen.add(dir)
           await window.api.ensureProject({ name: known.name, repoRoot: dir })
-        } catch {
-          // ignore
-        }
+        } catch { /* ignore */ }
       }
     }
 
@@ -287,63 +295,37 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
       await window.api.deleteProject(projectId)
       setSavedProjects((prev) => prev.filter((p) => p.id !== projectId))
       const removed = savedProjects.find((p) => p.id === projectId)
-      if (removed && removed.repo_root === directory) {
-        setDirectory('')
-      }
-    } catch {
-      // ignore
-    }
+      if (removed && removed.repo_root === directory) setDirectory('')
+    } catch { /* ignore */ }
   }, [directory, savedProjects])
 
   useEffect(() => {
     let isMounted = true
-
     const loadWorktreeRoot = async () => {
       try {
         const result = await window.api.getWorktreeRoot()
-        if (isMounted && result.ok && result.data) {
-          setWorktreeRoot(result.data)
-        }
-      } catch {
-        // ignore preview path failures
-      }
+        if (isMounted && result.ok && result.data) setWorktreeRoot(result.data)
+      } catch { /* ignore */ }
     }
-
     void loadWorktreeRoot()
-
-    return () => {
-      isMounted = false
-    }
+    return () => { isMounted = false }
   }, [])
 
   useEffect(() => {
-    if (!directory.trim()) {
-      setDirError(null)
-      setValidating(false)
-      return
-    }
-
+    if (!directory.trim()) { setDirError(null); setValidating(false); return }
     const currentDir = directory.trim()
     setValidating(true)
-
     const timer = setTimeout(async () => {
       if (onValidateDirectory) {
         try {
           const isValid = await onValidateDirectory(currentDir)
-          // Only update state if the directory hasn't changed since we started
           setDirectory((latest) => {
-            if (latest.trim() === currentDir) {
-              setDirError(isValid ? null : 'This directory is not a valid git repository.')
-              setValidating(false)
-            }
+            if (latest.trim() === currentDir) { setDirError(isValid ? null : 'This directory is not a valid git repository.'); setValidating(false) }
             return latest
           })
         } catch {
           setDirectory((latest) => {
-            if (latest.trim() === currentDir) {
-              setDirError('Could not validate directory.')
-              setValidating(false)
-            }
+            if (latest.trim() === currentDir) { setDirError('Could not validate directory.'); setValidating(false) }
             return latest
           })
         }
@@ -351,55 +333,94 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
         setValidating(false)
       }
     }, 500)
-
     return () => clearTimeout(timer)
   }, [directory, onValidateDirectory])
 
-  // Load per-project fresh worktree + base branch settings when directory changes.
-  // Guarded on projectsReady to avoid resetting state before the init flow completes.
+  // Load per-project settings when directory changes
   useEffect(() => {
     const dir = directory.trim()
     if (!dir || !projectsReady) return
-
     let cancelled = false
     setDetectingBranch(true)
-
-    const loadSettings = async () => {
+    const loadProjectSettings = async () => {
       try {
         const repoRootResult = await window.api.getRepoRoot(dir)
         if (cancelled) return
         const repoRoot = repoRootResult.ok && repoRootResult.data ? repoRootResult.data : dir
-
         const matchedProject = savedProjects.find((p) => p.repo_root === repoRoot)
         setFreshWorktree(!!matchedProject?.fresh_worktree)
-
-        if (matchedProject?.default_branch) {
-          setBaseBranch(matchedProject.default_branch)
-          return
-        }
-
+        if (matchedProject?.default_branch) { setBaseBranch(matchedProject.default_branch); return }
         const branchResult = await window.api.getDefaultBranch(repoRoot)
         if (cancelled) return
         setBaseBranch(branchResult.ok && branchResult.data ? branchResult.data : 'origin/main')
       } catch {
-        if (!cancelled) {
-          setFreshWorktree(false)
-          setBaseBranch('origin/main')
-        }
+        if (!cancelled) { setFreshWorktree(false); setBaseBranch('origin/main') }
       } finally {
         if (!cancelled) setDetectingBranch(false)
       }
     }
-    void loadSettings()
+    void loadProjectSettings()
     return () => { cancelled = true }
   }, [directory, savedProjects, projectsReady])
+
+  // Fetch sessions when import tab is active and directory is valid
+  useEffect(() => {
+    if (activeTab !== 'import' || !directory.trim() || dirError || validating) {
+      setImportSessions([]); setImportError(null); setSelectedSession(null)
+      return
+    }
+    let cancelled = false
+    const fetchSessions = async () => {
+      setImportLoading(true); setImportError(null); setImportSessions([]); setSelectedSession(null)
+      try {
+        const result = await window.api.listSessionsByProject(directory.trim())
+        if (cancelled) return
+        if (result.ok && result.data) {
+          const sorted = [...result.data].sort((a, b) => b.updatedAt - a.updatedAt)
+          setImportSessions(sorted)
+          if (sorted.length === 0) setImportError('No sessions found for this project.')
+        } else {
+          setImportError(result.error ?? 'Failed to list sessions.')
+        }
+      } catch (err) {
+        if (!cancelled) setImportError(String(err))
+      } finally {
+        if (!cancelled) setImportLoading(false)
+      }
+    }
+    void fetchSessions()
+    return () => { cancelled = true }
+  }, [activeTab, directory, dirError, validating])
+
+  // Reset import state when switching tabs
+  useEffect(() => {
+    if (activeTab !== 'import') { setSelectedSession(null); setImportSearch(''); setImportName(''); setImportPrompt('') }
+  }, [activeTab])
+
+  // Close session dropdown on outside click
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (sessionDropdownRef.current && !sessionDropdownRef.current.contains(event.target as Node)) {
+        setShowSessionDropdown(false)
+        setImportSearch('')
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const filteredImportSessions = useMemo(() => {
+    if (!importSearch.trim()) return importSessions
+    const q = importSearch.toLowerCase()
+    return importSessions.filter((s) =>
+      s.title.toLowerCase().includes(q) || s.id.toLowerCase().includes(q)
+    )
+  }, [importSessions, importSearch])
 
   // Close dropdown when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setShowDropdown(false)
-      }
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) setShowDropdown(false)
     }
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
@@ -409,20 +430,14 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
     try {
       const repoRootResult = await window.api.getRepoRoot(dir)
       const canonicalRoot = repoRootResult.ok && repoRootResult.data ? repoRootResult.data : dir
-      // Write settings before reloading projects to avoid the settings effect
-      // reading stale fresh_worktree values from an intermediate savedProjects update.
       const name = dirDisplayName(canonicalRoot)
       const ensureResult = await window.api.ensureProject({ name, repoRoot: canonicalRoot })
-      if (!ensureResult.ok) {
-        console.warn('Failed to ensure project:', ensureResult.error)
-      }
+      if (!ensureResult.ok) console.warn('Failed to ensure project:', ensureResult.error)
       const settingsResult = await window.api.updateProjectSettings({
         repoRoot: canonicalRoot,
         settings: { fresh_worktree: freshWorktree, default_branch: baseBranch || null }
       })
-      if (!settingsResult.ok) {
-        console.warn('Failed to persist worktree settings:', settingsResult.error)
-      }
+      if (!settingsResult.ok) console.warn('Failed to persist worktree settings:', settingsResult.error)
       await window.api.setPreference('launch:last-directory', canonicalRoot)
       await loadProjects()
     } catch (err) {
@@ -432,16 +447,35 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
 
   const handleLaunch = async () => {
     if (!directory.trim() || dirError || validating) return
+    if (activeTab === 'import' && !selectedSession) return
     setLaunching(true)
     try {
+      const effectiveStrategy = activeTab === 'import' ? 'new-worktree' : worktreeStrategy
+
       const freshConfig: FreshWorktreeConfig | undefined =
-        worktreeStrategy === 'new-worktree' && freshWorktree
+        effectiveStrategy === 'new-worktree' && freshWorktree
           ? { enabled: true, baseBranch }
           : undefined
 
-      // Must complete before onClose unmounts the component
+      const importConfig: ImportSessionConfig | undefined =
+        activeTab === 'import' && selectedSession
+          ? { sessionId: selectedSession.id, sessionTitle: selectedSession.title }
+          : undefined
+
+      const effectiveTitle = activeTab === 'import'
+        ? (importName.trim() || selectedSession?.title || undefined)
+        : (title || undefined)
+
+      const effectivePrompt = activeTab === 'import'
+        ? (importPrompt.trim() || undefined)
+        : (prompt || undefined)
+
+      const effectiveAttachments = activeTab === 'new' && attachments.length > 0
+        ? attachments
+        : undefined
+
       await persistProjectSettings(directory.trim())
-      await onLaunch(directory, prompt || undefined, title || undefined, model, worktreeStrategy, attachments.length > 0 ? attachments : undefined, freshConfig)
+      await onLaunch(directory, effectivePrompt, effectiveTitle, model, effectiveStrategy, effectiveAttachments, freshConfig, importConfig)
 
       clearAttachments()
       onClose()
@@ -453,10 +487,7 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
 
   const handleBrowse = async () => {
     const selected = await onSelectDirectory()
-    if (selected) {
-      setDirectory(selected)
-      setShowDropdown(false)
-    }
+    if (selected) { setDirectory(selected); setShowDropdown(false) }
   }
 
   const handleSelectProject = (repoRoot: string) => {
@@ -473,33 +504,70 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
   const selectedProject = savedProjects.find((p) => p.repo_root === directory)
   const hasDirectory = directory.trim().length > 0
 
+  const isLaunchDisabled = activeTab === 'new'
+    ? !directory.trim() || launching || validating || !!dirError
+    : !directory.trim() || launching || validating || !!dirError || !selectedSession
+
+  const launchButtonLabel = launching
+    ? 'Launching...'
+    : activeTab === 'import' && selectedSession
+      ? 'Fork & Launch'
+      : 'Launch Agent'
+
   return (
     <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/60" onClick={onClose}>
       <div
         className="w-[560px] max-h-[85vh] bg-kumo-elevated border border-kumo-line rounded-xl shadow-2xl flex flex-col"
         onClick={(event) => event.stopPropagation()}
       >
-        {/* Header */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-kumo-line">
-          <h2 className="text-base font-semibold text-kumo-strong">Launch New Agent</h2>
-          <button
-            onClick={onClose}
-            className="w-7 h-7 flex items-center justify-center rounded-md border border-kumo-line text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill transition-colors"
-          >
-            <X size={14} />
-          </button>
+        {/* Header with tabs */}
+        <div className="flex flex-col border-b border-kumo-line">
+          <div className="flex items-center justify-between px-5 pt-4 pb-0">
+            <h2 className="text-base font-semibold text-kumo-strong">Launch Agent</h2>
+            <button
+              onClick={onClose}
+              className="w-7 h-7 flex items-center justify-center rounded-md border border-kumo-line text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill transition-colors"
+            >
+              <X size={14} />
+            </button>
+          </div>
+          <div className="flex gap-0 px-5 mt-3">
+            <button
+              type="button"
+              onClick={() => setActiveTab('new')}
+              className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium border-b-2 transition-colors -mb-px ${
+                activeTab === 'new'
+                  ? 'text-kumo-default border-kumo-brand'
+                  : 'text-kumo-subtle border-transparent hover:text-kumo-default'
+              }`}
+            >
+              <Play size={12} weight="bold" />
+              New Agent
+            </button>
+            <button
+              type="button"
+              onClick={() => setActiveTab('import')}
+              className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium border-b-2 transition-colors -mb-px ${
+                activeTab === 'import'
+                  ? 'text-kumo-default border-kumo-brand'
+                  : 'text-kumo-subtle border-transparent hover:text-kumo-default'
+              }`}
+            >
+              <ClockCounterClockwise size={12} weight="bold" />
+              Import Session
+            </button>
+          </div>
         </div>
 
         {/* Body */}
-        <div className="px-5 py-4 flex flex-col gap-4 overflow-y-auto overflow-x-hidden">
-          {/* Directory Selector */}
+        <div className="px-5 py-4 flex flex-col gap-4 overflow-y-auto overflow-x-hidden min-h-0 flex-1">
+          {/* Directory Selector — shared between tabs */}
           <div className="flex flex-col gap-1.5">
             <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
               Project Directory
             </label>
             <div className="relative flex gap-2" ref={dropdownRef}>
               <div className="flex-1 min-w-0 relative">
-                {/* Selector button */}
                 <button
                   type="button"
                   onClick={() => setShowDropdown(!showDropdown)}
@@ -524,9 +592,12 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
                   <CaretDown size={14} className="text-kumo-subtle shrink-0" />
                 </button>
 
-                {/* Dropdown */}
                 {showDropdown && (
-                  <div className="absolute top-full left-0 right-0 mt-1 bg-kumo-control border border-kumo-fill-hover rounded-md shadow-2xl z-10 max-h-[240px] overflow-y-auto overflow-x-hidden">
+                  <div className="fixed mt-1 bg-kumo-control border border-kumo-fill-hover rounded-md shadow-2xl z-[210] max-h-[320px] overflow-y-auto overflow-x-hidden" style={{
+                    width: dropdownRef.current?.querySelector('button')?.getBoundingClientRect().width,
+                    left: dropdownRef.current?.querySelector('button')?.getBoundingClientRect().left,
+                    top: (dropdownRef.current?.querySelector('button')?.getBoundingClientRect().bottom ?? 0) + 4
+                  }}>
                     {savedProjects.length > 0 && (
                       <>
                         <div className="px-3 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wider">
@@ -539,12 +610,8 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
                             onMouseDown={() => handleSelectProject(project.repo_root)}
                           >
                             <div className="min-w-0 flex-1">
-                              <div className="text-xs text-kumo-default font-medium truncate">
-                                {project.name}
-                              </div>
-                              <div className="text-[11px] text-kumo-subtle font-mono truncate">
-                                {project.repo_root}
-                              </div>
+                              <div className="text-xs text-kumo-default font-medium truncate">{project.name}</div>
+                              <div className="text-[11px] text-kumo-subtle font-mono truncate">{project.repo_root}</div>
                             </div>
                             <button
                               onMouseDown={(e) => void removeProject(project.id, e)}
@@ -575,9 +642,7 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
                 <FolderOpen size={16} />
               </button>
             </div>
-            {validating && (
-              <p className="text-[11px] text-kumo-subtle">Validating directory...</p>
-            )}
+            {validating && <p className="text-[11px] text-kumo-subtle">Validating directory...</p>}
             {dirError && (
               <p className="text-[11px] text-kumo-danger flex items-center gap-1">
                 <Warning size={12} />
@@ -586,212 +651,368 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
             )}
           </div>
 
-          {/* Branch / Worktree Strategy */}
-          <div className="flex flex-col gap-1.5">
-            <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
-              Branch Strategy
-            </label>
-            <div className="relative">
-              <SelectField
-                value={worktreeStrategy}
-                onChange={(value) => setWorktreeStrategy(value as WorktreeStrategy)}
-                options={[
-                  { value: 'new-worktree', label: 'New Worktree (recommended)' },
-                  { value: 'current-directory', label: 'Use Current Directory' }
-                ]}
-                buttonClassName={selectButtonClasses}
-                menuClassName={selectMenuClasses}
-              />
-            </div>
-            {worktreeStrategy === 'new-worktree' && estimatedWorktreePath && (
-              <p className="text-[11px] text-kumo-subtle font-mono truncate" title={estimatedWorktreePath}>
-                Worktree path: {estimatedWorktreePath}
-              </p>
-            )}
-            {worktreeStrategy === 'new-worktree' && (
-              <div className="flex flex-col gap-1.5 mt-1">
-                <label className="flex items-center gap-2 text-xs text-kumo-default cursor-pointer select-none">
-                  <input
-                    type="checkbox"
-                    checked={freshWorktree}
-                    onChange={(e) => setFreshWorktree(e.target.checked)}
-                    className="rounded border-kumo-line bg-kumo-control text-kumo-accent focus:ring-kumo-ring h-3.5 w-3.5"
-                  />
-                  Fetch latest from base branch
+          {/* ── New Agent Tab ── */}
+          {activeTab === 'new' && (
+            <>
+              {/* Branch / Worktree Strategy */}
+              <div className="flex flex-col gap-1.5">
+                <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
+                  Branch Strategy
                 </label>
-                {freshWorktree && (
-                  <input
-                    type="text"
-                    value={baseBranch}
-                    onChange={(e) => setBaseBranch(e.target.value)}
-                    placeholder={detectingBranch ? 'Detecting...' : 'origin/main'}
-                    disabled={detectingBranch}
-                    className="w-full rounded-md border border-kumo-line bg-kumo-control px-2.5 py-1.5 text-xs text-kumo-default font-mono placeholder:text-kumo-subtle outline-none transition-colors focus:border-kumo-ring disabled:opacity-50"
+                <div className="relative">
+                  <SelectField
+                    value={worktreeStrategy}
+                    onChange={(value) => setWorktreeStrategy(value as WorktreeStrategy)}
+                    options={[
+                      { value: 'new-worktree', label: 'New Worktree (recommended)' },
+                      { value: 'current-directory', label: 'Use Current Directory' }
+                    ]}
+                    buttonClassName={selectButtonClasses}
+                    menuClassName={selectMenuClasses}
                   />
+                </div>
+                {worktreeStrategy === 'new-worktree' && estimatedWorktreePath && (
+                  <p className="text-[11px] text-kumo-subtle font-mono truncate" title={estimatedWorktreePath}>
+                    Worktree path: {estimatedWorktreePath}
+                  </p>
+                )}
+                {worktreeStrategy === 'new-worktree' && (
+                  <div className="flex flex-col gap-2 mt-2">
+                    <button
+                      type="button"
+                      onClick={() => setFreshWorktree(!freshWorktree)}
+                      className="flex items-center gap-2 text-xs text-kumo-default cursor-pointer select-none group"
+                    >
+                      <span className={`flex items-center justify-center w-3.5 h-3.5 rounded border transition-colors ${
+                        freshWorktree
+                          ? 'bg-kumo-brand border-kumo-brand text-white'
+                          : 'border-kumo-line bg-kumo-control group-hover:border-kumo-subtle'
+                      }`}>
+                        {freshWorktree && <span className="text-[9px] font-bold leading-none">&#10003;</span>}
+                      </span>
+                      Fetch latest from base branch
+                    </button>
+                    {freshWorktree && (
+                      <input
+                        type="text"
+                        value={baseBranch}
+                        onChange={(e) => setBaseBranch(e.target.value)}
+                        placeholder={detectingBranch ? 'Detecting...' : 'origin/main'}
+                        disabled={detectingBranch}
+                        className="w-full rounded-md border border-kumo-line bg-kumo-control px-2.5 py-1.5 text-xs text-kumo-default font-mono placeholder:text-kumo-subtle outline-none transition-colors focus:border-kumo-ring disabled:opacity-50"
+                      />
+                    )}
+                  </div>
                 )}
               </div>
-            )}
-          </div>
 
-          {/* Model */}
-          <div className="flex flex-col gap-1.5">
-            <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">Model</label>
-            <div className="relative">
-              <SelectField
-                value={model}
-                onChange={(value) => setModel(value)}
-                options={modelOptions}
-                buttonClassName={selectButtonClasses}
-                menuClassName={selectMenuClasses}
-              />
-            </div>
-          </div>
+              {/* Model */}
+              <div className="flex flex-col gap-1.5">
+                <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">Model</label>
+                <div className="relative">
+                  <SelectField
+                    value={model}
+                    onChange={(value) => setModel(value)}
+                    options={modelOptions}
+                    buttonClassName={selectButtonClasses}
+                    menuClassName={selectMenuClasses}
+                  />
+                </div>
+              </div>
 
-          {/* Title (optional) */}
-          <div className="flex flex-col gap-1.5">
-            <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
-              Agent Name <span className="text-kumo-subtle/60">(optional)</span>
-            </label>
-            <input
-              type="text"
-              value={title}
-              onChange={(event) => setTitle(event.target.value)}
-              placeholder="auth-refactor"
-              className="px-3 py-2 bg-kumo-control border border-kumo-line rounded-md text-sm text-kumo-default outline-none focus:border-kumo-ring placeholder:text-kumo-subtle"
-            />
-          </div>
+              {/* Title (optional) */}
+              <div className="flex flex-col gap-1.5">
+                <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
+                  Agent Name <span className="text-kumo-subtle/60">(optional)</span>
+                </label>
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(event) => setTitle(event.target.value)}
+                  placeholder="auth-refactor"
+                  className="px-3 py-2 bg-kumo-control border border-kumo-line rounded-md text-sm text-kumo-default outline-none focus:border-kumo-ring placeholder:text-kumo-subtle"
+                />
+              </div>
 
-          {/* Prompt */}
-          <div className="flex flex-col gap-1.5">
-            <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
-              Initial Prompt <span className="text-kumo-subtle/60">(optional — you can prompt from the session)</span>
-            </label>
-            <div
-              className={`relative flex flex-col gap-0 rounded-md border transition-colors ${
-                isDragOver ? 'border-kumo-brand bg-kumo-brand/[0.04]' : 'border-kumo-line focus-within:border-kumo-ring'
-              }`}
-              onDragOver={handleDragOver}
-              onDragEnter={handleDragEnter}
-              onDragLeave={handleDragLeave}
-              onDrop={handleDrop}
-            >
-              {attachments.length > 0 && (
-                <div className="flex gap-2 px-3 py-2 overflow-x-auto">
-                  {attachments.map((att) => (
-                    <div key={att.id} className="relative group shrink-0">
-                      <img
-                        src={att.dataUrl}
-                        alt={att.filename ?? 'attachment'}
-                        className="h-16 w-16 rounded-md border border-kumo-line object-cover"
-                      />
+              {/* Prompt */}
+              <div className="flex flex-col gap-1.5">
+                <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
+                  Initial Prompt <span className="text-kumo-subtle/60">(optional — you can prompt from the session)</span>
+                </label>
+                <div
+                  className={`relative flex flex-col gap-0 rounded-md border transition-colors ${
+                    isDragOver ? 'border-kumo-brand bg-kumo-brand/[0.04]' : 'border-kumo-line focus-within:border-kumo-ring'
+                  }`}
+                  onDragOver={handleDragOver}
+                  onDragEnter={handleDragEnter}
+                  onDragLeave={handleDragLeave}
+                  onDrop={handleDrop}
+                >
+                  {attachments.length > 0 && (
+                    <div className="flex gap-2 px-3 py-2 overflow-x-auto">
+                      {attachments.map((att) => (
+                        <div key={att.id} className="relative group shrink-0">
+                          <img
+                            src={att.dataUrl}
+                            alt={att.filename ?? 'attachment'}
+                            className="h-16 w-16 rounded-md border border-kumo-line object-cover"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => removeAttachment(att.id!)}
+                            className="absolute -top-1.5 -right-1.5 w-4 h-4 flex items-center justify-center rounded-full bg-kumo-danger text-white text-[9px] font-bold opacity-0 group-hover:opacity-100 transition-opacity"
+                          >
+                            <X size={8} weight="bold" />
+                          </button>
+                          {att.filename && (
+                            <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white text-[8px] px-1 py-0.5 rounded-b-md truncate">
+                              {att.filename}
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  {showCommandAutocomplete && (
+                    <div className="absolute bottom-full left-0 right-0 z-20 mb-2 rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl">
+                      {matchingCommands.map((item, index) => (
+                        <button
+                          key={item.command}
+                          type="button"
+                          onMouseDown={(event) => { event.preventDefault(); setPrompt(`${item.command} `) }}
+                          className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
+                            index === commandPickerIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
+                          }`}
+                        >
+                          <span className="font-mono text-[11px] text-kumo-default">{item.command}</span>
+                          <span className="text-[11px] text-kumo-subtle">{item.description}</span>
+                        </button>
+                      ))}
+                      <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
+                        Tab/Enter to select · Arrow keys to navigate · Esc to dismiss
+                      </div>
+                    </div>
+                  )}
+
+                  {showAgentPicker && (
+                    <div className="absolute bottom-full left-0 right-0 z-20 mb-2 rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl">
+                      <div className="px-2.5 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wide">Agents</div>
+                      {matchingAgents.map((cfg, index) => (
+                        <button
+                          key={cfg.name}
+                          type="button"
+                          onMouseDown={(event) => { event.preventDefault(); insertAgentMention(cfg.name) }}
+                          className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
+                            index === agentPickerIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
+                          }`}
+                        >
+                          <span className="font-mono text-[11px] text-kumo-brand">@{cfg.name}</span>
+                          {cfg.description && <span className="text-[11px] text-kumo-subtle truncate">{cfg.description}</span>}
+                        </button>
+                      ))}
+                      <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
+                        Tab/Enter to select · Arrow keys to navigate · Esc to dismiss
+                      </div>
+                    </div>
+                  )}
+
+                  <textarea
+                    ref={promptRef}
+                    value={prompt}
+                    onChange={handlePromptChange}
+                    onKeyDown={handlePromptKeyDown}
+                    onKeyUp={(e) => setCursorPos(e.currentTarget.selectionStart)}
+                    onClick={(e) => setCursorPos(e.currentTarget.selectionStart)}
+                    onPaste={handlePaste}
+                    placeholder={isDragOver ? 'Drop image here...' : 'Leave empty to start an interactive session... Type / for commands, @ for agents.'}
+                    rows={3}
+                    className="px-3 py-2 bg-kumo-control rounded-md text-sm text-kumo-default outline-none placeholder:text-kumo-subtle resize-none border-0 focus:ring-0"
+                  />
+                  <div className="flex items-center gap-2 px-3 py-1.5 border-t border-kumo-line">
+                    <button
+                      type="button"
+                      onClick={() => fileInputRef.current?.click()}
+                      className="flex items-center gap-1 text-[10px] text-kumo-subtle hover:text-kumo-default transition-colors"
+                      title="Attach image"
+                    >
+                      <Paperclip size={11} />
+                      <span>Attach image</span>
+                    </button>
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept="image/png,image/jpeg,image/gif,image/webp"
+                      multiple
+                      className="hidden"
+                      onChange={handleFileInputChange}
+                    />
+                    <span className="text-[10px] text-kumo-subtle/60">Paste or drag images to attach.</span>
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+
+          {/* ── Import Session Tab ── */}
+          {activeTab === 'import' && (
+            <>
+              {hasDirectory && !dirError && !validating && (
+                <>
+                  {/* Session dropdown */}
+                  <div className="flex flex-col gap-1.5">
+                    <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
+                      Session
+                    </label>
+                    <div className="relative" ref={sessionDropdownRef}>
                       <button
                         type="button"
-                        onClick={() => removeAttachment(att.id!)}
-                        className="absolute -top-1.5 -right-1.5 w-4 h-4 flex items-center justify-center rounded-full bg-kumo-danger text-white text-[9px] font-bold opacity-0 group-hover:opacity-100 transition-opacity"
+                        onClick={() => { if (!importLoading && !importError) setShowSessionDropdown(!showSessionDropdown) }}
+                        disabled={importLoading}
+                        className={`w-full flex items-center gap-2 px-3 py-2 bg-kumo-control border border-kumo-line rounded-md text-sm outline-none transition-colors ${
+                          importLoading ? 'opacity-60 cursor-wait' : 'hover:bg-kumo-fill focus:border-kumo-ring'
+                        }`}
                       >
-                        <X size={8} weight="bold" />
+                        <div className="min-w-0 flex-1 text-left truncate">
+                          {importLoading ? (
+                            <span className="flex items-center gap-2 text-kumo-subtle">
+                              <CircleNotch size={13} className="animate-spin shrink-0" />
+                              Loading sessions...
+                            </span>
+                          ) : importError ? (
+                            <span className="text-kumo-subtle">{importError}</span>
+                          ) : selectedSession ? (
+                            <>
+                              <span className="text-kumo-default font-medium">{selectedSession.title}</span>
+                              <span className="text-kumo-subtle text-xs ml-2">{formatTimestamp(selectedSession.updatedAt)}</span>
+                            </>
+                          ) : (
+                            <span className="text-kumo-subtle">
+                              {importSessions.length === 0 ? 'No sessions found' : 'Select a session...'}
+                            </span>
+                          )}
+                        </div>
+                        {!importLoading && <CaretDown size={14} className="text-kumo-subtle shrink-0" />}
                       </button>
-                      {att.filename && (
-                        <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white text-[8px] px-1 py-0.5 rounded-b-md truncate">
-                          {att.filename}
+
+                      {showSessionDropdown && !importLoading && importSessions.length > 0 && (
+                        <div className="fixed mt-1 bg-kumo-control border border-kumo-fill-hover rounded-md shadow-2xl z-[210] max-h-[320px] flex flex-col overflow-hidden" style={{
+                          width: sessionDropdownRef.current?.getBoundingClientRect().width,
+                          left: sessionDropdownRef.current?.getBoundingClientRect().left,
+                          top: (sessionDropdownRef.current?.getBoundingClientRect().bottom ?? 0) + 4
+                        }}>
+                          <div className="px-2 pt-2 pb-1 shrink-0">
+                            <input
+                              type="text"
+                              value={importSearch}
+                              onChange={(e) => setImportSearch(e.target.value)}
+                              placeholder="Search sessions..."
+                              className="w-full rounded border border-kumo-line bg-kumo-elevated px-2 py-1 text-xs text-kumo-default placeholder:text-kumo-subtle outline-none focus:border-kumo-ring"
+                              autoFocus
+                            />
+                          </div>
+                          <div className="overflow-y-auto flex-1">
+                            {filteredImportSessions.map((session) => {
+                              const isSelected = selectedSession?.id === session.id
+                              const wtLabel = worktreeLabel(session.directory, directory.trim())
+                              return (
+                                <div
+                                  key={session.id}
+                                  onMouseDown={() => {
+                                    setSelectedSession(session)
+                                    setImportName(deriveForkedName(session.title))
+                                    setShowSessionDropdown(false)
+                                    setImportSearch('')
+                                  }}
+                                  className={`flex items-center gap-2.5 px-3 py-2 cursor-pointer transition-colors ${
+                                    isSelected ? 'bg-kumo-brand/10' : 'hover:bg-kumo-fill-hover'
+                                  }`}
+                                >
+                                  <div className="flex-1 min-w-0">
+                                    <div className="text-xs text-kumo-default font-medium truncate">{session.title}</div>
+                                    <div className="flex items-center gap-1.5 text-[10px] text-kumo-subtle mt-0.5">
+                                      <span>{formatTimestamp(session.updatedAt)}</span>
+                                      {wtLabel && (
+                                        <>
+                                          <span className="text-kumo-line">|</span>
+                                          <span className="font-mono truncate">{wtLabel}</span>
+                                        </>
+                                      )}
+                                    </div>
+                                  </div>
+                                  {isSelected && (
+                                    <span className="shrink-0 text-[10px] font-medium text-kumo-brand">&#10003;</span>
+                                  )}
+                                </div>
+                              )
+                            })}
+                            {filteredImportSessions.length === 0 && (
+                              <div className="px-3 py-4 text-xs text-kumo-subtle text-center">No matching sessions</div>
+                            )}
+                          </div>
                         </div>
                       )}
                     </div>
-                  ))}
-                </div>
+                    <p className="text-[11px] text-kumo-subtle -mt-0.5">
+                      Creates a new worktree and copies the session history into it.
+                    </p>
+                  </div>
+
+                  {/* Name + Model — shown after session selected */}
+                  {selectedSession && (
+                    <>
+                      <div className="flex flex-col gap-1.5">
+                        <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
+                          Agent Name
+                        </label>
+                        <input
+                          type="text"
+                          value={importName}
+                          onChange={(e) => setImportName(e.target.value)}
+                          placeholder={selectedSession.title}
+                          className="px-3 py-2 bg-kumo-control border border-kumo-line rounded-md text-sm text-kumo-default outline-none focus:border-kumo-ring placeholder:text-kumo-subtle"
+                        />
+                      </div>
+
+                      <div className="flex flex-col gap-1.5">
+                        <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
+                          Model
+                        </label>
+                        <div className="relative">
+                          <SelectField
+                            value={model}
+                            onChange={(value) => setModel(value)}
+                            options={modelOptions}
+                            buttonClassName={selectButtonClasses}
+                            menuClassName={selectMenuClasses}
+                          />
+                        </div>
+                      </div>
+
+                      <div className="flex flex-col gap-1.5">
+                        <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
+                          Initial Prompt <span className="text-kumo-subtle/60">(optional)</span>
+                        </label>
+                        <textarea
+                          value={importPrompt}
+                          onChange={(e) => setImportPrompt(e.target.value)}
+                          placeholder="Continue where you left off, or give new instructions..."
+                          rows={2}
+                          className="px-3 py-2 bg-kumo-control border border-kumo-line rounded-md text-sm text-kumo-default outline-none placeholder:text-kumo-subtle resize-none focus:border-kumo-ring"
+                        />
+                      </div>
+                    </>
+                  )}
+                </>
               )}
 
-              {/* Command autocomplete dropdown */}
-              {showCommandAutocomplete && (
-                <div className="absolute bottom-full left-0 right-0 z-20 mb-2 rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl">
-                  {matchingCommands.map((item, index) => (
-                    <button
-                      key={item.command}
-                      type="button"
-                      onMouseDown={(event) => {
-                        event.preventDefault()
-                        setPrompt(`${item.command} `)
-                      }}
-                      className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
-                        index === commandPickerIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
-                      }`}
-                    >
-                      <span className="font-mono text-[11px] text-kumo-default">{item.command}</span>
-                      <span className="text-[11px] text-kumo-subtle">{item.description}</span>
-                    </button>
-                  ))}
-                  <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
-                    Tab/Enter to select · Arrow keys to navigate · Esc to dismiss
-                  </div>
+              {!hasDirectory && !validating && (
+                <div className="flex items-center justify-center py-8 text-xs text-kumo-subtle">
+                  Select a project directory to browse sessions.
                 </div>
               )}
-
-              {/* Agent picker dropdown */}
-              {showAgentPicker && (
-                <div className="absolute bottom-full left-0 right-0 z-20 mb-2 rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl">
-                  <div className="px-2.5 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wide">
-                    Agents
-                  </div>
-                  {matchingAgents.map((cfg, index) => (
-                    <button
-                      key={cfg.name}
-                      type="button"
-                      onMouseDown={(event) => {
-                        event.preventDefault()
-                        insertAgentMention(cfg.name)
-                      }}
-                      className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
-                        index === agentPickerIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
-                      }`}
-                    >
-                      <span className="font-mono text-[11px] text-kumo-brand">@{cfg.name}</span>
-                      {cfg.description && (
-                        <span className="text-[11px] text-kumo-subtle truncate">{cfg.description}</span>
-                      )}
-                    </button>
-                  ))}
-                  <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
-                    Tab/Enter to select · Arrow keys to navigate · Esc to dismiss
-                  </div>
-                </div>
-              )}
-
-              <textarea
-                ref={promptRef}
-                value={prompt}
-                onChange={handlePromptChange}
-                onKeyDown={handlePromptKeyDown}
-                onKeyUp={(e) => setCursorPos(e.currentTarget.selectionStart)}
-                onClick={(e) => setCursorPos(e.currentTarget.selectionStart)}
-                onPaste={handlePaste}
-                placeholder={isDragOver ? 'Drop image here...' : 'Leave empty to start an interactive session... Type / for commands, @ for agents.'}
-                rows={3}
-                className="px-3 py-2 bg-kumo-control rounded-md text-sm text-kumo-default outline-none placeholder:text-kumo-subtle resize-none border-0 focus:ring-0"
-              />
-              <div className="flex items-center gap-2 px-3 pb-2">
-                <button
-                  type="button"
-                  onClick={() => fileInputRef.current?.click()}
-                  className="flex items-center gap-1 text-[10px] text-kumo-subtle hover:text-kumo-default transition-colors"
-                  title="Attach image"
-                >
-                  <Paperclip size={11} />
-                  <span>Attach image</span>
-                </button>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept="image/png,image/jpeg,image/gif,image/webp"
-                  multiple
-                  className="hidden"
-                  onChange={handleFileInputChange}
-                />
-                <span className="text-[10px] text-kumo-subtle">
-                  Paste or drag images to attach.
-                </span>
-              </div>
-            </div>
-          </div>
+            </>
+          )}
         </div>
 
         {/* Footer */}
@@ -804,10 +1025,10 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
           </button>
           <button
             onClick={handleLaunch}
-            disabled={!directory.trim() || launching || validating || !!dirError}
+            disabled={isLaunchDisabled}
             className="px-4 py-2 text-xs font-medium text-white bg-kumo-brand rounded-md hover:bg-kumo-brand-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            {launching ? 'Launching...' : 'Launch Agent'}
+            {launchButtonLabel}
           </button>
         </div>
       </div>

--- a/src/renderer/src/demoApi.ts
+++ b/src/renderer/src/demoApi.ts
@@ -301,6 +301,8 @@ export function createDemoApi(): OrchestratorApi {
     listAgentConfigs: () => ok([]),
     listTools: () => ok([]),
     listSessions: () => ok([]),
+    listSessionsByProject: () => ok([]),
+    forkSession: () => ok({ sessionId: 'demo-fork', title: 'Forked session' }),
     resumeAgent: noop,
     listAgents: () => ok(DEMO_AGENTS),
     updateAgentMeta: noop,

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -33,6 +33,8 @@ export interface OrchestratorApi {
   listTools: (agentId: string) => Promise<IpcResult>
   sendMessageWithModel: (agentId: string, text: string, providerID: string, modelID: string, attachments?: MessageAttachment[]) => Promise<IpcResult>
   listSessions: (directory: string) => Promise<IpcResult<SessionListEntry[]>>
+  listSessionsByProject: (projectDirectory: string) => Promise<IpcResult<ProjectSessionEntry[]>>
+  forkSession: (options: { sourceSessionId: string; targetDirectory: string }) => Promise<IpcResult<{ sessionId: string; title: string }>>
   resumeAgent: (options: { directory: string; sessionId: string; title?: string }) => Promise<IpcResult>
   listAgents: () => Promise<IpcResult<ListAgentsPayload>>
   updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelIds?: string[]; prUrl?: string }) => Promise<IpcResult>
@@ -111,6 +113,14 @@ export interface WorktreeListEntry {
 export interface SessionListEntry {
   id: string
   title: string
+  createdAt: number
+  updatedAt: number
+}
+
+export interface ProjectSessionEntry {
+  id: string
+  title: string
+  directory: string
   createdAt: number
   updatedAt: number
 }


### PR DESCRIPTION
Sessions survive worktree deletion because OpenCode stores them in a global database. This adds a way to find those sessions and fork them into fresh worktrees so you can pick up where you left off.

LaunchModal gains an 'Import Session' tab. Select a project, pick a session from the dropdown, name the agent, optionally set a prompt, and hit Fork & Launch. The orchestrator creates a worktree, forks the session into it via the SDK, and resumes it as a new agent.

Renaming an agent now syncs the title to the OpenCode session so sessions are easier to find when browsing for import later.

Backend adds listSessionsByProject (all root sessions across worktrees) and forkSession (copies messages into a target directory).