### PR TITLE
Reconnect SSE stream before sending prompts

### DIFF
--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -242,6 +242,10 @@ class AgentController {
 
     // Only send the initial prompt if one was provided
     if (prompt && prompt.trim()) {
+      // The server may have disposed between session.create and now
+      // (server.instance.disposed closes the SSE stream). Re-establish
+      // the stream before sending the prompt so response events aren't lost.
+      await handle.bridge.ensureStreaming()
       await client.session.promptAsync({
         sessionID: session.id,
         directory,
@@ -301,6 +305,7 @@ class AgentController {
     })
 
     if (prompt && prompt.trim()) {
+      await handle.bridge.ensureStreaming()
       await runtime.client.session.promptAsync({
         sessionID: session.id,
         directory: handle.directory,
@@ -353,6 +358,7 @@ class AgentController {
     const runtime = await this.ensureRuntimeForAgent(handle)
     runtimeManager.touchRuntimeActivity(runtime.id)
 
+    await handle.bridge.ensureStreaming()
     await runtime.client.session.promptAsync({
       sessionID: handle.sessionId,
       directory: handle.directory,
@@ -748,6 +754,7 @@ class AgentController {
     const runtime = await this.ensureRuntimeForAgent(handle)
     runtimeManager.touchRuntimeActivity(runtime.id)
 
+    await handle.bridge.ensureStreaming()
     await runtime.client.session.promptAsync({
       sessionID: handle.sessionId,
       directory: handle.directory,

--- a/src/main/services/event-bridge.ts
+++ b/src/main/services/event-bridge.ts
@@ -16,6 +16,7 @@ const MAX_RECONNECT_ATTEMPTS = 10
 export class EventBridge {
   private abortController: AbortController | null = null
   private connected = false
+  private streaming = false
   private isReconnecting = false
   private reconnectAttempts = 0
   private currentBackoff = INITIAL_BACKOFF_MS
@@ -45,6 +46,25 @@ export class EventBridge {
     await this.connectStream()
   }
 
+  /**
+   * Guarantee the SSE stream is alive before sending a prompt.
+   * If the server disposed and the stream ended, reconnect immediately
+   * and wait for it to be ready — otherwise the prompt's response
+   * events are lost.
+   */
+  async ensureStreaming(): Promise<void> {
+    if (this.streaming) return
+    if (!this.connected) {
+      await this.start()
+      return
+    }
+    console.log(`[EventBridge:${this.runtimeId}] Stream dead, reconnecting before prompt`)
+    this.isReconnecting = false
+    this.reconnectAttempts = 0
+    this.currentBackoff = INITIAL_BACKOFF_MS
+    await this.connectStream()
+  }
+
   private async connectStream(): Promise<void> {
     try {
       const result = await this.client.event.subscribe({
@@ -61,11 +81,14 @@ export class EventBridge {
       // immediately after the connection is established.
       if ('stream' in result && result.stream) {
         console.log(`[EventBridge:${this.runtimeId}] Stream available, starting consumer`)
+        this.streaming = true
         this.consumeStream(result.stream as AsyncIterable<{ type: string; properties: unknown }>)
       } else {
         console.error(`[EventBridge:${this.runtimeId}] No stream in subscribe result! Keys: ${Object.keys(result as object).join(', ')}`)
+        this.streaming = false
       }
     } catch (error) {
+      this.streaming = false
       if (this.connected) {
         console.error(`[EventBridge:${this.runtimeId}] Event stream error:`, error)
         this.broadcastToRenderer('event:error', {
@@ -90,8 +113,16 @@ export class EventBridge {
         }
         this.forwardEvent(event)
       }
-      console.log(`[EventBridge:${this.runtimeId}] Stream ended naturally after ${this.eventCount} events`)
+      this.streaming = false
+      // The server closed the SSE stream (e.g. server.instance.disposed).
+      // Reconnect so events from subsequent prompts aren't lost.
+      if (this.connected) {
+        console.log(`[EventBridge:${this.runtimeId}] Stream ended after ${this.eventCount} events, reconnecting`)
+        this.eventCount = 0
+        this.scheduleReconnect()
+      }
     } catch (error) {
+      this.streaming = false
       if (this.connected) {
         console.error(`[EventBridge:${this.runtimeId}] Stream consumption error after ${this.eventCount} events:`, error)
         this.broadcastToRenderer('event:error', {
@@ -149,6 +180,7 @@ export class EventBridge {
 
   stop(): void {
     this.connected = false
+    this.streaming = false
     this.isReconnecting = false
     this.reconnectAttempts = 0
     this.currentBackoff = INITIAL_BACKOFF_MS


### PR DESCRIPTION
Reconnect SSE stream before sending prompts

The OpenCode server can emit server.instance.disposed and close the
SSE stream between session.create and promptAsync. When this happens
the bridge's consumeStream exits silently and all response events
are lost — the agent appears stuck with only the user's message.

Add EventBridge.ensureStreaming() which verifies the stream is alive
and reconnects synchronously if it died. Called before every
promptAsync in launchAgent, sendMessage, sendMessageWithModel, and
resetSession.

Also auto-reconnect via scheduleReconnect when the stream ends
naturally, so the bridge recovers even without an immediate prompt.