### PR TITLE
Add notification sound toggle setting

### DIFF
--- a/src/__tests__/notification-service.test.ts
+++ b/src/__tests__/notification-service.test.ts
@@ -30,11 +30,21 @@ class TestNotificationService {
     disconnected: true
   }
 
+  private soundEnabled = true
+
   private sentNotifications = new Map<string, number>()
-  public notificationsSent: Array<{ agentId: string; status: NotifiableEventType; agentName: string; projectName?: string }> = []
+  public notificationsSent: Array<{ agentId: string; status: NotifiableEventType; agentName: string; projectName?: string; silent: boolean }> = []
 
   setPreference(eventType: NotifiableEventType, enabled: boolean): void {
     this.preferences[eventType] = enabled
+  }
+
+  setSoundEnabled(enabled: boolean): void {
+    this.soundEnabled = enabled
+  }
+
+  getSoundEnabled(): boolean {
+    return this.soundEnabled
   }
 
   getPreferences(): NotificationPreferences {
@@ -56,7 +66,7 @@ class TestNotificationService {
     }
 
     this.recordNotification(agentId, status)
-    this.notificationsSent.push({ agentId, status, agentName, projectName })
+    this.notificationsSent.push({ agentId, status, agentName, projectName, silent: !this.soundEnabled })
   }
 
   private isDuplicate(agentId: string, eventType: NotifiableEventType): boolean {
@@ -214,13 +224,41 @@ describe('NotificationService', () => {
         agentId: 'agent-1',
         status: 'errored',
         agentName: 'Build Worker',
-        projectName: 'my-project'
+        projectName: 'my-project',
+        silent: false
       })
     })
 
     it('handles missing project name', () => {
       service.checkAndNotify('agent-1', 'needs_approval', 'Agent X')
       expect(service.notificationsSent[0].projectName).toBeUndefined()
+    })
+  })
+
+  describe('sound preference', () => {
+    it('defaults to sound enabled', () => {
+      expect(service.getSoundEnabled()).toBe(true)
+    })
+
+    it('sends notifications with silent=false when sound is enabled', () => {
+      service.checkAndNotify('agent-1', 'errored', 'Agent Alpha')
+      expect(service.notificationsSent[0].silent).toBe(false)
+    })
+
+    it('sends notifications with silent=true when sound is disabled', () => {
+      service.setSoundEnabled(false)
+      service.checkAndNotify('agent-1', 'errored', 'Agent Alpha')
+      expect(service.notificationsSent[0].silent).toBe(true)
+    })
+
+    it('can toggle sound back on after disabling', () => {
+      service.setSoundEnabled(false)
+      expect(service.getSoundEnabled()).toBe(false)
+      service.setSoundEnabled(true)
+      expect(service.getSoundEnabled()).toBe(true)
+
+      service.checkAndNotify('agent-1', 'errored', 'Agent Alpha')
+      expect(service.notificationsSent[0].silent).toBe(false)
     })
   })
 })

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -740,6 +740,25 @@ export function registerIpcHandlers(): void {
     }
   })
 
