### PR TITLE
Prevent action rail buttons from wrapping text internally

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -866,8 +866,9 @@ export function App() {
 
   const handleQuickAction = useCallback(async (action: QuickAction) => {
     if (!selectedAgentId) return
-    await storeSendMessage(selectedAgentId, action.prompt, undefined, undefined, action.label)
-  }, [selectedAgentId, storeSendMessage])
+    // Route through handleSendMessage so slash commands are executed properly
+    await handleSendMessage(action.prompt)
+  }, [selectedAgentId, handleSendMessage])
 
   const handleOpenInEditor = useCallback(() => {
     if (!selectedAgentId) return
@@ -890,8 +891,19 @@ export function App() {
   }, [store])
 
   const handleQuickActionForAgent = useCallback(async (agentId: string, action: QuickAction) => {
-    await store.sendMessage(agentId, action.prompt, undefined, undefined, action.label)
-  }, [store])
+    const trimmed = action.prompt.trim()
+    if (trimmed.startsWith('/')) {
+      const spaceIndex = trimmed.indexOf(' ')
+      const commandName = spaceIndex === -1 ? trimmed.slice(1) : trimmed.slice(1, spaceIndex)
+      const commandArgs = spaceIndex === -1 ? '' : trimmed.slice(spaceIndex + 1).trim()
+      const isKnownCommand = agentCommands.some((cmd) => cmd.command === `/${commandName}`)
+      if (isKnownCommand) {
+        await storeExecuteCommand(agentId, commandName, commandArgs)
+        return
+      }
+    }
+    await store.sendMessage(agentId, trimmed, undefined, undefined, action.label)
+  }, [store, agentCommands, storeExecuteCommand])
 
   const handleOpenTerminal = useCallback((agentId: string) => {
     const liveAgent = findLiveAgent(agentId)

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -814,8 +814,8 @@ export const DetailDrawer = memo(function DetailDrawer({
 
         {/* Bottom pane — action rail + input, resizable height */}
         <div style={{ height: inputHeight }} className="shrink-0 flex flex-col min-h-0">
-        {/* Action Rail — single row */}
-        <div className="flex gap-1 items-center px-3 py-1.5 border-t border-kumo-line shrink-0">
+        {/* Action Rail — single row, scrollable */}
+        <div className="flex gap-1 items-center px-3 py-1.5 border-t border-kumo-line shrink-0 overflow-x-auto">
           {onApprove && (
             <ActionButton icon={<Check size={12} weight="bold" />} label="Approve" variant="approve" onClick={onApprove} />
           )}
@@ -849,7 +849,7 @@ export const DetailDrawer = memo(function DetailDrawer({
               key={`placeholder-${i}`}
               type="button"
               onClick={onOpenQuickActionSettings}
-              className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md border border-dashed border-kumo-line text-kumo-subtle/50 hover:border-kumo-subtle hover:text-kumo-subtle transition-colors"
+              className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md border border-dashed whitespace-nowrap border-kumo-line text-kumo-subtle/50 hover:border-kumo-subtle hover:text-kumo-subtle transition-colors"
               title="Configure in Settings → Quick Actions"
             >
               <Plus size={10} />
@@ -1474,7 +1474,7 @@ function ActionButton({
     <button
       onClick={onClick}
       disabled={disabled}
-      className={`flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md border transition-colors ${styles[variant]} ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+      className={`flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md border whitespace-nowrap transition-colors ${styles[variant]} ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
     >
       {icon}
       {label}
@@ -1530,7 +1530,7 @@ function ActionDropdownButton({
     <div ref={containerRef} className="relative inline-flex">
       <button
         onClick={toggle}
-        className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md border bg-kumo-control border-kumo-line text-kumo-default hover:bg-kumo-fill transition-colors"
+        className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md border whitespace-nowrap bg-kumo-control border-kumo-line text-kumo-default hover:bg-kumo-fill transition-colors"
       >
         {icon}
         {label}


### PR DESCRIPTION
Add whitespace-nowrap to ActionButton, ActionDropdownButton, and
placeholder buttons so labels like "PR Draft" and "Open In" stay
on one line. Make the rail overflow-x-auto so it scrolls horizontally
when the drawer is narrow instead of squishing buttons.