### PR TITLE
Add customizable quick action buttons to agent drawer

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -7,7 +7,7 @@ import { StatusBar } from './components/StatusBar'
 import { DetailDrawer, type ChatCommand } from './components/DetailDrawer'
 import { LaunchModal, type FreshWorktreeConfig, type ImportSessionConfig } from './components/LaunchModal'
 import { SessionBrowser } from './components/SessionBrowser'
-import { SettingsModal } from './components/SettingsModal'
+import { SettingsModal, type SettingsTabId } from './components/SettingsModal'
 import { CommandPalette } from './components/CommandPalette'
 import { ModelPickerModal } from './components/ModelPickerModal'
 import { McpModal } from './components/McpModal'
@@ -17,7 +17,7 @@ import { type AgentRuntime, type Interrupt, type Message, type ColumnKey, type C
 import type { FileChange } from './components/FilesChanged'
 import type { ToolCall } from './components/ToolsUsage'
 import type { EventEntry } from './components/EventLog'
-import { loadSettings } from './data/settings'
+import { loadSettings, type QuickAction } from './data/settings'
 
 const NEW_AGENT_COMMAND = '/new'
 const AGENT_MENTION_REGEX = /@(\w+)/
@@ -72,6 +72,7 @@ export function App() {
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
   const [showLaunchModal, setShowLaunchModal] = useState(false)
   const [showSettings, setShowSettings] = useState(false)
+  const [settingsTab, setSettingsTab] = useState<SettingsTabId>('general')
   const [showCommandPalette, setShowCommandPalette] = useState(false)
   const [showSessionBrowser, setShowSessionBrowser] = useState(false)
 
@@ -863,6 +864,11 @@ export function App() {
     await storeSendMessage(selectedAgentId, loadSettings().createPrPrompt, undefined, undefined, 'Create PR')
   }, [selectedAgentId, storeSendMessage])
 
+  const handleQuickAction = useCallback(async (action: QuickAction) => {
+    if (!selectedAgentId) return
+    await storeSendMessage(selectedAgentId, action.prompt, undefined, undefined, action.label)
+  }, [selectedAgentId, storeSendMessage])
+
   const handleOpenInEditor = useCallback(() => {
     if (!selectedAgentId) return
     const liveAgent = findLiveAgent(selectedAgentId)
@@ -881,6 +887,10 @@ export function App() {
 
   const handleCreatePrForAgent = useCallback(async (agentId: string) => {
     await store.sendMessage(agentId, loadSettings().createPrPrompt, undefined, undefined, 'Create PR')
+  }, [store])
+
+  const handleQuickActionForAgent = useCallback(async (agentId: string, action: QuickAction) => {
+    await store.sendMessage(agentId, action.prompt, undefined, undefined, action.label)
   }, [store])
 
   const handleOpenTerminal = useCallback((agentId: string) => {
@@ -1330,6 +1340,7 @@ export function App() {
         onOpenTerminal={handleOpenTerminal}
         onOpenInEditor={handleOpenInEditorForAgent}
         onCreatePr={handleCreatePrForAgent}
+        onQuickAction={handleQuickActionForAgent}
         onSetPrUrl={storeSetPrUrl}
         onChangeModel={(agentId) => {
           setModelPickerAgentId(agentId)
@@ -1374,6 +1385,8 @@ export function App() {
           onAbort={handleAbort}
           onRemove={handleDrawerRemove}
            onCreatePr={handleCreatePr}
+           onQuickAction={handleQuickAction}
+           onOpenQuickActionSettings={() => { setSettingsTab('quick-actions'); setShowSettings(true) }}
            onSetPrUrl={handleDrawerSetPrUrl}
            onOpenInEditor={handleOpenInEditor}
           onChangeModel={handleDrawerChangeModel}
@@ -1419,7 +1432,7 @@ export function App() {
       )}
 
       {showSettings && (
-        <SettingsModal onClose={() => setShowSettings(false)} />
+        <SettingsModal onClose={() => { setShowSettings(false); setSettingsTab('general') }} initialTab={settingsTab} commands={agentCommands} />
       )}
 
       {showModelPicker && modelPickerAgentId && (

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -17,12 +17,17 @@ import {
   PaperPlaneTilt,
   Paperclip,
   ArrowLineUpRight,
-  Link
+  Link,
+  Plus,
+  Rocket,
+  Lightning,
+  Code,
+  CheckCircle,
 } from '@phosphor-icons/react'
 import type { AgentRuntime, Message, LabelDefinition, LabelColorKey } from '../types'
 import { formatBranchLabel } from '../types'
 import type { LivePermission, LiveQuestion } from '../hooks/useAgentStore'
-import { loadSettings, SETTINGS_CHANGED_EVENT } from '../data/settings'
+import { loadSettings, SETTINGS_CHANGED_EVENT, MAX_QUICK_ACTIONS, isQuickActionValid, type QuickAction, type QuickActionIcon } from '../data/settings'
 import { useImageAttachments } from '../hooks/useImageAttachments'
 import { StatusBadge } from './StatusBadge'
 import { LabelDropdown } from './LabelDropdown'
@@ -38,13 +43,24 @@ import type { EventEntry } from './EventLog'
 
 export type { FileChange, ToolCall, EventEntry }
 
+const quickActionIconMap: Record<QuickActionIcon, typeof Lightning> = {
+  'git-pull-request': GitPullRequest,
+  'rocket': Rocket,
+  'lightning': Lightning,
+  'terminal': Terminal,
+  'code': Code,
+  'check-circle': CheckCircle,
+  'paper-plane': PaperPlaneTilt,
+  'wrench': Wrench,
+}
+
 const DRAWER_WIDTH_KEY = 'oc-orchestrator:drawer-width'
 const DEFAULT_DRAWER_WIDTH = 600
 const MIN_DRAWER_WIDTH = 400
 const MAX_DRAWER_WIDTH = 1000
 const INPUT_HEIGHT_KEY = 'oc-orchestrator:input-height'
-const DEFAULT_INPUT_HEIGHT = 120
-const MIN_INPUT_HEIGHT = 80
+const DEFAULT_INPUT_HEIGHT_RATIO = 0.3 // 30% of window height
+const MIN_INPUT_HEIGHT = 100
 const MAX_INPUT_HEIGHT = 500
 const VISIBLE_MESSAGE_WINDOW = 50
 const LOAD_MORE_INCREMENT = 50
@@ -78,7 +94,7 @@ function loadInputHeight(): number {
       if (height >= MIN_INPUT_HEIGHT && height <= MAX_INPUT_HEIGHT) return height
     }
   } catch { /* ignore */ }
-  return DEFAULT_INPUT_HEIGHT
+  return Math.max(MIN_INPUT_HEIGHT, Math.round(window.innerHeight * DEFAULT_INPUT_HEIGHT_RATIO))
 }
 
 type TabKey = 'transcript' | 'files' | 'tools' | 'events'
@@ -113,6 +129,8 @@ interface DetailDrawerProps {
   onAbort?: () => void
   onRemove?: () => void
   onCreatePr?: () => void
+  onQuickAction?: (action: QuickAction) => void
+  onOpenQuickActionSettings?: () => void
   onSetPrUrl?: (prUrl: string | null) => void
   onOpenInEditor?: () => void
   onChangeModel?: () => void
@@ -144,6 +162,8 @@ export const DetailDrawer = memo(function DetailDrawer({
   onAbort,
   onRemove,
   onCreatePr,
+  onQuickAction,
+  onOpenQuickActionSettings,
   onSetPrUrl,
   onOpenInEditor,
   onChangeModel,
@@ -199,10 +219,15 @@ export const DetailDrawer = memo(function DetailDrawer({
     setVisibleMessageCount((prev) => prev + LOAD_MORE_INCREMENT)
   }, [])
 
-  // Verbose mode: global setting, reactive to changes from SettingsModal
+  // Settings: reactive to changes from SettingsModal
   const [isVerbose, setIsVerbose] = useState(() => loadSettings().verboseMode)
+  const [quickActions, setQuickActions] = useState(() => loadSettings().quickActions)
   useEffect(() => {
-    const onSettingsChanged = () => setIsVerbose(loadSettings().verboseMode)
+    const onSettingsChanged = () => {
+      const s = loadSettings()
+      setIsVerbose(s.verboseMode)
+      setQuickActions(s.quickActions)
+    }
     window.addEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged)
     return () => window.removeEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged)
   }, [])
@@ -607,10 +632,21 @@ export const DetailDrawer = memo(function DetailDrawer({
             </div>
           </div>
           <div className="flex items-center gap-1.5 shrink-0">
-            <span className="text-[10px] text-kumo-subtle font-mono whitespace-nowrap">
-              {agent.model}
-              {agent.lastActivityAtMs ? ` · ${formatRelativeTime(agent.lastActivityAtMs)}` : ''}
-            </span>
+            {onChangeModel ? (
+              <button
+                onClick={onChangeModel}
+                className="text-[10px] text-kumo-subtle font-mono whitespace-nowrap hover:text-kumo-default transition-colors"
+                title="Change model"
+              >
+                {agent.model}
+                {agent.lastActivityAtMs ? ` · ${formatRelativeTime(agent.lastActivityAtMs)}` : ''}
+              </button>
+            ) : (
+              <span className="text-[10px] text-kumo-subtle font-mono whitespace-nowrap">
+                {agent.model}
+                {agent.lastActivityAtMs ? ` · ${formatRelativeTime(agent.lastActivityAtMs)}` : ''}
+              </span>
+            )}
             <StatusBadge status={agent.status} />
             {onRemove && (
               <button
@@ -778,8 +814,8 @@ export const DetailDrawer = memo(function DetailDrawer({
 
         {/* Bottom pane — action rail + input, resizable height */}
         <div style={{ height: inputHeight }} className="shrink-0 flex flex-col min-h-0">
-        {/* Action Rail */}
-        <div className="flex gap-1 px-3 py-1.5 border-t border-kumo-line shrink-0">
+        {/* Action Rail — single row */}
+        <div className="flex gap-1 items-center px-3 py-1.5 border-t border-kumo-line shrink-0">
           {onApprove && (
             <ActionButton icon={<Check size={12} weight="bold" />} label="Approve" variant="approve" onClick={onApprove} />
           )}
@@ -800,10 +836,27 @@ export const DetailDrawer = memo(function DetailDrawer({
               variant="action"
             />
           )}
+          {/* Custom quick action buttons + placeholder slots */}
+          {quickActions.filter(isQuickActionValid).map((qa) => (
+            <QuickActionButton
+              key={qa.id}
+              action={qa}
+              onClick={onQuickAction ? () => onQuickAction(qa) : undefined}
+            />
+          ))}
+          {Array.from({ length: MAX_QUICK_ACTIONS - quickActions.filter(isQuickActionValid).length }, (_, i) => (
+            <button
+              key={`placeholder-${i}`}
+              type="button"
+              onClick={onOpenQuickActionSettings}
+              className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md border border-dashed border-kumo-line text-kumo-subtle/50 hover:border-kumo-subtle hover:text-kumo-subtle transition-colors"
+              title="Configure in Settings → Quick Actions"
+            >
+              <Plus size={10} />
+              Custom
+            </button>
+          ))}
           <div className="flex-1" />
-          {onChangeModel && (
-            <ActionButton icon={<Brain size={12} />} label="Model" onClick={onChangeModel} />
-          )}
           <ActionDropdownButton
             icon={<GitPullRequest size={12} />}
             label="PR"
@@ -1426,6 +1479,17 @@ function ActionButton({
       {icon}
       {label}
     </button>
+  )
+}
+
+function QuickActionButton({ action, onClick }: { action: QuickAction; onClick?: () => void }) {
+  const Icon = quickActionIconMap[action.icon] ?? Lightning
+  return (
+    <ActionButton
+      icon={<Icon size={12} />}
+      label={action.label}
+      onClick={onClick}
+    />
   )
 }
 

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -26,6 +26,26 @@ import { TextInputModal } from './TextInputModal'
 import { Tooltip } from './Tooltip'
 import { PrTooltipContent } from './PrTooltip'
 import { useDismiss } from '../hooks/useDismiss'
+import {
+  Lightning,
+  Rocket,
+  Code,
+  CheckCircle,
+  PaperPlaneTilt,
+  Wrench,
+} from '@phosphor-icons/react'
+import { loadSettings, SETTINGS_CHANGED_EVENT, isQuickActionValid, type QuickAction, type QuickActionIcon } from '../data/settings'
+
+const quickActionIconMap: Record<QuickActionIcon, typeof Lightning> = {
+  'git-pull-request': GitPullRequest,
+  'rocket': Rocket,
+  'lightning': Lightning,
+  'terminal': Terminal,
+  'code': Code,
+  'check-circle': CheckCircle,
+  'paper-plane': PaperPlaneTilt,
+  'wrench': Wrench,
+}
 
 interface FleetTableProps {
   agents: AgentRuntime[]
@@ -43,6 +63,7 @@ interface FleetTableProps {
   onOpenTerminal?: (agentId: string) => void
   onOpenInEditor?: (agentId: string) => void
   onCreatePr?: (agentId: string) => void
+  onQuickAction?: (agentId: string, action: QuickAction) => void
   onSetPrUrl?: (agentId: string, prUrl: string | null) => void
   onChangeModel?: (agentId: string) => void
   onToggleLabel?: (agentId: string, labelId: string) => void
@@ -91,6 +112,7 @@ export function FleetTable({
   onOpenTerminal,
   onOpenInEditor,
   onCreatePr,
+  onQuickAction,
   onSetPrUrl,
   onChangeModel,
   onToggleLabel,
@@ -425,6 +447,10 @@ export function FleetTable({
             onCreatePr?.(contextMenu.agentId)
             closeContextMenu()
           }}
+          onQuickAction={(action: QuickAction) => {
+            onQuickAction?.(contextMenu.agentId, action)
+            closeContextMenu()
+          }}
           onRemovePrLink={() => {
             onSetPrUrl?.(contextMenu.agentId, null)
             closeContextMenu()
@@ -492,6 +518,7 @@ function ContextMenu({
   onOpenTerminal,
   onOpenInEditor,
   onCreatePr,
+  onQuickAction,
   onRemovePrLink,
   onEditPrLink,
   onToggleLabel,
@@ -513,6 +540,7 @@ function ContextMenu({
   onOpenTerminal: () => void
   onOpenInEditor: () => void
   onCreatePr: () => void
+  onQuickAction: (action: QuickAction) => void
   onRemovePrLink: () => void
   onEditPrLink: () => void
   onToggleLabel: (labelId: string) => void
@@ -523,6 +551,13 @@ function ContextMenu({
   onLabelDropdownChange?: (open: boolean) => void
 }) {
   const menuRef = useRef<HTMLDivElement>(null)
+  const [quickActions, setQuickActions] = useState(() => loadSettings().quickActions)
+
+  useEffect(() => {
+    const onSettingsChanged = () => setQuickActions(loadSettings().quickActions)
+    window.addEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged)
+    return () => window.removeEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged)
+  }, [])
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -599,6 +634,14 @@ function ContextMenu({
       <button className={itemClass} onClick={onCreatePr}>
         <GitPullRequest size={13} /> Create PR
       </button>
+      {quickActions.filter(isQuickActionValid).map((qa) => {
+        const Icon = quickActionIconMap[qa.icon] ?? Lightning
+        return (
+          <button key={qa.id} className={itemClass} onClick={() => onQuickAction(qa)}>
+            <Icon size={13} /> {qa.label}
+          </button>
+        )
+      })}
       <div className="px-2.5 py-1.5">
         <div className="text-[10px] text-kumo-subtle uppercase tracking-wide mb-1">Label</div>
         <LabelDropdown

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -1,17 +1,32 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
   X,
   GearSix,
   Keyboard,
   Info,
+  Lightning,
+  GitPullRequest,
+  Rocket,
+  Terminal as TerminalIcon,
+  Code,
+  CheckCircle,
+  PaperPlaneTilt,
+  Wrench,
+  Plus,
+  Trash,
+  CaretDown,
 } from '@phosphor-icons/react'
 import { SelectField } from './SelectField'
 import {
   DEFAULT_CREATE_PR_PROMPT,
+  MAX_QUICK_ACTIONS,
+  isQuickActionValid,
   loadSettings,
   saveSettings,
   type AppSettings,
   type NotificationPrefs,
+  type QuickAction,
+  type QuickActionIcon,
 } from '../data/settings'
 import { useModelOptions } from '../hooks/useModelOptions'
 
@@ -43,20 +58,45 @@ const KEYBOARD_SHORTCUTS = [
   { key: 'A', action: 'Approve Pending Tool', scope: 'Drawer' },
 ]
 
-type TabId = 'general' | 'shortcuts' | 'about'
+const ICON_OPTIONS: { value: QuickActionIcon; label: string; icon: typeof GitPullRequest }[] = [
+  { value: 'git-pull-request', label: 'PR', icon: GitPullRequest },
+  { value: 'rocket', label: 'Rocket', icon: Rocket },
+  { value: 'lightning', label: 'Lightning', icon: Lightning },
+  { value: 'terminal', label: 'Terminal', icon: TerminalIcon },
+  { value: 'code', label: 'Code', icon: Code },
+  { value: 'check-circle', label: 'Check', icon: CheckCircle },
+  { value: 'paper-plane', label: 'Send', icon: PaperPlaneTilt },
+  { value: 'wrench', label: 'Wrench', icon: Wrench },
+]
+
+function getIconComponent(iconKey: QuickActionIcon): typeof GitPullRequest {
+  return ICON_OPTIONS.find((o) => o.value === iconKey)?.icon ?? Lightning
+}
+
+type TabId = 'general' | 'quick-actions' | 'shortcuts' | 'about'
+
+export type SettingsTabId = 'general' | 'quick-actions' | 'shortcuts' | 'about'
+
+export interface ChatCommandOption {
+  command: string
+  description: string
+}
 
 interface SettingsModalProps {
   onClose: () => void
+  initialTab?: SettingsTabId
+  commands?: ChatCommandOption[]
 }
 
 const TAB_LIST: { id: TabId; label: string; icon: typeof GearSix }[] = [
   { id: 'general', label: 'General', icon: GearSix },
+  { id: 'quick-actions', label: 'Quick Actions', icon: Lightning },
   { id: 'shortcuts', label: 'Shortcuts', icon: Keyboard },
   { id: 'about', label: 'About', icon: Info },
 ]
 
-export function SettingsModal({ onClose }: SettingsModalProps) {
-  const [activeTab, setActiveTab] = useState<TabId>('general')
+export function SettingsModal({ onClose, initialTab = 'general', commands = [] }: SettingsModalProps) {
+  const [activeTab, setActiveTab] = useState<TabId>(initialTab)
   const [settings, setSettings] = useState(loadSettings)
   const [appVersion, setAppVersion] = useState<string>('')
   const { options: modelOptions } = useModelOptions()
@@ -262,6 +302,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                 </p>
               </div>
 
+              {/* Create PR Prompt */}
               <div className="flex flex-col gap-1.5">
                 <div className="flex items-center justify-between gap-3">
                   <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
@@ -296,6 +337,15 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                 <p className="text-[11px] text-kumo-subtle">Additional themes coming in a future release.</p>
               </div>
             </div>
+          )}
+
+          {activeTab === 'quick-actions' && (
+            <QuickActionsTab
+              quickActions={settings.quickActions}
+              onChange={(quickActions) => updateSettings({ quickActions })}
+              inputClasses={inputClasses}
+              commands={commands}
+            />
           )}
 
           {activeTab === 'shortcuts' && (
@@ -385,6 +435,284 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
              Save
           </button>
         </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Quick Actions Tab ──
+
+function QuickActionsTab({
+  quickActions,
+  onChange,
+  inputClasses,
+  commands = [],
+}: {
+  quickActions: QuickAction[]
+  onChange: (actions: QuickAction[]) => void
+  inputClasses: string
+  commands?: ChatCommandOption[]
+}) {
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [autoFocusId, setAutoFocusId] = useState<string | null>(null)
+  const labelInputRef = useRef<HTMLInputElement>(null)
+
+  // Auto-focus + select the label input when a new action is created
+  useEffect(() => {
+    if (autoFocusId && expandedId === autoFocusId && labelInputRef.current) {
+      labelInputRef.current.focus()
+      labelInputRef.current.select()
+      setAutoFocusId(null)
+    }
+  }, [autoFocusId, expandedId])
+
+  const addAction = () => {
+    if (quickActions.length >= MAX_QUICK_ACTIONS) return
+    const id = `qa-${Date.now()}`
+    const newAction: QuickAction = {
+      id,
+      label: 'New Action',
+      icon: 'lightning',
+      prompt: '',
+    }
+    onChange([...quickActions, newAction])
+    setExpandedId(id)
+    setAutoFocusId(id)
+  }
+
+  const updateAction = (id: string, partial: Partial<QuickAction>) => {
+    onChange(quickActions.map((qa) => (qa.id === id ? { ...qa, ...partial } : qa)))
+  }
+
+  const removeAction = (id: string) => {
+    onChange(quickActions.filter((qa) => qa.id !== id))
+    if (expandedId === id) setExpandedId(null)
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <p className="text-xs text-kumo-subtle">
+          Quick action buttons appear in the agent drawer&apos;s action rail. Each sends a prompt to the agent when clicked. You can have up to {MAX_QUICK_ACTIONS}.
+        </p>
+        <p className="text-[11px] text-kumo-subtle mt-1">
+          Tip: start a prompt with <code className="px-1 py-0.5 rounded bg-kumo-fill text-kumo-default">/command-name</code> to run an OpenCode slash command.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {quickActions.map((qa) => {
+          const isExpanded = expandedId === qa.id
+          const IconComp = getIconComponent(qa.icon)
+          const isValid = isQuickActionValid(qa)
+
+          return (
+            <div
+              key={qa.id}
+              className={`border rounded-lg overflow-hidden bg-kumo-control/30 ${isValid ? 'border-kumo-line' : 'border-kumo-danger/30'}`}
+            >
+              {/* Header with expand toggle + remove */}
+              <div className="flex items-center gap-2.5 px-3 py-2.5 hover:bg-kumo-fill/50 transition-colors">
+                <button
+                  type="button"
+                  onClick={() => setExpandedId(isExpanded ? null : qa.id)}
+                  className="flex items-center gap-2.5 flex-1 min-w-0 text-left"
+                >
+                  <IconComp size={14} className="text-kumo-subtle shrink-0" />
+                  <span className="text-sm font-medium text-kumo-default flex-1 truncate">{qa.label || 'Untitled'}</span>
+                  {!isValid && (
+                    <span className="text-[9px] text-kumo-danger font-medium shrink-0">Incomplete</span>
+                  )}
+                  <CaretDown
+                    size={12}
+                    className={`text-kumo-subtle transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                  />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => removeAction(qa.id)}
+                  className="w-6 h-6 flex items-center justify-center rounded-md text-kumo-subtle hover:text-kumo-danger hover:bg-kumo-danger/10 transition-colors shrink-0"
+                  title="Remove"
+                >
+                  <Trash size={12} />
+                </button>
+              </div>
+
+              {/* Expanded editor */}
+              {isExpanded && (
+                <div className="px-3 pb-3 flex flex-col gap-3 border-t border-kumo-line pt-3">
+                  {/* Label + Icon row */}
+                  <div className="flex gap-2">
+                    <div className="flex-1 flex flex-col gap-1">
+                      <label className="text-[11px] font-medium text-kumo-subtle uppercase tracking-wide">
+                        Button Label
+                      </label>
+                      <input
+                        ref={autoFocusId === qa.id || expandedId === qa.id ? labelInputRef : undefined}
+                        type="text"
+                        value={qa.label}
+                        onChange={(e) => updateAction(qa.id, { label: e.target.value })}
+                        maxLength={20}
+                        placeholder="e.g. Create PR, Run Tests"
+                        className={inputClasses}
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <label className="text-[11px] font-medium text-kumo-subtle uppercase tracking-wide">
+                        Icon
+                      </label>
+                      <div className="flex gap-1">
+                        {ICON_OPTIONS.map((opt) => {
+                          const OptIcon = opt.icon
+                          return (
+                            <button
+                              key={opt.value}
+                              type="button"
+                              onClick={() => updateAction(qa.id, { icon: opt.value })}
+                              title={opt.label}
+                              className={`w-7 h-7 flex items-center justify-center rounded-md border transition-colors ${
+                                qa.icon === opt.value
+                                  ? 'border-kumo-brand bg-kumo-brand/10 text-kumo-brand'
+                                  : 'border-kumo-line text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill'
+                              }`}
+                            >
+                              <OptIcon size={13} />
+                            </button>
+                          )
+                        })}
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Prompt with slash command autocomplete */}
+                  <PromptTextarea
+                    value={qa.prompt}
+                    onChange={(v) => updateAction(qa.id, { prompt: v })}
+                    commands={commands}
+                    inputClasses={inputClasses}
+                  />
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {quickActions.length < MAX_QUICK_ACTIONS && (
+        <button
+          type="button"
+          onClick={addAction}
+          className="flex items-center justify-center gap-1.5 px-3 py-2 text-xs font-medium text-kumo-subtle border border-dashed border-kumo-line rounded-lg hover:text-kumo-default hover:border-kumo-subtle hover:bg-kumo-fill/50 transition-colors"
+        >
+          <Plus size={12} />
+          Add Quick Action
+        </button>
+      )}
+    </div>
+  )
+}
+
+// ── Prompt textarea with slash command autocomplete ──
+
+function PromptTextarea({
+  value,
+  onChange,
+  commands,
+  inputClasses,
+}: {
+  value: string
+  onChange: (value: string) => void
+  commands: ChatCommandOption[]
+  inputClasses: string
+}) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const [showAutocomplete, setShowAutocomplete] = useState(false)
+  const [selectedIndex, setSelectedIndex] = useState(0)
+
+  // Show autocomplete when the full value starts with "/" and there's no space yet (single-token command)
+  const trimmed = value.trim().toLowerCase()
+  const isTypingCommand = value.startsWith('/') && !value.includes(' ') && !value.includes('\n')
+  const matchingCommands = isTypingCommand
+    ? commands.filter((c) => c.command.startsWith(trimmed))
+    : []
+  const shouldShow = showAutocomplete && matchingCommands.length > 0 && !commands.some((c) => c.command === trimmed)
+
+  const insertCommand = (command: string) => {
+    onChange(`${command} `)
+    setShowAutocomplete(false)
+    setSelectedIndex(0)
+    requestAnimationFrame(() => textareaRef.current?.focus())
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!shouldShow) return
+    if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
+      e.preventDefault()
+      const selected = matchingCommands[selectedIndex]
+      if (selected) insertCommand(selected.command)
+      return
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setSelectedIndex((prev) => (prev + 1) % matchingCommands.length)
+      return
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setSelectedIndex((prev) => (prev - 1 + matchingCommands.length) % matchingCommands.length)
+      return
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      setShowAutocomplete(false)
+      return
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-[11px] font-medium text-kumo-subtle uppercase tracking-wide">
+        Prompt
+      </label>
+      <div className="relative">
+        {shouldShow && (
+          <div className="absolute bottom-full left-0 right-0 z-20 mb-1 rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl max-h-40 overflow-y-auto">
+            {matchingCommands.map((cmd, index) => (
+              <button
+                key={cmd.command}
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                  insertCommand(cmd.command)
+                }}
+                className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
+                  index === selectedIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
+                }`}
+              >
+                <span className="font-mono text-[11px] text-kumo-default">{cmd.command}</span>
+                <span className="text-[11px] text-kumo-subtle truncate">{cmd.description}</span>
+              </button>
+            ))}
+            <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
+              Tab/Enter to select · Arrow keys to navigate
+            </div>
+          </div>
+        )}
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(e) => {
+            onChange(e.target.value)
+            setShowAutocomplete(true)
+            setSelectedIndex(0)
+          }}
+          onKeyDown={handleKeyDown}
+          onBlur={() => setTimeout(() => setShowAutocomplete(false), 150)}
+          onFocus={() => setShowAutocomplete(true)}
+          placeholder="The message sent to the agent when this button is clicked... Type / for commands."
+          rows={6}
+          className={`${inputClasses} min-h-24 resize-y leading-6`}
+        />
       </div>
     </div>
   )

--- a/src/renderer/src/data/settings.ts
+++ b/src/renderer/src/data/settings.ts
@@ -5,12 +5,32 @@ export interface NotificationPrefs {
   completed: boolean
 }
 
+export type QuickActionIcon =
+  | 'git-pull-request'
+  | 'rocket'
+  | 'lightning'
+  | 'terminal'
+  | 'code'
+  | 'check-circle'
+  | 'paper-plane'
+  | 'wrench'
+
+export interface QuickAction {
+  id: string
+  label: string
+  icon: QuickActionIcon
+  prompt: string
+}
+
+export const MAX_QUICK_ACTIONS = 3
+
 export interface AppSettings {
   model: string
   editor: string
   customEditorCommand: string
   terminal: string
   createPrPrompt: string
+  quickActions: QuickAction[]
   notifications: NotificationPrefs
   verboseMode: boolean
   soundEnabled: boolean
@@ -35,6 +55,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   customEditorCommand: '',
   terminal: 'default',
   createPrPrompt: DEFAULT_CREATE_PR_PROMPT,
+  quickActions: [],
   notifications: {
     needs_approval: true,
     needs_input: true,
@@ -52,6 +73,12 @@ export function loadSettings(): AppSettings {
 
     const parsed = JSON.parse(stored) as Partial<AppSettings>
 
+    // Quick actions: take up to MAX_QUICK_ACTIONS, default to empty.
+    // Existing users without quickActions simply get no custom buttons (PR is still static).
+    const quickActions = Array.isArray(parsed.quickActions)
+      ? parsed.quickActions.slice(0, MAX_QUICK_ACTIONS)
+      : []
+
     return {
       ...DEFAULT_SETTINGS,
       ...parsed,
@@ -60,10 +87,15 @@ export function loadSettings(): AppSettings {
         ...(parsed.notifications ?? {}),
       },
       createPrPrompt: parsed.createPrPrompt?.trim() ? parsed.createPrPrompt : DEFAULT_CREATE_PR_PROMPT,
+      quickActions,
     }
   } catch {
     return DEFAULT_SETTINGS
   }
+}
+
+export function isQuickActionValid(qa: QuickAction): boolean {
+  return Boolean(qa.label?.trim() && qa.prompt?.trim())
 }
 
 export const SETTINGS_CHANGED_EVENT = 'oc-orchestrator:settings-changed'


### PR DESCRIPTION
Users can configure up to 3 custom quick action buttons that appear in
the agent drawer's action rail alongside Label, PR, and Open In. Each
button sends a configurable prompt to the agent when clicked.

- New Quick Actions tab in Settings with label, icon picker, prompt
  editor, and slash command autocomplete
- Empty placeholder slots in the drawer with dashed borders that
  deep-link to Settings → Quick Actions on click
- Model button moved from action rail to clickable header text
- Input pane defaults to 30% of window height for better usability
- Incomplete actions (missing label or prompt) hidden from buttons
  but editable in settings with visual indicator
- Existing PR prompt and static buttons unchanged for backward compat