### PR TITLE
Show loading indicator while restoring agents on startup

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,8 @@ import { startUpdateChecker, stopUpdateChecker } from './services/update-checker
 let mainWindowRef: BrowserWindow | null = null
 
 const WINDOW_BOUNDS_KEY = 'window_bounds'
+const DEFAULT_WIDTH = 1440
+const DEFAULT_HEIGHT = 900
 
 function getAppIcon(): Electron.NativeImage | undefined {
   const iconPath = app.isPackaged
@@ -27,7 +29,7 @@ function loadWindowBounds(): { x?: number; y?: number; width: number; height: nu
     const raw = database.getPreference(WINDOW_BOUNDS_KEY)
     if (raw) return JSON.parse(raw)
   } catch { /* ignore */ }
-  return { width: 1440, height: 900 }
+  return { width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT }
 }
 
 function saveWindowBounds(window: BrowserWindow): void {
@@ -36,15 +38,24 @@ function saveWindowBounds(window: BrowserWindow): void {
   database.setPreference(WINDOW_BOUNDS_KEY, JSON.stringify({ ...bounds, maximized }))
 }
 
-function createWindow(): BrowserWindow {
-  const savedBounds = loadWindowBounds()
+function applySavedBounds(window: BrowserWindow): void {
+  const saved = loadWindowBounds()
+  if (saved.x !== undefined && saved.y !== undefined) {
+    window.setBounds({ x: saved.x, y: saved.y, width: saved.width, height: saved.height })
+  } else if (saved.width !== DEFAULT_WIDTH || saved.height !== DEFAULT_HEIGHT) {
+    window.setSize(saved.width, saved.height)
+  }
+  if (saved.maximized) window.maximize()
+}
 
+function createWindow(): BrowserWindow {
   const mainWindow = new BrowserWindow({
     icon: getAppIcon(),
-    ...savedBounds,
+    width: DEFAULT_WIDTH,
+    height: DEFAULT_HEIGHT,
     minWidth: 1024,
     minHeight: 680,
-    show: false,
+    show: true,
     titleBarStyle: 'hiddenInset',
     trafficLightPosition: { x: 14, y: 14 },
     backgroundColor: '#0a0a0b',
@@ -52,14 +63,6 @@ function createWindow(): BrowserWindow {
       preload: join(__dirname, '../preload/index.js'),
       sandbox: false
     }
-  })
-
-  if (savedBounds.maximized) {
-    mainWindow.maximize()
-  }
-
-  mainWindow.on('ready-to-show', () => {
-    mainWindow.show()
   })
 
   mainWindow.on('resized', () => saveWindowBounds(mainWindow))
@@ -109,23 +112,37 @@ app.whenReady().then(async () => {
     app.dock.setIcon(appIcon)
   }
 
-  // Initialize the database
+  registerIpcHandlers()
+
+  // Create the window before DB init so the UI appears immediately.
+  mainWindowRef = createWindow()
+
   await database.init()
   console.log('[Main] Database initialized')
   database.logEvent(null, 'app:started')
+  applySavedBounds(mainWindowRef)
 
-  registerIpcHandlers()
-
-  await agentController.restorePersistedAgents()
-  console.log('[Main] Restored persisted agents')
-
-  mainWindowRef = createWindow()
-
-  // Start runtime health checks after window creation
   runtimeManager.startHealthChecks()
   agentController.startIdleRuntimeChecks()
   startUpdateChecker()
-  console.log('[Main] Health checks started')
+
+  // Restore agents after the renderer has loaded so the window appears
+  // with the loading indicator before we start spawning runtimes.
+  // If did-finish-load already fired while awaiting DB init, start immediately.
+  const startRestore = (): void => {
+    agentController.restorePersistedAgents().then(() => {
+      console.log('[Main] Restored persisted agents')
+      for (const win of BrowserWindow.getAllWindows()) {
+        win.webContents.send('agents:restored')
+      }
+    })
+  }
+
+  if (!mainWindowRef.webContents.isLoading()) {
+    startRestore()
+  } else {
+    mainWindowRef.webContents.once('did-finish-load', startRestore)
+  }
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -341,6 +341,10 @@ export function registerIpcHandlers(): void {
     }
   })
 
+  ipcMain.handle('agent:restored', () => {
+    return { ok: true, data: agentController.restored }
+  })
+
   ipcMain.handle('agent:list', async () => {
     const agents = agentController.getAllAgents()
     return {

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -109,9 +109,11 @@ const DEFAULT_RUNTIME_IDLE_TIMEOUT_MS = 15 * 60_000
 class AgentController {
   private agents = new Map<string, AgentHandle>()
   private bridges = new Map<string, EventBridge>()
+  private pendingBridge = new Map<string, Promise<RuntimeInfo>>()
   private nextId = 1
   private idleRuntimeTimer: ReturnType<typeof setInterval> | null = null
   private stoppingIdleRuntimes = false
+  restored = false
 
   async restorePersistedAgents(): Promise<void> {
     const persistedAgents = this.loadPersistedAgents()
@@ -156,6 +158,7 @@ class AgentController {
     }
 
     this.persistAgents()
+    this.restored = true
   }
 
   /**

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -90,6 +90,9 @@ const api = {
   listAgents: (): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:list'),
 
+  isAgentsRestored: (): Promise<IpcResult<boolean>> =>
+    ipcRenderer.invoke('agent:restored'),
+
   updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelIds?: string[] }): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:update-meta', agentId, meta),
 
@@ -278,6 +281,12 @@ const api = {
     const handler = (_event: Electron.IpcRendererEvent, data: unknown) => callback(data as never)
     ipcRenderer.on('notification:select-agent', handler)
     return () => ipcRenderer.removeListener('notification:select-agent', handler)
+  },
+
+  onAgentsRestored: (callback: () => void) => {
+    const handler = () => callback()
+    ipcRenderer.on('agents:restored', handler)
+    return () => ipcRenderer.removeListener('agents:restored', handler)
   }
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1314,38 +1314,47 @@ export function App() {
         }}
       />
 
-      <FleetTable
-        agents={filteredAgents}
-        selectedId={selectedAgentId}
-        onSelect={setSelectedAgentId}
-        sortColumn={sortColumn}
-        sortDirection={sortDirection}
-        onSort={handleSort}
-        onApprove={handleRowApprove}
-        onReply={handleRowReply}
-        onStop={handleRowStop}
-        onOpen={handleRowOpen}
-        onRemove={handleRemoveAgent}
-        onRename={storeRenameAgent}
-        onOpenTerminal={handleOpenTerminal}
-        onOpenInEditor={handleOpenInEditorForAgent}
-        onCreatePr={handleCreatePrForAgent}
-        onSetPrUrl={storeSetPrUrl}
-        onChangeModel={(agentId) => {
-          setModelPickerAgentId(agentId)
-          setShowModelPicker(true)
-        }}
-        onToggleLabel={handleToggleLabel}
-        onClearLabels={handleClearLabels}
-        onReplaceLabel={handleReplaceLabel}
-        allLabels={allLabels}
-        onCreateLabel={createLabel}
-        onDeleteLabel={handleDeleteLabel}
-        visibleColumns={visibleColumns}
-        columnWidths={columnWidths}
-        onColumnResize={handleColumnResize}
-        onColumnResetWidth={handleColumnResetWidth}
-      />
+      {store.initializing ? (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-3 text-kumo-subtle">
+            <div className="h-5 w-5 border-2 border-kumo-subtle/30 border-t-kumo-subtle rounded-full animate-spin" />
+            <span className="text-sm">Restoring agents...</span>
+          </div>
+        </div>
+      ) : (
+        <FleetTable
+          agents={filteredAgents}
+          selectedId={selectedAgentId}
+          onSelect={setSelectedAgentId}
+          sortColumn={sortColumn}
+          sortDirection={sortDirection}
+          onSort={handleSort}
+          onApprove={handleRowApprove}
+          onReply={handleRowReply}
+          onStop={handleRowStop}
+          onOpen={handleRowOpen}
+          onRemove={handleRemoveAgent}
+          onRename={storeRenameAgent}
+          onOpenTerminal={handleOpenTerminal}
+          onOpenInEditor={handleOpenInEditorForAgent}
+          onCreatePr={handleCreatePrForAgent}
+          onSetPrUrl={storeSetPrUrl}
+          onChangeModel={(agentId) => {
+            setModelPickerAgentId(agentId)
+            setShowModelPicker(true)
+          }}
+          onToggleLabel={handleToggleLabel}
+          onClearLabels={handleClearLabels}
+          onReplaceLabel={handleReplaceLabel}
+          allLabels={allLabels}
+          onCreateLabel={createLabel}
+          onDeleteLabel={handleDeleteLabel}
+          visibleColumns={visibleColumns}
+          columnWidths={columnWidths}
+          onColumnResize={handleColumnResize}
+          onColumnResetWidth={handleColumnResetWidth}
+        />
+      )}
 
       <StatusBar
         agentCount={displayAgents.length}

--- a/src/renderer/src/demoApi.ts
+++ b/src/renderer/src/demoApi.ts
@@ -305,6 +305,7 @@ export function createDemoApi(): OrchestratorApi {
     forkSession: () => ok({ sessionId: 'demo-fork', title: 'Forked session' }),
     resumeAgent: noop,
     listAgents: () => ok(DEMO_AGENTS),
+    isAgentsRestored: () => ok(true),
     updateAgentMeta: noop,
     getStatuses: () => ok(DEMO_STATUSES),
     replyToQuestion: noop,
@@ -382,6 +383,7 @@ export function createDemoApi(): OrchestratorApi {
     onRuntimeStopped: noopListener,
     onEventError: noopListener,
     onUpdateAvailable: noopListener,
-    onNotificationSelectAgent: noopListener
+    onNotificationSelectAgent: noopListener,
+    onAgentsRestored: noopListener
   }
 }

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -154,6 +154,7 @@ interface AgentStoreState {
   fileChanges: Map<string, FileChangeRecord[]> // keyed by sessionId
   eventLog: Map<string, EventLogEntry[]> // keyed by sessionId
   healthy: boolean
+  initializing: boolean
 }
 
 let state: AgentStoreState = {
@@ -163,7 +164,8 @@ let state: AgentStoreState = {
   messages: new Map(),
   fileChanges: new Map(),
   eventLog: new Map(),
-  healthy: true
+  healthy: true,
+  initializing: true
 }
 
 let eventCounter = 0
@@ -1789,6 +1791,7 @@ export function useAgentStore() {
       } catch {
         // Questions API may not be available on older servers
       }
+
     }
 
     const cleanups = [
@@ -1799,10 +1802,29 @@ export function useAgentStore() {
         console.error(`[EventError] Runtime ${data.runtimeId}: ${data.error}`)
         state.healthy = false
         emit({ agents: true })
+      }),
+      window.api.onAgentsRestored(async () => {
+        await initializeAgents()
+        if (!cancelled && state.initializing) {
+          state.initializing = false
+          emit({ agents: true })
+        }
       })
     ]
 
-    void initializeAgents()
+    // Run initial fetch. If restoration already completed before we
+    // mounted (fast startup or no persisted agents), clear initializing
+    // immediately. Otherwise the onAgentsRestored listener handles it.
+    const boot = async (): Promise<void> => {
+      await initializeAgents()
+      if (cancelled) return
+      const restored = await window.api.isAgentsRestored()
+      if (!cancelled && restored.ok && restored.data && state.initializing) {
+        state.initializing = false
+        emit({ agents: true })
+      }
+    }
+    void boot()
 
     // Periodic status reconciliation: re-poll the server every 30s to correct
     // any status drift caused by missed SSE events (reconnection gaps, dropped
@@ -2292,6 +2314,7 @@ export function useAgentStore() {
     permissions,
     questions,
     healthy: storeState.healthy,
+    initializing: storeState.initializing,
     launchAgent,
     sendMessage,
     listCommands,
@@ -2316,7 +2339,7 @@ export function useAgentStore() {
     getEventsForSession,
     getToolCallsForSession
   }), [
-    agents, permissions, questions, storeState.healthy,
+    agents, permissions, questions, storeState.healthy, storeState.initializing,
     launchAgent, sendMessage, listCommands, listAgentConfigs,
     executeCommand, prepareFreshAgent, resetSession,
     respondToPermission, replyToQuestion, rejectQuestion,

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -37,6 +37,7 @@ export interface OrchestratorApi {
   forkSession: (options: { sourceSessionId: string; targetDirectory: string }) => Promise<IpcResult<{ sessionId: string; title: string }>>
   resumeAgent: (options: { directory: string; sessionId: string; title?: string }) => Promise<IpcResult>
   listAgents: () => Promise<IpcResult<ListAgentsPayload>>
+  isAgentsRestored: () => Promise<IpcResult<boolean>>
   updateAgentMeta: (agentId: string, meta: { displayName?: string; taskSummary?: string; persistedStatus?: string; labelIds?: string[]; prUrl?: string }) => Promise<IpcResult>
   getStatuses: () => Promise<IpcResult<AgentStatusesPayload>>
   replyToQuestion: (agentId: string, requestId: string, answers: string[][]) => Promise<IpcResult>
@@ -104,6 +105,7 @@ export interface OrchestratorApi {
   onEventError: (callback: (data: { runtimeId: string; error: string }) => void) => () => void
   onUpdateAvailable: (callback: (data: { currentVersion: string; latestVersion: string }) => void) => () => void
   onNotificationSelectAgent: (callback: (data: { agentId: string }) => void) => () => void
+  onAgentsRestored: (callback: () => void) => () => void
 }
 
 export interface WorktreeListEntry {


### PR DESCRIPTION
Move window creation before restorePersistedAgents so the app appears
immediately. Restoration runs in the background and broadcasts
agents:restored when done, triggering the renderer to re-fetch.

The FleetTable area shows a spinner with "Restoring agents..." until
initialization completes.