### PR TITLE
Jump to last user message when clicking the Last Message cell

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useCallback, useEffect } from 'react'
 import { TopBar } from './components/TopBar'
 import { InterruptBanner } from './components/InterruptBanner'
 import { FilterBar, matchesFilter, EMPTY_FILTER, cycleFilter, loadPersistedFilter, persistFilter, loadPersistedSearch, persistSearch, type FilterState, type StatusFilter } from './components/FilterBar'
-import { FleetTable } from './components/FleetTable'
+import { FleetTable, type DrawerScrollTarget } from './components/FleetTable'
 import { StatusBar } from './components/StatusBar'
 import { DetailDrawer, type ChatCommand } from './components/DetailDrawer'
 import { LaunchModal, type FreshWorktreeConfig, type ImportSessionConfig } from './components/LaunchModal'
@@ -69,7 +69,16 @@ export function App() {
     persistSearch(value)
   }, [])
 
-  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
+  const [selectedAgentId, setSelectedAgentIdRaw] = useState<string | null>(null)
+  // Scroll request signal for DetailDrawer. `seq` bumps on every request so
+  // clicking the same cell twice in a row still retriggers the scroll.
+  const [drawerScrollRequest, setDrawerScrollRequest] = useState<{ target: DrawerScrollTarget; seq: number } | null>(null)
+  const setSelectedAgentId = useCallback((id: string | null, scrollTarget?: DrawerScrollTarget) => {
+    setSelectedAgentIdRaw(id)
+    if (id && scrollTarget) {
+      setDrawerScrollRequest((prev) => ({ target: scrollTarget, seq: (prev?.seq ?? 0) + 1 }))
+    }
+  }, [])
   const [showLaunchModal, setShowLaunchModal] = useState(false)
   const [showSettings, setShowSettings] = useState(false)
   const [settingsTab, setSettingsTab] = useState<SettingsTabId>('general')
