### PR TITLE
Add rich tooltip on PR link hover

### DIFF
--- a/src/renderer/src/app.css
+++ b/src/renderer/src/app.css
@@ -232,6 +232,12 @@ body {
   border-radius: 6px;
 }
 
+/* ── Tooltip ── */
+@keyframes tooltip-fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 /* ── Selection ── */
 ::selection {
   background: rgba(37, 99, 235, 0.3);

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -23,6 +23,8 @@ import { formatBranchLabel, isUrgent, labelSortKey, compareStatusPriority, ALL_C
 import { StatusBadge } from './StatusBadge'
 import { LabelDropdown } from './LabelDropdown'
 import { TextInputModal } from './TextInputModal'
+import { Tooltip } from './Tooltip'
+import { PrTooltipContent } from './PrTooltip'
 import { useDismiss } from '../hooks/useDismiss'
 
 interface FleetTableProps {
@@ -822,13 +824,14 @@ function AgentRow({
             onRemove={onRemove}
           />
           {agent.prUrl ? (
-            <button
-              onClick={(event) => { event.stopPropagation(); window.api?.openExternal(agent.prUrl!) }}
-              className="w-6 h-6 flex items-center justify-center rounded text-kumo-brand hover:bg-kumo-brand/20 transition-colors cursor-pointer"
-              title={agent.prUrl}
-            >
-              <GitPullRequest size={13} weight="bold" />
-            </button>
+            <Tooltip content={<PrTooltipContent url={agent.prUrl} />} position="top">
+              <button
+                onClick={(event) => { event.stopPropagation(); window.api?.openExternal(agent.prUrl!) }}
+                className="w-6 h-6 flex items-center justify-center rounded text-kumo-brand hover:bg-kumo-brand/20 transition-colors cursor-pointer"
+              >
+                <GitPullRequest size={13} weight="bold" />
+              </button>
+            </Tooltip>
           ) : (
             <button
               onClick={(event) => { event.stopPropagation(); onEditPrLink?.() }}

--- a/src/renderer/src/components/PrBadge.tsx
+++ b/src/renderer/src/components/PrBadge.tsx
@@ -1,4 +1,6 @@
 import { GitPullRequest } from '@phosphor-icons/react'
+import { Tooltip } from './Tooltip'
+import { PrTooltipContent } from './PrTooltip'
 
 interface PrBadgeProps {
   url: string
@@ -7,16 +9,17 @@ interface PrBadgeProps {
 
 export function PrBadge({ url, stopPropagation }: PrBadgeProps) {
   return (
-    <button
-      onClick={(event) => {
-        if (stopPropagation) event.stopPropagation()
-        window.api?.openExternal(url)
-      }}
-      className="shrink-0 inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-kumo-brand/10 text-kumo-brand hover:bg-kumo-brand/20 transition-colors text-[9px] font-medium cursor-pointer"
-      title={url}
-    >
-      <GitPullRequest size={10} weight="bold" />
-      PR
-    </button>
+    <Tooltip content={<PrTooltipContent url={url} />} position="top">
+      <button
+        onClick={(event) => {
+          if (stopPropagation) event.stopPropagation()
+          window.api?.openExternal(url)
+        }}
+        className="shrink-0 inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-kumo-brand/10 text-kumo-brand hover:bg-kumo-brand/20 transition-colors text-[9px] font-medium cursor-pointer"
+      >
+        <GitPullRequest size={10} weight="bold" />
+        PR
+      </button>
+    </Tooltip>
   )
 }

--- a/src/renderer/src/components/PrTooltip.tsx
+++ b/src/renderer/src/components/PrTooltip.tsx
@@ -1,0 +1,77 @@
+import { GitMerge, GitPullRequest, GitlabLogo, GithubLogo } from '@phosphor-icons/react'
+import type { ReactNode } from 'react'
+
+type PrHost = 'github' | 'gitlab'
+
+interface PrInfo {
+  host: PrHost
+  owner: string
+  repo: string
+  number: string
+}
+
+const hostMeta: Record<PrHost, { icon: ReactNode; label: string }> = {
+  github: { icon: <GithubLogo size={12} weight="bold" />, label: 'GitHub' },
+  gitlab: { icon: <GitlabLogo size={12} weight="bold" />, label: 'GitLab' },
+}
+
+function parsePrUrl(url: string): PrInfo | null {
+  try {
+    const u = new URL(url)
+    const parts = u.pathname.split('/').filter(Boolean)
+
+    // GitHub: github.com/:owner/:repo/pull/:number
+    if (u.hostname === 'github.com' || u.hostname.includes('github')) {
+      const pullIdx = parts.indexOf('pull')
+      if (pullIdx >= 2 && parts[pullIdx + 1]) {
+        return { host: 'github', owner: parts[pullIdx - 2], repo: parts[pullIdx - 1], number: parts[pullIdx + 1] }
+      }
+    }
+
+    // GitLab: gitlab.com/:group(s)/:repo/-/merge_requests/:number
+    if (u.hostname.includes('gitlab') || u.hostname.includes('cfdata')) {
+      const mrIdx = parts.indexOf('merge_requests')
+      const dashIdx = parts.indexOf('-')
+      if (mrIdx >= 1 && parts[mrIdx + 1] && dashIdx >= 2) {
+        return { host: 'gitlab', owner: parts.slice(0, dashIdx - 1).join('/'), repo: parts[dashIdx - 1], number: parts[mrIdx + 1] }
+      }
+    }
+
+    return null
+  } catch {
+    return null
+  }
+}
+
+const cardClass = 'rounded-lg border border-kumo-line bg-kumo-elevated px-3 py-2 shadow-xl text-[11px] max-w-[320px]'
+
+export function PrTooltipContent({ url }: { url: string }): ReactNode {
+  const info = parsePrUrl(url)
+
+  if (!info) {
+    return (
+      <div className={cardClass}>
+        <div className="flex items-center gap-1.5 text-kumo-subtle">
+          <GitPullRequest size={12} weight="bold" />
+          <span className="text-kumo-default truncate">{url}</span>
+        </div>
+      </div>
+    )
+  }
+
+  const { icon, label } = hostMeta[info.host]
+
+  return (
+    <div className={`${cardClass} min-w-[180px] space-y-1.5`}>
+      <div className="flex items-center gap-1.5 text-kumo-subtle">
+        {icon}
+        <span>{label}</span>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <GitMerge size={12} weight="bold" className="shrink-0 text-kumo-brand" />
+        <span className="text-kumo-default font-medium truncate">{info.owner}/{info.repo}</span>
+        <span className="text-kumo-brand font-mono">#{info.number}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/Tooltip.tsx
+++ b/src/renderer/src/components/Tooltip.tsx
@@ -1,0 +1,48 @@
+import { useState, useRef, useEffect, type ReactNode } from 'react'
+
+interface TooltipProps {
+  content: ReactNode
+  children: ReactNode
+  delay?: number
+  position?: 'top' | 'bottom'
+}
+
+const positionStyles = {
+  top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
+  bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
+} as const
+
+export function Tooltip({ content, children, delay = 1000, position = 'top' }: TooltipProps) {
+  const [visible, setVisible] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearTimer = () => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = null
+  }
+
+  useEffect(() => clearTimer, [])
+
+  return (
+    <div
+      className="relative inline-flex"
+      onMouseEnter={() => {
+        timerRef.current = setTimeout(() => setVisible(true), delay)
+      }}
+      onMouseLeave={() => {
+        clearTimer()
+        setVisible(false)
+      }}
+    >
+      {children}
+      {visible && (
+        <div
+          className={`absolute ${positionStyles[position]} z-[200] pointer-events-none`}
+          style={{ animation: 'tooltip-fade-in 150ms ease-out' }}
+        >
+          {content}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Add rich tooltip on PR link hover

Show a delayed tooltip (1s) when hovering the PR icon in FleetTable
and PrBadge. Parses GitHub and GitLab URLs to display host, repo path,
and PR number. Falls back to the raw URL for unrecognized formats.