### PR TITLE
Use status priority as tie-breaker when column sort values are equal

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -13,7 +13,7 @@ import { ModelPickerModal } from './components/ModelPickerModal'
 import { McpModal } from './components/McpModal'
 import { useAgentStore, setViewedAgentId, type LiveAgent } from './hooks/useAgentStore'
 import { useCustomLabels } from './hooks/useCustomLabels'
-import { type AgentRuntime, type Interrupt, type Message, type ColumnKey, type ColumnWidths, loadColumnVisibility, saveColumnVisibility, loadColumnWidths, saveColumnWidths } from './types'
+import { type AgentRuntime, type Interrupt, type Message, type ColumnKey, type ColumnWidths, loadColumnVisibility, saveColumnVisibility, loadColumnWidths, saveColumnWidths, compareStatusPriority } from './types'
 import type { FileChange } from './components/FilesChanged'
 import type { ToolCall } from './components/ToolsUsage'
 import type { EventEntry } from './components/EventLog'
@@ -444,7 +444,8 @@ export function App() {
         if (leftVal > rightVal) return sortDirection === 'asc' ? 1 : -1
       }
 
-      return 0
+      // Tie-breaker: sort by status priority (running before idle, etc.)
+      return compareStatusPriority(left.status, right.status)
     })
 
     return agents

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -19,7 +19,7 @@ import {
   ArrowLineUpRight
 } from '@phosphor-icons/react'
 import type { AgentRuntime, LabelDefinition, LabelColorKey, ColumnKey, ColumnWidths } from '../types'
-import { formatBranchLabel, isUrgent, labelSortKey, ALL_COLUMNS } from '../types'
+import { formatBranchLabel, isUrgent, labelSortKey, compareStatusPriority, ALL_COLUMNS } from '../types'
 import { StatusBadge } from './StatusBadge'
 import { LabelDropdown } from './LabelDropdown'
 import { TextInputModal } from './TextInputModal'
@@ -265,7 +265,8 @@ export function FleetTable({
 
       if (leftVal < rightVal) return sortDirection === 'asc' ? -1 : 1
       if (leftVal > rightVal) return sortDirection === 'asc' ? 1 : -1
-      return 0
+      // Tie-breaker: sort by status priority (running before idle, etc.)
+      return compareStatusPriority(left.status, right.status)
     })
 
     return sorted

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -229,3 +229,19 @@ export function labelSortKey(labelIds: string[], allLabels: LabelDefinition[] = 
   if (labelIds.length === 0) return '\uffff'
   return resolveNames(labelIds, allLabels).join(',').toLowerCase()
 }
+
+const STATUS_PRIORITY: Record<AgentStatus, number> = {
+  needs_input: 0,
+  needs_approval: 1,
+  running: 2,
+  starting: 3,
+  idle: 4,
+  stopping: 5,
+  errored: 6,
+  completed: 7,
+  disconnected: 8
+}
+
+export function compareStatusPriority(a: AgentStatus, b: AgentStatus): number {
+  return STATUS_PRIORITY[a] - STATUS_PRIORITY[b]
+}


### PR DESCRIPTION
When sorting by any column (e.g. label), agents with the same value appeared in arbitrary order. Add a STATUS_PRIORITY map so the sort falls through to status when the primary column comparison is tied. Running agents now sort above idle, needs_input above running, etc.