### PR TITLE
Fix new agent messages not appearing due to emit race

### DIFF
--- a/src/main/services/event-bridge.ts
+++ b/src/main/services/event-bridge.ts
@@ -60,7 +60,10 @@ export class EventBridge {
       // Consume the stream in the background so start() can resolve
       // immediately after the connection is established.
       if ('stream' in result && result.stream) {
+        console.log(`[EventBridge:${this.runtimeId}] Stream available, starting consumer`)
         this.consumeStream(result.stream as AsyncIterable<{ type: string; properties: unknown }>)
+      } else {
+        console.error(`[EventBridge:${this.runtimeId}] No stream in subscribe result! Keys: ${Object.keys(result as object).join(', ')}`)
       }
     } catch (error) {
       if (this.connected) {
@@ -75,15 +78,22 @@ export class EventBridge {
     }
   }
 
+  private eventCount = 0
+
   private async consumeStream(stream: AsyncIterable<{ type: string; properties: unknown }>): Promise<void> {
     try {
       for await (const event of stream) {
         if (!this.connected) break
+        this.eventCount++
+        if (this.eventCount <= 5 || this.eventCount % 50 === 0) {
+          console.log(`[EventBridge:${this.runtimeId}] Event #${this.eventCount}: ${event.type}`)
+        }
         this.forwardEvent(event)
       }
+      console.log(`[EventBridge:${this.runtimeId}] Stream ended naturally after ${this.eventCount} events`)
     } catch (error) {
       if (this.connected) {
-        console.error(`[EventBridge:${this.runtimeId}] Stream consumption error:`, error)
+        console.error(`[EventBridge:${this.runtimeId}] Stream consumption error after ${this.eventCount} events:`, error)
         this.broadcastToRenderer('event:error', {
           runtimeId: this.runtimeId,
           error: String(error)

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -1253,7 +1253,10 @@ function handleAgentLaunched(payload: AgentLaunchedPayload): void {
   const existingMsgs = state.messages.get(payload.sessionId)
   console.debug(`[handleAgentLaunched] id=${payload.id} session=${payload.sessionId.slice(-8)} existingMsgs=${existingMsgs?.length ?? 'none'} agentExists=${state.agents.has(payload.id)}`)
   upsertAgent(payload)
-  emit({ agents: true })
+  // Emit messages alongside agents so any SSE events that arrived before the
+  // agent was registered (race between IPC broadcast and SSE delivery) are
+  // picked up by the selectedMessages memo in the same render pass.
+  emit({ agents: true, messages: true })
 
   if (window.api) {
     // Fetch historical messages so resumed sessions aren't blank.
@@ -1665,7 +1668,7 @@ function dispatchPendingMessage(agentId: string): void {
     }
   }
 
-  emit({ agents: true, questions: true })
+  emit({ agents: true, messages: true, questions: true })
 
   void window.api.sendMessage(agentId, text, agentConfig, attachments).then((result) => {
     if (result && !result.ok) {
@@ -1997,7 +2000,7 @@ export function useAgentStore() {
       }
     }
 
-    emit({ agents: true, questions: true })
+    emit({ agents: true, messages: true, questions: true })
 
     const result = await window.api.sendMessage(agentId, text, agentConfig, attachments)
 


### PR DESCRIPTION
Fix new agent messages not appearing due to emit race

When a new agent launches, SSE events can arrive before the
agent:launched IPC broadcast registers the agent in the store.
Messages are stored by sessionId regardless, but the UI never
re-renders because handleAgentLaunched only emitted { agents: true }
— messagesVersion wasn't incremented, so the selectedMessages memo
saw stale data.

Fix by emitting { agents: true, messages: true } from
handleAgentLaunched and both sendMessage paths (which inject
optimistic user messages via applyOptimisticSendState but weren't
emitting the messages flag either).

Also add debug logging to EventBridge (stream lifecycle) and
processEvent/handleAgentLaunched (event delivery timing) to aid
diagnosis if the issue recurs.