### PR TITLE
Add searchable model dropdown, View menu with DevTools, and event debug logging

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -130,6 +130,20 @@ app.whenReady().then(async () => {
       ]
     },
     { role: 'editMenu' },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'reload' },
+        { role: 'forceReload' },
+        { role: 'toggleDevTools' },
+        { type: 'separator' },
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+      ]
+    },
     { role: 'windowMenu' },
   ]))
 

--- a/src/renderer/src/components/LaunchModal.tsx
+++ b/src/renderer/src/components/LaunchModal.tsx
@@ -754,6 +754,8 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
                     value={model}
                     onChange={(value) => setModel(value)}
                     options={modelOptions}
+                    searchable
+                    searchPlaceholder="Search models…"
                     buttonClassName={selectButtonClasses}
                     menuClassName={selectMenuClasses}
                   />
@@ -1040,6 +1042,8 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
                             value={model}
                             onChange={(value) => setModel(value)}
                             options={modelOptions}
+                            searchable
+                            searchPlaceholder="Search models…"
                             buttonClassName={selectButtonClasses}
                             menuClassName={selectMenuClasses}
                           />

--- a/src/renderer/src/components/SelectField.tsx
+++ b/src/renderer/src/components/SelectField.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { CaretDown, Check } from '@phosphor-icons/react'
+import { CaretDown, Check, MagnifyingGlass } from '@phosphor-icons/react'
 
 interface SelectOption {
   value: string
@@ -10,6 +10,8 @@ interface SelectFieldProps {
   value: string
   options: readonly SelectOption[]
   onChange: (value: string) => void
+  searchable?: boolean
+  searchPlaceholder?: string
   buttonClassName?: string
   menuClassName?: string
 }
@@ -18,15 +20,28 @@ export function SelectField({
   value,
   options,
   onChange,
+  searchable = false,
+  searchPlaceholder = 'Search…',
   buttonClassName,
   menuClassName
 }: SelectFieldProps) {
   const [isOpen, setIsOpen] = useState(false)
+  const [search, setSearch] = useState('')
   const containerRef = useRef<HTMLDivElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
 
   const selectedOption = useMemo(() => {
     return options.find((option) => option.value === value) ?? options[0]
   }, [options, value])
+
+  const filteredOptions = useMemo(() => {
+    if (!searchable || !search.trim()) return options
+    const query = search.toLowerCase()
+    return options.filter((option) =>
+      option.label.toLowerCase().includes(query) ||
+      option.value.toLowerCase().includes(query)
+    )
+  }, [options, searchable, search])
 
   useEffect(() => {
     if (!isOpen) return
@@ -52,6 +67,14 @@ export function SelectField({
     }
   }, [isOpen])
 
+  // Reset search and auto-focus when dropdown opens
+  useEffect(() => {
+    if (isOpen && searchable) {
+      setSearch('')
+      requestAnimationFrame(() => searchInputRef.current?.focus())
+    }
+  }, [isOpen, searchable])
+
   return (
     <div ref={containerRef} className="relative">
       <button
@@ -70,29 +93,49 @@ export function SelectField({
           role="listbox"
           className={menuClassName}
         >
-          {options.map((option) => {
-            const isSelected = option.value === value
-            return (
-              <button
-                key={option.value}
-                type="button"
-                role="option"
-                aria-selected={isSelected}
-                onClick={() => {
-                  onChange(option.value)
-                  setIsOpen(false)
-                }}
-                className={`flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm transition-colors ${
-                  isSelected
-                    ? 'bg-kumo-fill text-kumo-strong'
-                    : 'text-kumo-default hover:bg-kumo-fill'
-                }`}
-              >
-                <span className="truncate">{option.label}</span>
-                <Check size={14} className={isSelected ? 'text-kumo-brand' : 'invisible'} />
-              </button>
-            )
-          })}
+          {searchable && (
+            <div className="px-2 pt-2 pb-1">
+              <div className="relative">
+                <MagnifyingGlass size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-kumo-subtle" />
+                <input
+                  ref={searchInputRef}
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder={searchPlaceholder}
+                  className="w-full pl-7 pr-2.5 py-1.5 bg-kumo-control border border-kumo-line rounded-md text-xs text-kumo-default outline-none focus:border-kumo-ring placeholder:text-kumo-subtle"
+                  onKeyDown={(e) => e.stopPropagation()}
+                />
+              </div>
+            </div>
+          )}
+          {filteredOptions.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-kumo-subtle text-center">No matches</div>
+          ) : (
+            filteredOptions.map((option) => {
+              const isSelected = option.value === value
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  onClick={() => {
+                    onChange(option.value)
+                    setIsOpen(false)
+                  }}
+                  className={`flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm transition-colors ${
+                    isSelected
+                      ? 'bg-kumo-fill text-kumo-strong'
+                      : 'text-kumo-default hover:bg-kumo-fill'
+                  }`}
+                >
+                  <span className="truncate">{option.label}</span>
+                  <Check size={14} className={isSelected ? 'text-kumo-brand' : 'invisible'} />
+                </button>
+              )
+            })
+          )}
         </div>
       )}
     </div>

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -181,6 +181,8 @@ export function SettingsModal({ onClose, initialTab = 'general', commands = [] }
                     value={settings.model}
                     onChange={(value) => updateSettings({ model: value })}
                     options={modelOptions}
+                    searchable
+                    searchPlaceholder="Search models…"
                     buttonClassName={selectButtonClasses}
                     menuClassName={selectMenuClasses}
                   />

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -704,6 +704,15 @@ function processEvent(payload: OpenCodeEventPayload): void {
     logEvent(resolvedSessionId, type, props)
   }
 
+  // DEBUG: trace event delivery for new sessions
+  if (type === 'message.updated' || type === 'message.part.updated') {
+    const dbgSession = (props.info as Record<string, unknown>)?.sessionID ?? (props.part as Record<string, unknown>)?.sessionID
+    const hasAgent = !!findAgentBySession(dbgSession as string)
+    const hasMsgs = state.messages.has(dbgSession as string)
+    const msgCount = state.messages.get(dbgSession as string)?.length ?? 0
+    console.debug(`[processEvent] ${type} session=${(dbgSession as string)?.slice(-8)} agent=${hasAgent} msgs=${hasMsgs}(${msgCount})`)
+  }
+
   switch (type) {
     case 'session.status': {
       const sessionId = props.sessionID as string
@@ -1241,6 +1250,8 @@ function processEvent(payload: OpenCodeEventPayload): void {
 const RESUME_MESSAGE_LIMIT = 10
 
 function handleAgentLaunched(payload: AgentLaunchedPayload): void {
+  const existingMsgs = state.messages.get(payload.sessionId)
+  console.debug(`[handleAgentLaunched] id=${payload.id} session=${payload.sessionId.slice(-8)} existingMsgs=${existingMsgs?.length ?? 'none'} agentExists=${state.agents.has(payload.id)}`)
   upsertAgent(payload)
   emit({ agents: true })
 
@@ -1250,8 +1261,10 @@ function handleAgentLaunched(payload: AgentLaunchedPayload): void {
     void window.api.getMessages(payload.id).then((result) => {
       if (!result.ok || !result.data) return
       const entries = result.data as HistoricalSessionMessage[]
+      console.debug(`[handleAgentLaunched:hydrate] id=${payload.id} session=${payload.sessionId.slice(-8)} historicalMsgs=${entries?.length ?? 0} currentStoreMsgs=${state.messages.get(payload.sessionId)?.length ?? 0}`)
       if (!Array.isArray(entries) || entries.length === 0) return
       hydrateHistoricalMessages(entries.slice(-RESUME_MESSAGE_LIMIT))
+      console.debug(`[handleAgentLaunched:hydrate] after hydration storeMsgs=${state.messages.get(payload.sessionId)?.length ?? 0} parts=${state.messages.get(payload.sessionId)?.map(m => `${m.role}:${m.parts.length}`).join(',')}`)
       emit({ messages: true })
     })
 


### PR DESCRIPTION
Add searchable model dropdown, View menu with DevTools, and event debug logging

SelectField gains an opt-in searchable prop that adds a partial-match
filter input (matches against both label and value). Enabled on all
three model SelectFields (LaunchModal x2, SettingsModal).

Add a View menu to the app menu bar with Toggle Developer Tools,
reload, zoom controls, and fullscreen — DevTools were previously
inaccessible in production builds.

Add temporary debug logging to processEvent and handleAgentLaunched
to diagnose why new agent sessions show user messages but not
assistant replies.