### PR TITLE
Fix agent name overridden by prompt text and filter state reset by navigation

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1259,7 +1259,7 @@ export function App() {
       {showInterruptBanner && (
         <InterruptBanner
           interrupts={displayInterrupts}
-          onReviewAll={() => setFilter({ ...EMPTY_FILTER, statuses: new Set<StatusFilter>(['blocked']) })}
+          onReviewAll={() => setFilter((prev) => ({ ...prev, statuses: new Set<StatusFilter>(['blocked']), excludeStatuses: new Set() }))}
           onDismiss={() => setDismissedInterruptIds(new Set(displayInterrupts.map((i) => i.id)))}
         />
       )}
@@ -1461,8 +1461,8 @@ export function App() {
             setShowCommandPalette(false)
             setShowSettings(true)
           }}
-          onFilterChange={(newFilter) => {
-            setFilter(newFilter)
+          onFilterChange={(updater) => {
+            setFilter(updater)
             setShowCommandPalette(false)
           }}
           onStopAll={async () => {

--- a/src/renderer/src/components/CommandPalette.tsx
+++ b/src/renderer/src/components/CommandPalette.tsx
@@ -12,7 +12,7 @@ import {
   CircleNotch,
   ClockCounterClockwise
 } from '@phosphor-icons/react'
-import { EMPTY_FILTER, type FilterState, type StatusFilter } from './FilterBar'
+import { type FilterState, type StatusFilter } from './FilterBar'
 
 interface CommandPaletteProps {
   agents: Array<{ id: string; name: string; projectName: string; status: string }>
@@ -21,7 +21,7 @@ interface CommandPaletteProps {
   onLaunchAgent: () => void
   onResumeSession: () => void
   onOpenSettings: () => void
-  onFilterChange: (filter: FilterState) => void
+  onFilterChange: (filter: FilterState | ((prev: FilterState) => FilterState)) => void
   onStopAll: () => void
   onApproveAll: () => void
 }
@@ -151,6 +151,11 @@ export function CommandPalette({
       }
     ]
 
+    const navigateWithStatus = (statuses: Set<StatusFilter>): void => {
+      onClose()
+      onFilterChange((prev) => ({ ...prev, statuses, excludeStatuses: new Set() }))
+    }
+
     const navigationCommands: CommandItem[] = [
       {
         id: 'nav-fleet',
@@ -158,10 +163,7 @@ export function CommandPalette({
         description: 'View the full agent fleet',
         icon: <SquaresFour size={16} className="text-kumo-link" />,
         category: 'navigation',
-        action: () => {
-          onClose()
-          onFilterChange(EMPTY_FILTER)
-        }
+        action: () => navigateWithStatus(new Set())
       },
       {
         id: 'nav-blocked',
@@ -169,10 +171,7 @@ export function CommandPalette({
         description: 'Filter to agents needing attention',
         icon: <Warning size={16} className="text-kumo-danger" />,
         category: 'navigation',
-        action: () => {
-          onClose()
-          onFilterChange({ ...EMPTY_FILTER, statuses: new Set<StatusFilter>(['blocked']) })
-        }
+        action: () => navigateWithStatus(new Set(['blocked']))
       },
       {
         id: 'nav-running',
@@ -180,10 +179,7 @@ export function CommandPalette({
         description: 'Filter to actively running agents',
         icon: <CircleNotch size={16} className="text-kumo-success" />,
         category: 'navigation',
-        action: () => {
-          onClose()
-          onFilterChange({ ...EMPTY_FILTER, statuses: new Set<StatusFilter>(['running']) })
-        }
+        action: () => navigateWithStatus(new Set(['running']))
       }
     ]
 

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -1309,20 +1309,26 @@ function upsertAgent(payload: AgentLaunchedPayload, initialStatus?: AgentStatus)
   const hasPrompt = payload.prompt && payload.prompt.trim().length > 0
   const existingAgent = state.agents.get(payload.id)
 
-  // If the agent was launched with a prompt but no explicit title, derive name from prompt
-  // If launched without either, mark as autoNamed so the first prompt can rename it
-  const hasExplicitTitle = payload.title !== payload.prompt?.slice(0, 80) &&
-    !payload.title.match(/^.+-\d+$/) // matches pattern like "project-1" (auto-generated)
+  // Detect auto-generated titles: the backend produces "projectSlug-N" when no
+  // title and no prompt are provided, or echoes the prompt's first 80 chars.
+  const projectSlug = payload.directory.split('/').pop() ?? 'project'
+  const isAutoTitle = payload.title === payload.prompt?.slice(0, 80)
+    || new RegExp(`^${projectSlug.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}-\\d+$`).test(payload.title)
   const agentName = hasPrompt
     ? deriveNameFromPrompt(payload.prompt)
     : payload.title.slice(0, 30)
+
+  // On reconnection upsertAgent runs again — preserve the user's rename.
+  const autoNamed = existingAgent !== undefined
+    ? existingAgent.autoNamed
+    : isAutoTitle
 
   const agent: LiveAgent = {
     id: payload.id,
     runtimeId: payload.runtimeId,
     sessionId: payload.sessionId,
     directory: payload.directory,
-    name: payload.displayName || existingAgent?.name || (hasExplicitTitle ? payload.title.slice(0, 30) : agentName),
+    name: payload.displayName || existingAgent?.name || (isAutoTitle ? agentName : payload.title.slice(0, 30)),
     projectName: payload.projectName || existingAgent?.projectName || payload.directory.split('/').pop() || payload.directory,
     branchName: existingAgent?.branchName ?? payload.branchName ?? '',
     isWorktree: payload.isWorktree ?? existingAgent?.isWorktree ?? false,
@@ -1336,7 +1342,7 @@ function upsertAgent(payload: AgentLaunchedPayload, initialStatus?: AgentStatus)
     lastActivityAt: existingAgent?.lastActivityAt ?? Date.now(),
     cost: existingAgent?.cost ?? 0,
     tokens: existingAgent?.tokens ?? { input: 0, output: 0 },
-    autoNamed: !hasExplicitTitle
+    autoNamed
   }
 
   state.agents.set(payload.id, agent)


### PR DESCRIPTION
The auto-generated title regex in upsertAgent (/^.+-\d+$/) matched any
title ending in dash-digits, causing user-renamed agents to be treated as
autoNamed. On reconnection, upsertAgent recomputed autoNamed from the
payload title instead of preserving the existing value, so the next SSE
user-message event would overwrite the custom name with deriveNameFromPrompt.

Replace the broad regex with a precise check against the backend's actual
projectSlug-N pattern and preserve existingAgent.autoNamed across upserts.

CommandPalette navigation commands and InterruptBanner's Review All replaced
the entire FilterState with EMPTY_FILTER, wiping project/label/exclude
filters. Change these to functional updates that only modify the status
dimension.