### PR TITLE
Add Settings to macOS menu bar and rebrand dev app as Orchestrator

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -3,6 +3,8 @@
 // Set up Electron app dependencies when available; skip cleanly for global installs.
 
 const { execSync } = require('child_process')
+const path = require('path')
+const fs = require('fs')
 
 try {
   require.resolve('electron-builder')
@@ -10,7 +12,40 @@ try {
   process.exit(0)
 }
 
-execSync('electron-builder install-app-deps', {
-  stdio: 'inherit',
-  cwd: require('path').resolve(__dirname, '..')
-})
+const root = path.resolve(__dirname, '..')
+
+execSync('electron-builder install-app-deps', { stdio: 'inherit', cwd: root })
+
+// Rebrand Electron.app → Orchestrator.app for dev mode on macOS.
+// Patches the Info.plist (name + icon), copies our .icns, renames the .app
+// bundle, and updates path.txt so the electron module resolves the new path.
+if (process.platform === 'darwin') {
+  const dist = path.join(root, 'node_modules/electron/dist')
+  const oldApp = path.join(dist, 'Electron.app')
+  const newApp = path.join(dist, 'Orchestrator.app')
+  const appBundle = fs.existsSync(newApp) ? newApp : oldApp
+  const plist = path.join(appBundle, 'Contents/Info.plist')
+
+  if (fs.existsSync(plist)) {
+    try {
+      execSync(`plutil -replace CFBundleName -string Orchestrator "${plist}"`)
+      execSync(`plutil -replace CFBundleDisplayName -string Orchestrator "${plist}"`)
+      execSync(`plutil -replace CFBundleIconFile -string orchestrator.icns "${plist}"`)
+      fs.copyFileSync(
+        path.join(root, 'resources/icon.icns'),
+        path.join(appBundle, 'Contents/Resources/orchestrator.icns')
+      )
+
+      if (fs.existsSync(oldApp)) {
+        fs.renameSync(oldApp, newApp)
+      }
+
+      const pathFile = path.join(root, 'node_modules/electron/path.txt')
+      fs.writeFileSync(pathFile, 'Orchestrator.app/Contents/MacOS/Electron')
+
+      console.log('[postinstall] Rebranded Electron.app → Orchestrator.app')
+    } catch (err) {
+      console.warn('[postinstall] Failed to rebrand Electron.app:', err.message)
+    }
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,6 +6,11 @@ import { database } from './services/database'
 import { runtimeManager } from './services/runtime-manager'
 import { startUpdateChecker, stopUpdateChecker } from './services/update-checker'
 
+// Pin userData path before setName — otherwise it shifts to ~/Library/Application Support/Orchestrator/
+const userDataPath = app.getPath('userData')
+app.setName('Orchestrator')
+app.setPath('userData', userDataPath)
+
 let mainWindowRef: BrowserWindow | null = null
 
 const WINDOW_BOUNDS_KEY = 'window_bounds'
@@ -99,9 +104,31 @@ function createWindow(): BrowserWindow {
 }
 
 app.whenReady().then(async () => {
-  // Explicit menu suppresses macOS representedObject warnings from Electron's default
   Menu.setApplicationMenu(Menu.buildFromTemplate([
-    { role: 'appMenu' },
+    {
+      label: 'Orchestrator',
+      submenu: [
+        { role: 'about' },
+        { type: 'separator' },
+        {
+          label: 'Settings…',
+          accelerator: 'CmdOrCtrl+,',
+          click: () => {
+            for (const win of BrowserWindow.getAllWindows()) {
+              win.webContents.send('menu:open-settings')
+            }
+          }
+        },
+        { type: 'separator' },
+        { role: 'services' },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' },
+      ]
+    },
     { role: 'editMenu' },
     { role: 'windowMenu' },
   ]))

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -287,6 +287,12 @@ const api = {
     const handler = () => callback()
     ipcRenderer.on('agents:restored', handler)
     return () => ipcRenderer.removeListener('agents:restored', handler)
+  },
+
+  onMenuOpenSettings: (callback: () => void) => {
+    const handler = () => callback()
+    ipcRenderer.on('menu:open-settings', handler)
+    return () => ipcRenderer.removeListener('menu:open-settings', handler)
   }
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -267,6 +267,14 @@ export function App() {
   // The detail drawer looks up agents from the unfiltered list, so we
   // only need to set the selection — no need to clear filters/search.
 
+  // Menu bar: open settings modal when triggered from native menu
+  useEffect(() => {
+    if (!window.api?.onMenuOpenSettings) return
+    return window.api.onMenuOpenSettings(() => {
+      setShowSettings(true)
+    })
+  }, [])
+
   // Push path: main process sends agentId directly via IPC
   useEffect(() => {
     if (!window.api?.onNotificationSelectAgent) return

--- a/src/renderer/src/demoApi.ts
+++ b/src/renderer/src/demoApi.ts
@@ -384,6 +384,7 @@ export function createDemoApi(): OrchestratorApi {
     onEventError: noopListener,
     onUpdateAvailable: noopListener,
     onNotificationSelectAgent: noopListener,
-    onAgentsRestored: noopListener
+    onAgentsRestored: noopListener,
+    onMenuOpenSettings: noopListener
   }
 }

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -106,6 +106,7 @@ export interface OrchestratorApi {
   onUpdateAvailable: (callback: (data: { currentVersion: string; latestVersion: string }) => void) => () => void
   onNotificationSelectAgent: (callback: (data: { agentId: string }) => void) => () => void
   onAgentsRestored: (callback: () => void) => () => void
+  onMenuOpenSettings: (callback: () => void) => () => void
 }
 
 export interface WorktreeListEntry {


### PR DESCRIPTION
Replace the default appMenu role with a custom app menu containing a
Settings item (Cmd+,) that opens the settings modal via IPC. Rebrand
the Electron.app bundle to Orchestrator.app in postinstall so the
dock, menu bar, and app switcher all show the correct name and icon
during development.