### PR TITLE
Add interactive tooltip with action icons and clickable PR number

### DIFF
--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -362,6 +362,7 @@ export function FleetTable({
                 onCreateLabel={onCreateLabel}
                 onDeleteLabel={onDeleteLabel}
                 onEditPrLink={() => setPrLinkState({ agentId: agent.id, currentUrl: agent.prUrl ?? '' })}
+                onRemovePrLink={onSetPrUrl ? () => onSetPrUrl(agent.id, null) : undefined}
                 onOpenTerminal={onOpenTerminal ? () => onOpenTerminal(agent.id) : undefined}
                 onOpenInEditor={onOpenInEditor ? () => onOpenInEditor(agent.id) : undefined}
                 isInlineEditing={inlineEditId === agent.id}
@@ -649,6 +650,7 @@ function AgentRow({
   onCreateLabel,
   onDeleteLabel,
   onEditPrLink,
+  onRemovePrLink,
   onOpenTerminal,
   onOpenInEditor,
   isInlineEditing,
@@ -675,6 +677,7 @@ function AgentRow({
   onCreateLabel?: (name: string, colorKey: LabelColorKey) => Promise<LabelDefinition | null>
   onDeleteLabel?: (id: string) => Promise<boolean>
   onEditPrLink?: () => void
+  onRemovePrLink?: () => void
   onOpenTerminal?: () => void
   onOpenInEditor?: () => void
   isInlineEditing: boolean
@@ -824,7 +827,20 @@ function AgentRow({
             onRemove={onRemove}
           />
           {agent.prUrl ? (
-            <Tooltip content={<PrTooltipContent url={agent.prUrl} />} position="top">
+            <Tooltip
+              content={
+                <PrTooltipContent
+                  url={agent.prUrl}
+                  actions={{
+                    onOpen: () => window.api?.openExternal(agent.prUrl!),
+                    onEdit: onEditPrLink,
+                    onRemove: onRemovePrLink,
+                  }}
+                />
+              }
+              position="top"
+              interactive
+            >
               <button
                 onClick={(event) => { event.stopPropagation(); window.api?.openExternal(agent.prUrl!) }}
                 className="w-6 h-6 flex items-center justify-center rounded text-kumo-brand hover:bg-kumo-brand/20 transition-colors cursor-pointer"

--- a/src/renderer/src/components/PrBadge.tsx
+++ b/src/renderer/src/components/PrBadge.tsx
@@ -1,15 +1,21 @@
 import { GitPullRequest } from '@phosphor-icons/react'
 import { Tooltip } from './Tooltip'
-import { PrTooltipContent } from './PrTooltip'
+import { PrTooltipContent, type PrTooltipActions } from './PrTooltip'
 
 interface PrBadgeProps {
   url: string
   stopPropagation?: boolean
+  actions?: PrTooltipActions
 }
 
-export function PrBadge({ url, stopPropagation }: PrBadgeProps) {
+export function PrBadge({ url, stopPropagation, actions }: PrBadgeProps) {
+  const hasActions = actions && (actions.onOpen || actions.onEdit || actions.onRemove)
   return (
-    <Tooltip content={<PrTooltipContent url={url} />} position="top">
+    <Tooltip
+      content={<PrTooltipContent url={url} actions={actions} />}
+      position="top"
+      interactive={!!hasActions}
+    >
       <button
         onClick={(event) => {
           if (stopPropagation) event.stopPropagation()

--- a/src/renderer/src/components/PrTooltip.tsx
+++ b/src/renderer/src/components/PrTooltip.tsx
@@ -1,4 +1,4 @@
-import { GitMerge, GitPullRequest, GitlabLogo, GithubLogo } from '@phosphor-icons/react'
+import { ArrowLineUpRight, GitMerge, GitPullRequest, GitlabLogo, GithubLogo, PencilSimple, Trash } from '@phosphor-icons/react'
 import type { ReactNode } from 'react'
 
 type PrHost = 'github' | 'gitlab'
@@ -10,9 +10,19 @@ interface PrInfo {
   number: string
 }
 
+export interface PrTooltipActions {
+  onOpen?: () => void
+  onEdit?: () => void
+  onRemove?: () => void
+}
+
 const hostMeta: Record<PrHost, { icon: ReactNode; label: string }> = {
   github: { icon: <GithubLogo size={12} weight="bold" />, label: 'GitHub' },
   gitlab: { icon: <GitlabLogo size={12} weight="bold" />, label: 'GitLab' },
+}
+
+function openExternal(url: string) {
+  window.api?.openExternal(url)
 }
 
 function parsePrUrl(url: string): PrInfo | null {
@@ -44,17 +54,49 @@ function parsePrUrl(url: string): PrInfo | null {
 }
 
 const cardClass = 'rounded-lg border border-kumo-line bg-kumo-elevated px-3 py-2 shadow-xl text-[11px] max-w-[320px]'
+const actionBtnClass = 'w-6 h-6 flex items-center justify-center rounded hover:bg-kumo-fill transition-colors cursor-pointer'
 
-export function PrTooltipContent({ url }: { url: string }): ReactNode {
+function ActionBar({ onOpen, onEdit, onRemove }: PrTooltipActions) {
+  if (!onOpen && !onEdit && !onRemove) return null
+  return (
+    <div className="flex items-center gap-0.5 border-t border-kumo-line pt-1.5 -mx-1">
+      {onOpen && (
+        <button onClick={onOpen} className={`${actionBtnClass} text-kumo-subtle hover:text-kumo-default`} title="Open PR">
+          <ArrowLineUpRight size={12} weight="bold" />
+        </button>
+      )}
+      {onEdit && (
+        <button onClick={onEdit} className={`${actionBtnClass} text-kumo-subtle hover:text-kumo-default`} title="Edit PR link">
+          <PencilSimple size={12} weight="bold" />
+        </button>
+      )}
+      {onRemove && (
+        <button onClick={onRemove} className={`${actionBtnClass} text-kumo-subtle hover:text-kumo-danger`} title="Remove PR link">
+          <Trash size={12} weight="bold" />
+        </button>
+      )}
+    </div>
+  )
+}
+
+interface PrTooltipContentProps {
+  url: string
+  actions?: PrTooltipActions
+}
+
+export function PrTooltipContent({ url, actions }: PrTooltipContentProps): ReactNode {
   const info = parsePrUrl(url)
 
   if (!info) {
     return (
-      <div className={cardClass}>
+      <div className={`${cardClass} space-y-1.5`}>
         <div className="flex items-center gap-1.5 text-kumo-subtle">
           <GitPullRequest size={12} weight="bold" />
-          <span className="text-kumo-default truncate">{url}</span>
+          <button onClick={() => openExternal(url)} className="text-kumo-default truncate hover:underline cursor-pointer">
+            {url}
+          </button>
         </div>
+        {actions && <ActionBar {...actions} />}
       </div>
     )
   }
@@ -70,8 +112,14 @@ export function PrTooltipContent({ url }: { url: string }): ReactNode {
       <div className="flex items-center gap-1.5">
         <GitMerge size={12} weight="bold" className="shrink-0 text-kumo-brand" />
         <span className="text-kumo-default font-medium truncate">{info.owner}/{info.repo}</span>
-        <span className="text-kumo-brand font-mono">#{info.number}</span>
+        <button
+          onClick={() => openExternal(url)}
+          className="text-kumo-brand font-mono hover:underline cursor-pointer"
+        >
+          #{info.number}
+        </button>
       </div>
+      {actions && <ActionBar {...actions} />}
     </div>
   )
 }

--- a/src/renderer/src/components/Tooltip.tsx
+++ b/src/renderer/src/components/Tooltip.tsx
@@ -6,31 +6,41 @@ interface TooltipProps {
   children: ReactNode
   delay?: number
   position?: 'top' | 'bottom'
+  interactive?: boolean
 }
 
 const GAP = 8
 const VIEWPORT_PADDING = 8
+const LEAVE_GRACE_MS = 150
 
-export function Tooltip({ content, children, delay = 1000, position = 'top' }: TooltipProps) {
+export function Tooltip({ content, children, delay = 1000, position = 'top', interactive = false }: TooltipProps) {
   const [pending, setPending] = useState(false)
   const [finalCoords, setFinalCoords] = useState<{ top: number; left: number } | null>(null)
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const showTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const triggerRef = useRef<HTMLDivElement>(null)
   const anchorRef = useRef<{ centerX: number; anchorY: number } | null>(null)
 
-  const clearTimer = () => {
-    if (timerRef.current) clearTimeout(timerRef.current)
-    timerRef.current = null
+  const clearShowTimer = () => {
+    if (showTimerRef.current) clearTimeout(showTimerRef.current)
+    showTimerRef.current = null
   }
 
-  useEffect(() => clearTimer, [])
+  const clearHideTimer = () => {
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current)
+    hideTimerRef.current = null
+  }
+
+  useEffect(() => () => {
+    clearShowTimer()
+    clearHideTimer()
+  }, [])
 
   const measureAndPlace = useCallback((node: HTMLDivElement | null) => {
     if (!node || !anchorRef.current) return
     const { centerX, anchorY } = anchorRef.current
-    const tooltipRect = node.getBoundingClientRect()
-    const tooltipW = tooltipRect.width
-    const tooltipH = tooltipRect.height
+    const tooltipW = node.getBoundingClientRect().width
+    const tooltipH = node.getBoundingClientRect().height
 
     let left = centerX - tooltipW / 2
     left = Math.max(VIEWPORT_PADDING, Math.min(left, window.innerWidth - tooltipW - VIEWPORT_PADDING))
@@ -40,8 +50,20 @@ export function Tooltip({ content, children, delay = 1000, position = 'top' }: T
     setFinalCoords({ top, left })
   }, [position])
 
-  const showTooltip = () => {
-    timerRef.current = setTimeout(() => {
+  const isVisible = pending || finalCoords !== null
+
+  const dismiss = () => {
+    clearShowTimer()
+    clearHideTimer()
+    setPending(false)
+    setFinalCoords(null)
+    anchorRef.current = null
+  }
+
+  const startShow = () => {
+    clearHideTimer()
+    if (isVisible) return
+    showTimerRef.current = setTimeout(() => {
       const rect = triggerRef.current?.getBoundingClientRect()
       if (!rect) return
       anchorRef.current = {
@@ -52,26 +74,35 @@ export function Tooltip({ content, children, delay = 1000, position = 'top' }: T
     }, delay)
   }
 
-  const hideTooltip = () => {
-    clearTimer()
-    setPending(false)
-    setFinalCoords(null)
-    anchorRef.current = null
+  const startHide = () => {
+    clearShowTimer()
+    if (interactive) {
+      hideTimerRef.current = setTimeout(dismiss, LEAVE_GRACE_MS)
+    } else {
+      dismiss()
+    }
   }
+
+  const tooltipHandlers = interactive ? {
+    onMouseEnter: clearHideTimer,
+    onMouseLeave: dismiss,
+  } : {}
+
+  const pointerEvents = interactive ? 'auto' : 'none'
 
   return (
     <div
       ref={triggerRef}
       className="inline-flex"
-      onMouseEnter={showTooltip}
-      onMouseLeave={hideTooltip}
+      onMouseEnter={startShow}
+      onMouseLeave={startHide}
     >
       {children}
       {pending && !finalCoords && createPortal(
         <div
           ref={measureAndPlace}
-          className="fixed z-[200] pointer-events-none"
-          style={{ opacity: 0, top: 0, left: 0 }}
+          className="fixed z-[200]"
+          style={{ opacity: 0, top: 0, left: 0, pointerEvents: 'none' }}
         >
           {content}
         </div>,
@@ -79,12 +110,15 @@ export function Tooltip({ content, children, delay = 1000, position = 'top' }: T
       )}
       {finalCoords && createPortal(
         <div
-          className="fixed z-[200] pointer-events-none"
+          className="fixed z-[200]"
+          onClick={interactive ? (e) => e.stopPropagation() : undefined}
           style={{
             top: finalCoords.top,
             left: finalCoords.left,
+            pointerEvents,
             animation: 'tooltip-fade-in 150ms ease-out',
           }}
+          {...tooltipHandlers}
         >
           {content}
         </div>,


### PR DESCRIPTION
Add interactive tooltip with action icons and clickable PR number

Make the PR tooltip interactive so users can hover into it. Adds open,
edit, and remove action buttons in a bar at the bottom of the tooltip.
Makes the PR number a clickable link that opens the PR externally.

Fixes click-through where clicking the tooltip would select the
underlying table row (React portal synthetic event bubbling).