### PR TITLE
Fix unknown slash commands erroring and multiline arrow key history

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -792,9 +792,11 @@ export function App() {
       const handled = await handleBuiltInCommand(selectedAgentId, parsed.name, parsed.args)
       if (handled) return
 
-      // Not a built-in — try the runtime directly (custom slash commands, skills)
-      await storeExecuteCommand(selectedAgentId, parsed.name, parsed.args)
-      return
+      // Not a built-in — unknown commands fall through as plain messages
+      if (agentCommands.some((cmd) => cmd.command === `/${parsed.name}`)) {
+        await storeExecuteCommand(selectedAgentId, parsed.name, parsed.args)
+        return
+      }
     }
 
     // Check for @agentname mentions — extract agent name and strip from text
@@ -810,7 +812,7 @@ export function App() {
     }
 
     await storeSendMessage(selectedAgentId, text, undefined, attachments)
-  }, [agentConfigs, handleBuiltInCommand, selectedAgentId, selectedQuestion, storeSendMessage, storeExecuteCommand, storeReplyToQuestion, storeResetSession])
+  }, [agentCommands, agentConfigs, handleBuiltInCommand, selectedAgentId, selectedQuestion, storeSendMessage, storeExecuteCommand, storeReplyToQuestion, storeResetSession])
 
   const handleApprove = useCallback(async (permissionId: string) => {
     if (!selectedAgentId) return

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -536,16 +536,16 @@ export const DetailDrawer = memo(function DetailDrawer({
     }
 
     // ── Input history cycling (ArrowUp/ArrowDown) ──
-    // Only activates on single-line input, or when cursor is at the boundary.
     const history = inputHistories.get(agent.id)
     if (history && history.length > 0) {
       const textarea = event.currentTarget as HTMLTextAreaElement
-      const singleLine = !textarea.value.includes('\n')
-      const atStart = textarea.selectionStart === 0 && textarea.selectionEnd === 0
-      const atEnd = textarea.selectionStart === textarea.value.length && textarea.selectionEnd === textarea.value.length
+      const { value, selectionStart, selectionEnd } = textarea
+      const noSelection = selectionStart === selectionEnd
+      const onFirstLine = noSelection && !value.slice(0, selectionStart).includes('\n')
+      const onLastLine = noSelection && !value.slice(selectionEnd).includes('\n')
       const fromEnd = (i: number) => history[history.length - 1 - i]
 
-      if (event.key === 'ArrowUp' && (singleLine || atStart)) {
+      if (event.key === 'ArrowUp' && onFirstLine) {
         const next = historyIndexRef.current + 1
         if (next < history.length) {
           event.preventDefault()
@@ -556,7 +556,7 @@ export const DetailDrawer = memo(function DetailDrawer({
         return
       }
 
-      if (event.key === 'ArrowDown' && (singleLine || atEnd) && historyIndexRef.current >= 0) {
+      if (event.key === 'ArrowDown' && onLastLine && historyIndexRef.current >= 0) {
         event.preventDefault()
         historyIndexRef.current -= 1
         setInputText(historyIndexRef.current < 0 ? savedDraftRef.current : fromEnd(historyIndexRef.current))


### PR DESCRIPTION
Two bugs fixed.

Typing an unknown slash command would error on the runtime. Now
unknown commands fall through and get sent as a plain message instead.
The check uses the already loaded `agentCommands` list to decide
whether to route through `executeCommand` or `sendMessage`.

Pressing ArrowUp in a multiline textarea would jump to input history
even when the cursor was on the second line or below. Now ArrowUp
only triggers history cycling when the cursor sits on the first line,
and ArrowDown only triggers it on the last line. Normal textarea
line navigation works everywhere else.