+  ipcMain.handle('notifications:get-sound-enabled', async () => {
+    try {
+      return { ok: true, data: notificationService.getSoundEnabled() }
+    } catch (error) {
+      console.error('[IPC] notifications:get-sound-enabled failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  ipcMain.handle('notifications:set-sound-enabled', async (_event, enabled: boolean) => {
+    try {
+      notificationService.setSoundEnabled(enabled)
+      return { ok: true }
+    } catch (error) {
+      console.error('[IPC] notifications:set-sound-enabled failed:', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
   ipcMain.handle('notifications:get-pending-agent', async () => {
     try {
       const agentId = notificationService.getPendingAgentId()

--- a/src/main/services/notification-service.ts
+++ b/src/main/services/notification-service.ts
@@ -47,6 +47,8 @@ class NotificationService {
     disconnected: true
   }
 
+  private soundEnabled = true
+
   private sentNotifications = new Map<string, number>()
 
   // Prevent Notification objects from being garbage-collected before the
@@ -57,6 +59,14 @@ class NotificationService {
 
   setPreference(eventType: NotifiableEventType, enabled: boolean): void {
     this.preferences[eventType] = enabled
+  }
+
+  setSoundEnabled(enabled: boolean): void {
+    this.soundEnabled = enabled
+  }
+
+  getSoundEnabled(): boolean {
+    return this.soundEnabled
   }
 
   getPreferences(): NotificationPreferences {
@@ -150,7 +160,7 @@ class NotificationService {
     const notification = new Notification({
       title,
       body,
-      silent: false
+      silent: !this.soundEnabled
     })
 
     // Prevent GC from collecting the notification before the user clicks it.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -202,6 +202,12 @@ const api = {
   setNotificationPreference: (eventType: string, enabled: boolean): Promise<IpcResult> =>
     ipcRenderer.invoke('notifications:set-preference', eventType, enabled),
 
+  getSoundEnabled: (): Promise<IpcResult<boolean>> =>
+    ipcRenderer.invoke('notifications:get-sound-enabled'),
+
+  setSoundEnabled: (enabled: boolean): Promise<IpcResult> =>
+    ipcRenderer.invoke('notifications:set-sound-enabled', enabled),
+
   getPendingNotificationAgent: (): Promise<IpcResult<string | null>> =>
     ipcRenderer.invoke('notifications:get-pending-agent'),
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -243,6 +243,7 @@ export function App() {
     for (const [key, enabled] of Object.entries(settings.notifications)) {
       window.api.setNotificationPreference(key as keyof typeof settings.notifications, enabled)
     }
+    window.api.setSoundEnabled(settings.soundEnabled)
   }, [])
 
   // ── Suppress notifications for the agent whose transcript is open ──

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -191,10 +191,10 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                 </div>
               </div>
 
-              {/* Notification Preferences */}
+              {/* Notify When */}
               <div className="flex flex-col gap-2">
                 <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
-                  Notification Preferences
+                  Notify When
                 </label>
                 <div className="flex flex-col gap-2 pl-1">
                   {(
@@ -218,6 +218,27 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                     </label>
                   ))}
                 </div>
+              </div>
+
+              {/* Notification Sound */}
+              <div className="flex flex-col gap-2">
+                <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
+                  Notification Sound
+                </label>
+                <label className="flex items-center gap-2.5 cursor-pointer group pl-1">
+                  <input
+                    type="checkbox"
+                    checked={settings.soundEnabled}
+                    onChange={(event) => {
+                      updateSettings({ soundEnabled: event.target.checked })
+                      window.api.setSoundEnabled(event.target.checked)
+                    }}
+                    className="w-3.5 h-3.5 rounded border-kumo-line bg-kumo-control accent-kumo-brand"
+                  />
+                  <span className="text-sm text-kumo-default group-hover:text-kumo-strong transition-colors">
+                    Play sound with notifications
+                  </span>
+                </label>
               </div>
 
               {/* Verbose Mode */}

--- a/src/renderer/src/data/settings.ts
+++ b/src/renderer/src/data/settings.ts
@@ -13,6 +13,7 @@ export interface AppSettings {
   createPrPrompt: string
   notifications: NotificationPrefs
   verboseMode: boolean
+  soundEnabled: boolean
 }
 
 export const SETTINGS_STORAGE_KEY = 'oc-orchestrator:settings'
@@ -41,6 +42,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
     completed: false,
   },
   verboseMode: false,
+  soundEnabled: true,
 }
 
 export function loadSettings(): AppSettings {

--- a/src/renderer/src/demoApi.ts
+++ b/src/renderer/src/demoApi.ts
@@ -360,6 +360,8 @@ export function createDemoApi(): OrchestratorApi {
       disconnected: false
     }),
     setNotificationPreference: noop,
+    getSoundEnabled: () => ok(true),
+    setSoundEnabled: noop,
     getPendingNotificationAgent: () => ok(null),
 
     // ── App Info ──

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -82,6 +82,8 @@ export interface OrchestratorApi {
   // ── Notifications ──
   getNotificationPreferences: () => Promise<IpcResult<NotificationPreferences>>
   setNotificationPreference: (eventType: NotifiableEventType, enabled: boolean) => Promise<IpcResult>
+  getSoundEnabled: () => Promise<IpcResult<boolean>>
+  setSoundEnabled: (enabled: boolean) => Promise<IpcResult>
   getPendingNotificationAgent: () => Promise<IpcResult<string | null>>
 
   // ── App Info ──


### PR DESCRIPTION
Allow users to disable the OS notification sound while keeping visual notifications. Adds a 'Notification Sound' section in Settings, separate from the 'Notify When' status checkboxes. The preference persists in localStorage and syncs to the main process on startup.