### PR TITLE
Auto-focus transcript input when detail drawer opens

### DIFF
--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -329,6 +329,10 @@ export const DetailDrawer = memo(function DetailDrawer({
     return () => cancelAnimationFrame(frame)
   }, [])
 
+  useEffect(() => {
+    textareaRef.current?.focus()
+  }, [agent.id])
+
   const scrollToBottom = (el: HTMLDivElement) => { el.scrollTop = el.scrollHeight }
 
   const reengageFollow = () => {


### PR DESCRIPTION
Focus the textarea when the drawer mounts or the selected agent
changes, so users can immediately type after clicking a row.