### PR TITLE
Always execute slash commands via runtime instead of gating on cached list

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -794,6 +794,12 @@ export function App() {
 
       const handled = await handleBuiltInCommand(selectedAgentId, commandName, commandArgs)
       if (handled) return
+
+      // Not a built-in or cached command — try executing via the runtime anyway.
+      // The runtime may know about commands (custom slash commands, skills) that
+      // haven't been fetched into agentCommands yet.
+      await storeExecuteCommand(selectedAgentId, commandName, commandArgs)
+      return
     }
 
     // Check for @agentname mentions — extract agent name and strip from text
@@ -809,7 +815,7 @@ export function App() {
     }
 
     await storeSendMessage(selectedAgentId, text, undefined, attachments)
-  }, [agentConfigs, handleBuiltInCommand, selectedAgentId, selectedQuestion, storeSendMessage, storeReplyToQuestion, storeResetSession])
+  }, [agentConfigs, handleBuiltInCommand, selectedAgentId, selectedQuestion, storeSendMessage, storeExecuteCommand, storeReplyToQuestion, storeResetSession])
 
   const handleApprove = useCallback(async (permissionId: string) => {
     if (!selectedAgentId) return
@@ -904,14 +910,11 @@ export function App() {
       const spaceIndex = trimmed.indexOf(' ')
       const commandName = spaceIndex === -1 ? trimmed.slice(1) : trimmed.slice(1, spaceIndex)
       const commandArgs = spaceIndex === -1 ? '' : trimmed.slice(spaceIndex + 1).trim()
-      const isKnownCommand = agentCommands.some((cmd) => cmd.command === `/${commandName}`)
-      if (isKnownCommand) {
-        await storeExecuteCommand(agentId, commandName, commandArgs)
-        return
-      }
+      await storeExecuteCommand(agentId, commandName, commandArgs)
+      return
     }
     await store.sendMessage(agentId, trimmed, undefined, undefined, action.label)
-  }, [store, agentCommands, storeExecuteCommand])
+  }, [store, storeExecuteCommand])
 
   const handleOpenTerminal = useCallback((agentId: string) => {
     const liveAgent = findLiveAgent(agentId)

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -1537,7 +1537,7 @@ function ActionDropdownButton({
         <CaretDown size={10} className="ml-0.5" />
       </button>
       {open && (
-        <div className="absolute bottom-full left-0 mb-1 z-[100] min-w-[140px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl">
+        <div className="absolute bottom-full right-0 mb-1 z-[100] min-w-[140px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl">
           {visibleItems.map((item) => (
             <button
               key={item.label}

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -814,8 +814,8 @@ export const DetailDrawer = memo(function DetailDrawer({
 
         {/* Bottom pane — action rail + input, resizable height */}
         <div style={{ height: inputHeight }} className="shrink-0 flex flex-col min-h-0">
-        {/* Action Rail — single row, scrollable */}
-        <div className="flex gap-1 items-center px-3 py-1.5 border-t border-kumo-line shrink-0 overflow-x-auto">
+        {/* Action Rail */}
+        <div className="flex flex-wrap gap-1 items-center px-3 py-1.5 border-t border-kumo-line shrink-0">
           {onApprove && (
             <ActionButton icon={<Check size={12} weight="bold" />} label="Approve" variant="approve" onClick={onApprove} />
           )}


### PR DESCRIPTION
Slash commands in quick action prompts and the chat input were only
executed if they appeared in the cached agentCommands list. Custom
commands like /code-simplifier (defined in user config, fetched async)
could miss the cache and get sent as literal text instead.

Now any unrecognized /command is sent to executeCommand directly —
the runtime handles resolution. The cached list is still used for
built-in UI commands (model, compact, share, etc.) but no longer
gates execution of custom commands.