### PR TITLE
Persist column sort preferences across app restarts

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -13,13 +13,11 @@ import { ModelPickerModal } from './components/ModelPickerModal'
 import { McpModal } from './components/McpModal'
 import { useAgentStore, setViewedAgentId, type LiveAgent } from './hooks/useAgentStore'
 import { useCustomLabels } from './hooks/useCustomLabels'
-import { type AgentRuntime, type Interrupt, type Message, type ColumnKey, type ColumnWidths, loadColumnVisibility, saveColumnVisibility, loadColumnWidths, saveColumnWidths, compareStatusPriority } from './types'
+import { type AgentRuntime, type Interrupt, type Message, type ColumnKey, type ColumnWidths, type SortDirection, loadColumnVisibility, saveColumnVisibility, loadColumnWidths, saveColumnWidths, loadSort, saveSort, compareStatusPriority } from './types'
 import type { FileChange } from './components/FilesChanged'
 import type { ToolCall } from './components/ToolsUsage'
 import type { EventEntry } from './components/EventLog'
 import { loadSettings } from './data/settings'
-
-type SortDirection = 'asc' | 'desc'
 
 const NEW_AGENT_COMMAND = '/new'
 const AGENT_MENTION_REGEX = /@(\w+)/
@@ -77,8 +75,8 @@ export function App() {
   const [showCommandPalette, setShowCommandPalette] = useState(false)
   const [showSessionBrowser, setShowSessionBrowser] = useState(false)
 
-  const [sortColumn, setSortColumn] = useState<ColumnKey | null>(null)
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
+  const [sortColumn, setSortColumnRaw] = useState<ColumnKey | null>(() => loadSort().column)
+  const [sortDirection, setSortDirectionRaw] = useState<SortDirection>(() => loadSort().direction)
   const [tick, setTick] = useState(0)
   const [agentCommands, setAgentCommands] = useState<ChatCommand[]>([])
   const [agentConfigs, setAgentConfigs] = useState<Array<{ name: string; description?: string }>>([])
@@ -639,8 +637,10 @@ export function App() {
 
   // ── Sort handler ──
   const handleSort = useCallback((column: string, direction: 'asc' | 'desc') => {
-    setSortColumn(column as ColumnKey)
-    setSortDirection(direction)
+    const col = column as ColumnKey
+    setSortColumnRaw(col)
+    setSortDirectionRaw(direction)
+    saveSort({ column: col, direction })
   }, [])
 
   // ── Row actions ──
@@ -1309,6 +1309,8 @@ export function App() {
         agents={filteredAgents}
         selectedId={selectedAgentId}
         onSelect={setSelectedAgentId}
+        sortColumn={sortColumn}
+        sortDirection={sortDirection}
         onSort={handleSort}
         onApprove={handleRowApprove}
         onReply={handleRowReply}

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -18,7 +18,7 @@ import {
   Link,
   ArrowLineUpRight
 } from '@phosphor-icons/react'
-import type { AgentRuntime, LabelDefinition, LabelColorKey, ColumnKey, ColumnWidths } from '../types'
+import type { AgentRuntime, LabelDefinition, LabelColorKey, ColumnKey, ColumnWidths, SortDirection } from '../types'
 import { formatBranchLabel, isUrgent, labelSortKey, compareStatusPriority, ALL_COLUMNS } from '../types'
 import { StatusBadge } from './StatusBadge'
 import { LabelDropdown } from './LabelDropdown'
@@ -29,6 +29,8 @@ interface FleetTableProps {
   agents: AgentRuntime[]
   selectedId: string | null
   onSelect: (id: string) => void
+  sortColumn?: ColumnKey | null
+  sortDirection?: SortDirection
   onSort?: (column: string, direction: 'asc' | 'desc') => void
   onApprove?: (agentId: string) => void
   onReply?: (agentId: string) => void
@@ -53,8 +55,6 @@ interface FleetTableProps {
   onColumnResetWidth?: (key: ColumnKey) => void
 }
 
-type SortDirection = 'asc' | 'desc'
-
 const SCROLL_STEP = 200
 
 interface ContextMenuState {
@@ -77,6 +77,8 @@ export function FleetTable({
   agents,
   selectedId,
   onSelect,
+  sortColumn: sortColumnProp,
+  sortDirection: sortDirectionProp = 'asc',
   onSort,
   onApprove,
   onReply,
@@ -100,8 +102,10 @@ export function FleetTable({
   onColumnResize,
   onColumnResetWidth
 }: FleetTableProps) {
-  const [sortColumn, setSortColumn] = useState<ColumnKey | null>(null)
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
+  const [sortColumnLocal, setSortColumnLocal] = useState<ColumnKey | null>(null)
+  const [sortDirectionLocal, setSortDirectionLocal] = useState<SortDirection>('asc')
+  const sortColumn = sortColumnProp !== undefined ? sortColumnProp : sortColumnLocal
+  const sortDirection = sortDirectionProp !== undefined ? sortDirectionProp : sortDirectionLocal
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
   const [renameState, setRenameState] = useState<RenameState | null>(null)
   const [prLinkState, setPrLinkState] = useState<PrLinkState | null>(null)
@@ -176,8 +180,8 @@ export function FleetTable({
     if (sortColumn === column) {
       nextDirection = sortDirection === 'asc' ? 'desc' : 'asc'
     }
-    setSortColumn(column)
-    setSortDirection(nextDirection)
+    setSortColumnLocal(column)
+    setSortDirectionLocal(nextDirection)
     onSort?.(column, nextDirection)
   }, [sortColumn, sortDirection, onSort])
 

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -110,6 +110,28 @@ export const ALL_COLUMNS: ColumnDef[] = [
 
 const COLUMN_VIS_KEY = 'oc-orchestrator:column-visibility'
 const COLUMN_WIDTHS_KEY = 'oc-orchestrator:column-widths'
+const SORT_KEY = 'oc-orchestrator:sort'
+
+export type SortDirection = 'asc' | 'desc'
+
+export interface SortState {
+  column: ColumnKey | null
+  direction: SortDirection
+}
+
+export function loadSort(): SortState {
+  try {
+    const stored = localStorage.getItem(SORT_KEY)
+    if (!stored) return { column: null, direction: 'asc' }
+    return JSON.parse(stored) as SortState
+  } catch {
+    return { column: null, direction: 'asc' }
+  }
+}
+
+export function saveSort(state: SortState): void {
+  localStorage.setItem(SORT_KEY, JSON.stringify(state))
+}
 
 const DEFAULT_VISIBLE_COLUMNS = new Set<ColumnKey>(
   ALL_COLUMNS.filter((c) => c.defaultVisible).map((c) => c.key)


### PR DESCRIPTION
Sort column and direction were the only table-level UI preferences not
saved to localStorage. Every other preference (filters, search, column
visibility, column widths) already persisted. Added loadSort/saveSort
following the same pattern, and threaded sort state from App.tsx down
to FleetTable as props so both layers stay in sync on reload.