@@ -1404,6 +1413,7 @@ export function App() {
           events={selectedEvents}
           commands={agentCommands}
           agentConfigs={agentConfigs}
+          scrollRequest={drawerScrollRequest}
           onClose={handleCloseDrawer}
           onSendMessage={handleSendMessage}
           onApprove={selectedPermission ? handleDrawerApprove : undefined}

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -121,6 +121,12 @@ interface DetailDrawerProps {
   commands?: ChatCommand[]
   agentConfigs?: AgentConfigItem[]
   sessionNotice?: string
+  /**
+   * When set, jumps the transcript to a specific anchor. `seq` must bump for
+   * each request so repeated clicks retrigger the scroll even when the target
+   * is unchanged.
+   */
+  scrollRequest?: { target: 'last-user-message'; seq: number } | null
   onClose: () => void
   onSendMessage?: (text: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>) => void
   onApprove?: () => void
@@ -154,6 +160,7 @@ export const DetailDrawer = memo(function DetailDrawer({
   commands = [],
   agentConfigs = [],
   sessionNotice,
+  scrollRequest,
   onClose,
   onSendMessage,
   onApprove,
@@ -244,6 +251,14 @@ export const DetailDrawer = memo(function DetailDrawer({
   const followBottomRef = useRef(true)
   const isResizingRef = useRef(false)
   const isResizingVerticalRef = useRef(false)
+
+  // Map of message id -> DOM node for scroll-to-message. Populated by
+  // MessageBubble via registerRef callback.
+  const messageNodesRef = useRef<Map<string, HTMLElement>>(new Map())
+  const registerMessageRef = useCallback((id: string, node: HTMLElement | null) => {
+    if (node) messageNodesRef.current.set(id, node)
+    else messageNodesRef.current.delete(id)
+  }, [])
 
   const handleResizeStart = useCallback((event: React.MouseEvent) => {
     event.preventDefault()
@@ -436,6 +451,45 @@ export const DetailDrawer = memo(function DetailDrawer({
       container.removeEventListener('keydown', onKeyDown)
     }
   }, [activeTab])
+
+  // Scroll-to-target: react to scrollRequest.seq changes. Triggered when the
+  // user clicks the "Last Message" cell in the fleet table.
+  const lastHandledScrollSeqRef = useRef<number>(-1)
+  useEffect(() => {
+    if (!scrollRequest) return
+    if (scrollRequest.seq === lastHandledScrollSeqRef.current) return
+    lastHandledScrollSeqRef.current = scrollRequest.seq
+
+    if (scrollRequest.target !== 'last-user-message') return
+
+    let targetIndex = -1
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'user') {
+        targetIndex = i
+        break
+      }
+    }
+    if (targetIndex < 0) return
+    const targetId = messages[targetIndex].id
+
+    if (activeTab !== 'transcript') setActiveTab('transcript')
+
+    // Expand the visible window if the target is outside it so the node renders.
+    const neededCount = messages.length - targetIndex
+    if (neededCount > visibleMessageCount) {
+      setVisibleMessageCount(neededCount)
+    }
+
+    // Two rAFs: first waits for setActiveTab / setVisibleMessageCount to
+    // commit, second waits for the tab-switch effect's own rAF to run so
+    // our followBottom=false wins (otherwise streaming output would yank us
+    // back to the bottom immediately after jumping).
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      followBottomRef.current = false
+      setShowJumpToLatest(true)
+      messageNodesRef.current.get(targetId)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }))
+  }, [scrollRequest, messages, activeTab, visibleMessageCount])
 
   const handleInputChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setInputText(event.target.value)
@@ -711,7 +765,12 @@ export const DetailDrawer = memo(function DetailDrawer({
                       </button>
                     )}
                     {visibleMessages.map((message) => (
-                      <MessageBubble key={message.id} message={message} verbose={isVerbose} />
+                      <MessageBubble
+                        key={message.id}
+                        message={message}
+                        verbose={isVerbose}
+                        registerRef={registerMessageRef}
+                      />
                     ))}
                   </>
                 )}
@@ -1289,16 +1348,30 @@ function Tab({
   )
 }
 
-const MessageBubble = memo(function MessageBubble({ message, verbose = false }: { message: Message; verbose?: boolean }) {
+type MessageRefCallback = (id: string, node: HTMLElement | null) => void
+
+const MessageBubble = memo(function MessageBubble({
+  message,
+  verbose = false,
+  registerRef
+}: {
+  message: Message
+  verbose?: boolean
+  registerRef?: MessageRefCallback
+}) {
+  const rootRef = useCallback((node: HTMLElement | null) => {
+    registerRef?.(message.id, node)
+  }, [message.id, registerRef])
+
   if (message.role === 'tool-group') {
-    return <ToolGroupBubble message={message} verbose={verbose} />
+    return <ToolGroupBubble message={message} verbose={verbose} rootRef={rootRef} />
   }
 
   if (message.role === 'tool') {
     const toolName = message.toolName ?? extractToolName(message.content)
     const toolOutput = message.content ? extractToolOutput(message.content) : ''
     return (
-      <div className="font-mono text-[11px] px-2.5 py-1.5 bg-kumo-overlay border-l-2 border-kumo-fill-hover rounded-r-md text-kumo-subtle">
+      <div ref={rootRef} className="font-mono text-[11px] px-2.5 py-1.5 bg-kumo-overlay border-l-2 border-kumo-fill-hover rounded-r-md text-kumo-subtle">
         <div className="flex items-center gap-1.5 mb-0.5">
           <Wrench size={11} className="shrink-0" />
           <span className="font-semibold text-kumo-default">{toolName}</span>
@@ -1315,6 +1388,7 @@ const MessageBubble = memo(function MessageBubble({ message, verbose = false }: 
 
   return (
     <div
+      ref={rootRef}
       className={`px-3 py-2.5 rounded-lg text-[13px] leading-relaxed ${
         isUser
           ? 'bg-kumo-interact/10 border border-kumo-interact/15 text-kumo-default self-end max-w-[85%]'
@@ -1355,7 +1429,8 @@ const MessageBubble = memo(function MessageBubble({ message, verbose = false }: 
   prev.message.content === next.message.content &&
   prev.message.role === next.message.role &&
   prev.message.toolCalls === next.message.toolCalls &&
-  prev.verbose === next.verbose
+  prev.verbose === next.verbose &&
+  prev.registerRef === next.registerRef
 )
 
 const toolStateStyles: Record<string, string> = {
@@ -1427,7 +1502,15 @@ function summarizeToolInput(name: string, input: string | undefined): string | u
   }
 }
 
-const ToolGroupBubble = memo(function ToolGroupBubble({ message, verbose = false }: { message: Message; verbose?: boolean }) {
+const ToolGroupBubble = memo(function ToolGroupBubble({
+  message,
+  verbose = false,
+  rootRef
+}: {
+  message: Message
+  verbose?: boolean
+  rootRef?: (node: HTMLElement | null) => void
+}) {
   const [expanded, setExpanded] = useState(verbose)
   const toolCalls = message.toolCalls ?? []
 
@@ -1437,7 +1520,7 @@ const ToolGroupBubble = memo(function ToolGroupBubble({ message, verbose = false
   }, [verbose])
 
   return (
-    <div className="max-w-[95%] self-start">
+    <div ref={rootRef} className="max-w-[95%] self-start">
       <button
         onClick={() => setExpanded((prev) => !prev)}
         className="inline-flex items-center gap-2 rounded-lg border border-kumo-line bg-kumo-overlay px-3 py-2 text-left hover:bg-kumo-fill transition-colors"

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -47,10 +47,12 @@ const quickActionIconMap: Record<QuickActionIcon, typeof Lightning> = {
   'wrench': Wrench,
 }
 
+export type DrawerScrollTarget = 'last-user-message'
+
 interface FleetTableProps {
   agents: AgentRuntime[]
   selectedId: string | null
-  onSelect: (id: string) => void
+  onSelect: (id: string, scrollTarget?: DrawerScrollTarget) => void
   sortColumn?: ColumnKey | null
   sortDirection?: SortDirection
   onSort?: (column: string, direction: 'asc' | 'desc') => void
@@ -370,6 +372,7 @@ export function FleetTable({
                 selected={agent.id === selectedId}
                 visibleColumns={visibleColumns}
                 onSelect={() => onSelect(agent.id)}
+                onSelectLastMessage={() => onSelect(agent.id, 'last-user-message')}
                 onContextMenu={(event) => handleContextMenu(event, agent.id)}
                 onApprove={onApprove ? () => onApprove(agent.id) : undefined}
                 onReply={onReply ? () => onReply(agent.id) : undefined}
@@ -679,6 +682,7 @@ function AgentRow({
   selected,
   visibleColumns,
   onSelect,
+  onSelectLastMessage,
   onContextMenu,
   onApprove,
   onReply,
@@ -706,6 +710,7 @@ function AgentRow({
   selected: boolean
   visibleColumns: Set<ColumnKey>
   onSelect: () => void
+  onSelectLastMessage: () => void
   onContextMenu: (event: React.MouseEvent) => void
   onApprove?: () => void
   onReply?: () => void
@@ -838,7 +843,11 @@ function AgentRow({
         </td>
       )}
       {show('lastMessage') && (
-        <td className="px-3 py-2 truncate text-kumo-subtle text-[11px]" title={agent.lastMessage || undefined}>
+        <td
+          className="px-3 py-2 truncate text-kumo-subtle text-[11px] cursor-pointer hover:text-kumo-default"
+          title={agent.lastMessage ? `${agent.lastMessage}\n\nClick to jump to your last message` : undefined}
+          onClick={(event) => { event.stopPropagation(); onSelectLastMessage() }}
+        >
           {agent.lastMessage || <span className="text-kumo-muted italic">--</span>}
         </td>
       )}


### PR DESCRIPTION
Clicking the Last Message cell in the fleet table now opens the drawer and scrolls to the most recent user message, so you can review your prompt without hunting for it. Auto-follow is disabled on jump so streaming output doesn't yank you back to the bottom; the Jump to latest button re-engages it.

The cell also gets a pointer cursor and hover style so the action is discoverable.