### PR TITLE
Fix action rail layout, preserve quick action slot positions, simplify code

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -17,7 +17,7 @@ import { type AgentRuntime, type Interrupt, type Message, type ColumnKey, type C
 import type { FileChange } from './components/FilesChanged'
 import type { ToolCall } from './components/ToolsUsage'
 import type { EventEntry } from './components/EventLog'
-import { loadSettings, type QuickAction } from './data/settings'
+import { loadSettings, parseSlashCommand, type QuickAction } from './data/settings'
 
 const NEW_AGENT_COMMAND = '/new'
 const AGENT_MENTION_REGEX = /@(\w+)/
@@ -787,18 +787,13 @@ export function App() {
     }
 
     // Check if input is a slash command (other than /new which is handled above)
-    if (trimmedText.startsWith('/')) {
-      const spaceIndex = trimmedText.indexOf(' ')
-      const commandName = spaceIndex === -1 ? trimmedText.slice(1) : trimmedText.slice(1, spaceIndex)
-      const commandArgs = spaceIndex === -1 ? '' : trimmedText.slice(spaceIndex + 1).trim()
-
-      const handled = await handleBuiltInCommand(selectedAgentId, commandName, commandArgs)
+    const parsed = parseSlashCommand(trimmedText)
+    if (parsed) {
+      const handled = await handleBuiltInCommand(selectedAgentId, parsed.name, parsed.args)
       if (handled) return
 
-      // Not a built-in or cached command — try executing via the runtime anyway.
-      // The runtime may know about commands (custom slash commands, skills) that
-      // haven't been fetched into agentCommands yet.
-      await storeExecuteCommand(selectedAgentId, commandName, commandArgs)
+      // Not a built-in — try the runtime directly (custom slash commands, skills)
+      await storeExecuteCommand(selectedAgentId, parsed.name, parsed.args)
       return
     }
 
@@ -905,15 +900,12 @@ export function App() {
   }, [store])
 
   const handleQuickActionForAgent = useCallback(async (agentId: string, action: QuickAction) => {
-    const trimmed = action.prompt.trim()
-    if (trimmed.startsWith('/')) {
-      const spaceIndex = trimmed.indexOf(' ')
-      const commandName = spaceIndex === -1 ? trimmed.slice(1) : trimmed.slice(1, spaceIndex)
-      const commandArgs = spaceIndex === -1 ? '' : trimmed.slice(spaceIndex + 1).trim()
-      await storeExecuteCommand(agentId, commandName, commandArgs)
+    const parsed = parseSlashCommand(action.prompt)
+    if (parsed) {
+      await storeExecuteCommand(agentId, parsed.name, parsed.args)
       return
     }
-    await store.sendMessage(agentId, trimmed, undefined, undefined, action.label)
+    await store.sendMessage(agentId, action.prompt.trim(), undefined, undefined, action.label)
   }, [store, storeExecuteCommand])
 
   const handleOpenTerminal = useCallback((agentId: string) => {

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -824,14 +824,17 @@ export const DetailDrawer = memo(function DetailDrawer({
             <ActionButton icon={<XCircle size={12} />} label="Deny" variant="deny" onClick={onDeny} />
           )}
           {/* Custom quick action buttons — positional slots */}
-          {quickActions.map((qa, i) =>
-            qa && isQuickActionValid(qa) ? (
-              <QuickActionButton
-                key={qa.id}
-                action={qa}
-                onClick={onQuickAction ? () => onQuickAction(qa) : undefined}
-              />
-            ) : (
+          {quickActions.map((qa, i) => {
+            if (qa && isQuickActionValid(qa)) {
+              return (
+                <QuickActionButton
+                  key={qa.id}
+                  action={qa}
+                  onClick={onQuickAction ? () => onQuickAction(qa) : undefined}
+                />
+              )
+            }
+            return (
               <button
                 key={`placeholder-${i}`}
                 type="button"
@@ -843,7 +846,7 @@ export const DetailDrawer = memo(function DetailDrawer({
                 Custom
               </button>
             )
-          )}
+          })}
         </div>
 
         {/* Input row: text input left, action buttons + send right */}

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -815,7 +815,7 @@ export const DetailDrawer = memo(function DetailDrawer({
 
         {/* Bottom pane — action rail + input, resizable height */}
         <div style={{ height: inputHeight }} className="shrink-0 flex flex-col min-h-0">
-        {/* Action Rail — quick actions + approve/deny */}
+        {/* Action Rail */}
         <div className="flex flex-wrap gap-1 items-center px-3 py-1.5 border-t border-kumo-line shrink-0">
           {onApprove && (
             <ActionButton icon={<Check size={12} weight="bold" />} label="Approve" variant="approve" onClick={onApprove} />

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -823,26 +823,27 @@ export const DetailDrawer = memo(function DetailDrawer({
           {onDeny && (
             <ActionButton icon={<XCircle size={12} />} label="Deny" variant="deny" onClick={onDeny} />
           )}
-          {/* Custom quick action buttons + placeholder slots */}
-          {quickActions.filter(isQuickActionValid).map((qa) => (
-            <QuickActionButton
-              key={qa.id}
-              action={qa}
-              onClick={onQuickAction ? () => onQuickAction(qa) : undefined}
-            />
-          ))}
-          {Array.from({ length: MAX_QUICK_ACTIONS - quickActions.filter(isQuickActionValid).length }, (_, i) => (
-            <button
-              key={`placeholder-${i}`}
-              type="button"
-              onClick={onOpenQuickActionSettings}
-              className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md border border-dashed whitespace-nowrap border-kumo-line text-kumo-subtle/50 hover:border-kumo-subtle hover:text-kumo-subtle transition-colors"
-              title="Configure in Settings → Quick Actions"
-            >
-              <Plus size={10} />
-              Custom
-            </button>
-          ))}
+          {/* Custom quick action buttons — positional slots */}
+          {quickActions.map((qa, i) =>
+            qa && isQuickActionValid(qa) ? (
+              <QuickActionButton
+                key={qa.id}
+                action={qa}
+                onClick={onQuickAction ? () => onQuickAction(qa) : undefined}
+              />
+            ) : (
+              <button
+                key={`placeholder-${i}`}
+                type="button"
+                onClick={onOpenQuickActionSettings}
+                className="flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md border border-dashed whitespace-nowrap border-kumo-line text-kumo-subtle/50 hover:border-kumo-subtle hover:text-kumo-subtle transition-colors"
+                title="Configure in Settings → Quick Actions"
+              >
+                <Plus size={10} />
+                Custom
+              </button>
+            )
+          )}
         </div>
 
         {/* Input row: text input left, action buttons + send right */}

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -634,7 +634,7 @@ function ContextMenu({
       <button className={itemClass} onClick={onCreatePr}>
         <GitPullRequest size={13} /> Create PR
       </button>
-      {quickActions.filter(isQuickActionValid).map((qa) => {
+      {quickActions.filter((qa): qa is QuickAction => qa !== null && isQuickActionValid(qa)).map((qa) => {
         const Icon = quickActionIconMap[qa.icon] ?? Lightning
         return (
           <button key={qa.id} className={itemClass} onClick={() => onQuickAction(qa)}>

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -74,8 +74,6 @@ function getIconComponent(iconKey: QuickActionIcon): typeof GitPullRequest {
   return ICON_OPTIONS.find((o) => o.value === iconKey)?.icon ?? Lightning
 }
 
-type TabId = 'general' | 'quick-actions' | 'shortcuts' | 'about'
-
 export type SettingsTabId = 'general' | 'quick-actions' | 'shortcuts' | 'about'
 
 export interface ChatCommandOption {
@@ -89,7 +87,7 @@ interface SettingsModalProps {
   commands?: ChatCommandOption[]
 }
 
-const TAB_LIST: { id: TabId; label: string; icon: typeof GearSix }[] = [
+const TAB_LIST: { id: SettingsTabId; label: string; icon: typeof GearSix }[] = [
   { id: 'general', label: 'General', icon: GearSix },
   { id: 'quick-actions', label: 'Quick Actions', icon: Lightning },
   { id: 'shortcuts', label: 'Shortcuts', icon: Keyboard },
@@ -97,7 +95,7 @@ const TAB_LIST: { id: TabId; label: string; icon: typeof GearSix }[] = [
 ]
 
 export function SettingsModal({ onClose, initialTab = 'general', commands = [] }: SettingsModalProps) {
-  const [activeTab, setActiveTab] = useState<TabId>(initialTab)
+  const [activeTab, setActiveTab] = useState<SettingsTabId>(initialTab)
   const [settings, setSettings] = useState(loadSettings)
   const [appVersion, setAppVersion] = useState<string>('')
   const { options: modelOptions } = useModelOptions()
@@ -571,7 +569,7 @@ function QuickActionsTab({
                         Button Label
                       </label>
                       <input
-                        ref={autoFocusIndex === index || expandedIndex === index ? labelInputRef : undefined}
+                        ref={autoFocusIndex === index ? labelInputRef : undefined}
                         type="text"
                         value={qa.label}
                         onChange={(e) => updateAction(index, { label: e.target.value })}

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -27,6 +27,7 @@ import {
   type NotificationPrefs,
   type QuickAction,
   type QuickActionIcon,
+  type QuickActionSlots,
 } from '../data/settings'
 import { useModelOptions } from '../hooks/useModelOptions'
 
@@ -448,45 +449,51 @@ function QuickActionsTab({
   inputClasses,
   commands = [],
 }: {
-  quickActions: QuickAction[]
-  onChange: (actions: QuickAction[]) => void
+  quickActions: QuickActionSlots
+  onChange: (actions: QuickActionSlots) => void
   inputClasses: string
   commands?: ChatCommandOption[]
 }) {
-  const [expandedId, setExpandedId] = useState<string | null>(null)
-  const [autoFocusId, setAutoFocusId] = useState<string | null>(null)
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null)
+  const [autoFocusIndex, setAutoFocusIndex] = useState<number | null>(null)
   const labelInputRef = useRef<HTMLInputElement>(null)
 
   // Auto-focus + select the label input when a new action is created
   useEffect(() => {
-    if (autoFocusId && expandedId === autoFocusId && labelInputRef.current) {
+    if (autoFocusIndex !== null && expandedIndex === autoFocusIndex && labelInputRef.current) {
       labelInputRef.current.focus()
       labelInputRef.current.select()
-      setAutoFocusId(null)
+      setAutoFocusIndex(null)
     }
-  }, [autoFocusId, expandedId])
+  }, [autoFocusIndex, expandedIndex])
 
-  const addAction = () => {
-    if (quickActions.length >= MAX_QUICK_ACTIONS) return
-    const id = `qa-${Date.now()}`
+  const addActionAtSlot = (index: number) => {
     const newAction: QuickAction = {
-      id,
+      id: `qa-${Date.now()}`,
       label: 'New Action',
       icon: 'lightning',
       prompt: '',
     }
-    onChange([...quickActions, newAction])
-    setExpandedId(id)
-    setAutoFocusId(id)
+    const updated = [...quickActions]
+    updated[index] = newAction
+    onChange(updated)
+    setExpandedIndex(index)
+    setAutoFocusIndex(index)
   }
 
-  const updateAction = (id: string, partial: Partial<QuickAction>) => {
-    onChange(quickActions.map((qa) => (qa.id === id ? { ...qa, ...partial } : qa)))
+  const updateAction = (index: number, partial: Partial<QuickAction>) => {
+    const qa = quickActions[index]
+    if (!qa) return
+    const updated = [...quickActions]
+    updated[index] = { ...qa, ...partial }
+    onChange(updated)
   }
 
-  const removeAction = (id: string) => {
-    onChange(quickActions.filter((qa) => qa.id !== id))
-    if (expandedId === id) setExpandedId(null)
+  const removeAction = (index: number) => {
+    const updated = [...quickActions]
+    updated[index] = null
+    onChange(updated)
+    if (expandedIndex === index) setExpandedIndex(null)
   }
 
   return (
@@ -501,8 +508,23 @@ function QuickActionsTab({
       </div>
 
       <div className="flex flex-col gap-2">
-        {quickActions.map((qa) => {
-          const isExpanded = expandedId === qa.id
+        {quickActions.map((qa, index) => {
+          if (!qa) {
+            // Empty slot — show "Add" placeholder
+            return (
+              <button
+                key={`slot-${index}`}
+                type="button"
+                onClick={() => addActionAtSlot(index)}
+                className="flex items-center justify-center gap-1.5 px-3 py-2.5 text-xs font-medium text-kumo-subtle border border-dashed border-kumo-line rounded-lg hover:text-kumo-default hover:border-kumo-subtle hover:bg-kumo-fill/50 transition-colors"
+              >
+                <Plus size={12} />
+                Slot {index + 1} — Add Quick Action
+              </button>
+            )
+          }
+
+          const isExpanded = expandedIndex === index
           const IconComp = getIconComponent(qa.icon)
           const isValid = isQuickActionValid(qa)
 
@@ -513,9 +535,10 @@ function QuickActionsTab({
             >
               {/* Header with expand toggle + remove */}
               <div className="flex items-center gap-2.5 px-3 py-2.5 hover:bg-kumo-fill/50 transition-colors">
+                <span className="text-[10px] text-kumo-subtle font-mono shrink-0 w-3">{index + 1}</span>
                 <button
                   type="button"
-                  onClick={() => setExpandedId(isExpanded ? null : qa.id)}
+                  onClick={() => setExpandedIndex(isExpanded ? null : index)}
                   className="flex items-center gap-2.5 flex-1 min-w-0 text-left"
                 >
                   <IconComp size={14} className="text-kumo-subtle shrink-0" />
@@ -530,7 +553,7 @@ function QuickActionsTab({
                 </button>
                 <button
                   type="button"
-                  onClick={() => removeAction(qa.id)}
+                  onClick={() => removeAction(index)}
                   className="w-6 h-6 flex items-center justify-center rounded-md text-kumo-subtle hover:text-kumo-danger hover:bg-kumo-danger/10 transition-colors shrink-0"
                   title="Remove"
                 >
@@ -548,10 +571,10 @@ function QuickActionsTab({
                         Button Label
                       </label>
                       <input
-                        ref={autoFocusId === qa.id || expandedId === qa.id ? labelInputRef : undefined}
+                        ref={autoFocusIndex === index || expandedIndex === index ? labelInputRef : undefined}
                         type="text"
                         value={qa.label}
-                        onChange={(e) => updateAction(qa.id, { label: e.target.value })}
+                        onChange={(e) => updateAction(index, { label: e.target.value })}
                         maxLength={20}
                         placeholder="e.g. Create PR, Run Tests"
                         className={inputClasses}
@@ -568,7 +591,7 @@ function QuickActionsTab({
                             <button
                               key={opt.value}
                               type="button"
-                              onClick={() => updateAction(qa.id, { icon: opt.value })}
+                              onClick={() => updateAction(index, { icon: opt.value })}
                               title={opt.label}
                               className={`w-7 h-7 flex items-center justify-center rounded-md border transition-colors ${
                                 qa.icon === opt.value
@@ -587,7 +610,7 @@ function QuickActionsTab({
                   {/* Prompt with slash command autocomplete */}
                   <PromptTextarea
                     value={qa.prompt}
-                    onChange={(v) => updateAction(qa.id, { prompt: v })}
+                    onChange={(v) => updateAction(index, { prompt: v })}
                     commands={commands}
                     inputClasses={inputClasses}
                   />
@@ -597,17 +620,6 @@ function QuickActionsTab({
           )
         })}
       </div>
-
-      {quickActions.length < MAX_QUICK_ACTIONS && (
-        <button
-          type="button"
-          onClick={addAction}
-          className="flex items-center justify-center gap-1.5 px-3 py-2 text-xs font-medium text-kumo-subtle border border-dashed border-kumo-line rounded-lg hover:text-kumo-default hover:border-kumo-subtle hover:bg-kumo-fill/50 transition-colors"
-        >
-          <Plus size={12} />
-          Add Quick Action
-        </button>
-      )}
     </div>
   )
 }

--- a/src/renderer/src/data/settings.ts
+++ b/src/renderer/src/data/settings.ts
@@ -24,13 +24,17 @@ export interface QuickAction {
 
 export const MAX_QUICK_ACTIONS = 7
 
+// Fixed-length slots array: null entries represent empty slots.
+// This preserves button positions (e.g. slot 1 = command, slot 2 = empty, slot 3 = command).
+export type QuickActionSlots = (QuickAction | null)[]
+
 export interface AppSettings {
   model: string
   editor: string
   customEditorCommand: string
   terminal: string
   createPrPrompt: string
-  quickActions: QuickAction[]
+  quickActions: QuickActionSlots
   notifications: NotificationPrefs
   verboseMode: boolean
   soundEnabled: boolean
@@ -49,13 +53,17 @@ export const DEFAULT_CREATE_PR_PROMPT = `Prepare this work for review.
 
 Return the final PR URL or manual URL, plus a short note on what you committed.`
 
+export function emptySlots(): QuickActionSlots {
+  return Array.from({ length: MAX_QUICK_ACTIONS }, () => null)
+}
+
 export const DEFAULT_SETTINGS: AppSettings = {
   model: 'auto',
   editor: 'vscode',
   customEditorCommand: '',
   terminal: 'default',
   createPrPrompt: DEFAULT_CREATE_PR_PROMPT,
-  quickActions: [],
+  quickActions: emptySlots(),
   notifications: {
     needs_approval: true,
     needs_input: true,
@@ -73,11 +81,15 @@ export function loadSettings(): AppSettings {
 
     const parsed = JSON.parse(stored) as Partial<AppSettings>
 
-    // Quick actions: take up to MAX_QUICK_ACTIONS, default to empty.
-    // Existing users without quickActions simply get no custom buttons (PR is still static).
-    const quickActions = Array.isArray(parsed.quickActions)
-      ? parsed.quickActions.slice(0, MAX_QUICK_ACTIONS)
-      : []
+    // Quick actions: fixed-length slots array. Migrate old dense arrays and
+    // pad/trim to exactly MAX_QUICK_ACTIONS slots.
+    let quickActions: QuickActionSlots
+    if (Array.isArray(parsed.quickActions)) {
+      const raw = parsed.quickActions.slice(0, MAX_QUICK_ACTIONS)
+      quickActions = Array.from({ length: MAX_QUICK_ACTIONS }, (_, i) => raw[i] ?? null)
+    } else {
+      quickActions = emptySlots()
+    }
 
     return {
       ...DEFAULT_SETTINGS,

--- a/src/renderer/src/data/settings.ts
+++ b/src/renderer/src/data/settings.ts
@@ -24,8 +24,6 @@ export interface QuickAction {
 
 export const MAX_QUICK_ACTIONS = 7
 
-// Fixed-length slots array: null entries represent empty slots.
-// This preserves button positions (e.g. slot 1 = command, slot 2 = empty, slot 3 = command).
 export type QuickActionSlots = (QuickAction | null)[]
 
 export interface AppSettings {
@@ -54,7 +52,15 @@ export const DEFAULT_CREATE_PR_PROMPT = `Prepare this work for review.
 Return the final PR URL or manual URL, plus a short note on what you committed.`
 
 export function emptySlots(): QuickActionSlots {
-  return Array.from({ length: MAX_QUICK_ACTIONS }, () => null)
+  return new Array<QuickAction | null>(MAX_QUICK_ACTIONS).fill(null)
+}
+
+export function parseSlashCommand(text: string): { name: string; args: string } | null {
+  const trimmed = text.trim()
+  if (!trimmed.startsWith('/')) return null
+  const spaceIndex = trimmed.indexOf(' ')
+  if (spaceIndex === -1) return { name: trimmed.slice(1), args: '' }
+  return { name: trimmed.slice(1, spaceIndex), args: trimmed.slice(spaceIndex + 1).trim() }
 }
 
 export const DEFAULT_SETTINGS: AppSettings = {


### PR DESCRIPTION
## Fix dropdown menus clipped by overflow-x-auto on action rail

The action rail had overflow-x-auto which created an overflow context
that clipped dropdown menus opening upward. Replaced with flex-wrap
so buttons wrap to a second row when needed instead of scrolling,
and dropdowns can escape the container bounds.

## Use fixed-length slot array for quick actions to preserve positions

Quick actions are now stored as a fixed-length array where null entries
represent empty slots. This lets users configure e.g. slot 1 = command,
slot 2 = empty, slot 3 = command, and the positions are preserved in
both the settings UI and the action rail.

- QuickActionSlots type: (QuickAction | null)[]
- Settings tab shows all slots with numbered labels and add placeholders
- DetailDrawer renders each slot positionally (button or placeholder)
- Migrates old dense arrays by padding with nulls to MAX_QUICK_ACTIONS

## Simplify quick action code: extract shared helpers, remove duplication

- Extract parseSlashCommand() to settings.ts, replacing inline parsing
  in handleSendMessage and handleQuickActionForAgent
- Remove duplicate TabId type in SettingsModal (use exported SettingsTabId)
- Fix label input ref attaching to any expanded item instead of only
  the newly created one
- Replace nested ternary in action rail slot rendering with if/else
- Simplify emptySlots() to use Array.fill