### PR TITLE
Surface compaction and context-overflow state in the UI

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -16,6 +16,39 @@ interface Attachment {
 }
 
 /**
+ * Log an IPC handler error with rich details.
+ *
+ * Node's default formatting of Error objects shows name/message/stack, but SDK
+ * errors from @opencode-ai/sdk often stash useful context on `.cause`,
+ * `.response.data`, or `.body` which isn't printed. Surface those too so the
+ * `npm run dev` terminal contains everything needed to diagnose the failure.
+ */
+function logIpcError(channel: string, error: unknown, context?: Record<string, unknown>): void {
+  const err = error as (Error & {
+    cause?: unknown
+    status?: number
+    statusText?: string
+    body?: unknown
+    response?: { status?: number; statusText?: string; data?: unknown }
+  }) | null | undefined
+
+  const details: Record<string, unknown> = {}
+  if (context) Object.assign(details, context)
+  if (err?.name) details.name = err.name
+  if (err?.message) details.message = err.message
+  const status = err?.status ?? err?.response?.status
+  if (status !== undefined) details.status = status
+  const statusText = err?.statusText ?? err?.response?.statusText
+  if (statusText !== undefined) details.statusText = statusText
+  const body = err?.body ?? err?.response?.data
+  if (body !== undefined) details.body = body
+  if (err?.cause !== undefined) details.cause = err.cause
+
+  console.error(`[IPC] ${channel} failed:`, details)
+  if (err?.stack) console.error(err.stack)
+}
+
+/**
  * Register all IPC handlers for renderer <-> main communication.
  */
 export function registerIpcHandlers(): void {
@@ -46,7 +79,7 @@ export function registerIpcHandlers(): void {
         }
       }
     } catch (error) {
-      console.error('[IPC] agent:launch failed:', error)
+      logIpcError('agent:launch', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -56,7 +89,7 @@ export function registerIpcHandlers(): void {
       await agentController.sendMessage(agentId, text, agent, attachments)
       return { ok: true }
     } catch (error) {
-      console.error('[IPC] agent:send-message failed:', error)
+      logIpcError('agent:send-message', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -66,7 +99,7 @@ export function registerIpcHandlers(): void {
       await agentController.respondToPermission(agentId, permissionId, response)
       return { ok: true }
     } catch (error) {
-      console.error('[IPC] agent:respond-permission failed:', error)
+      logIpcError('agent:respond-permission', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -76,7 +109,7 @@ export function registerIpcHandlers(): void {
       await agentController.replyToQuestion(agentId, requestId, answers)
       return { ok: true }
     } catch (error) {
-      console.error('[IPC] agent:reply-question failed:', error)
+      logIpcError('agent:reply-question', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -86,7 +119,7 @@ export function registerIpcHandlers(): void {
       await agentController.rejectQuestion(agentId, requestId)
       return { ok: true }
     } catch (error) {
-      console.error('[IPC] agent:reject-question failed:', error)
+      logIpcError('agent:reject-question', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -96,7 +129,7 @@ export function registerIpcHandlers(): void {
       const questions = await agentController.getAllPendingQuestions()
       return { ok: true, data: questions }
     } catch (error) {
-      console.error('[IPC] agent:list-questions failed:', error)
+      logIpcError('agent:list-questions', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -106,7 +139,7 @@ export function registerIpcHandlers(): void {
       const permissions = await agentController.getAllPendingPermissions()
       return { ok: true, data: permissions }
     } catch (error) {
-      console.error('[IPC] agent:list-permissions failed:', error)
+      logIpcError('agent:list-permissions', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -116,7 +149,7 @@ export function registerIpcHandlers(): void {
       await agentController.abortAgent(agentId)
       return { ok: true }
     } catch (error) {
-      console.error('[IPC] agent:abort failed:', error)
+      logIpcError('agent:abort', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -126,7 +159,7 @@ export function registerIpcHandlers(): void {
       await agentController.removeAgent(agentId)
       return { ok: true }
     } catch (error) {
-      console.error('[IPC] agent:remove failed:', error)
+      logIpcError('agent:remove', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -145,7 +178,7 @@ export function registerIpcHandlers(): void {
         }
       }
     } catch (error) {
-      console.error('[IPC] agent:reset-session failed:', error)
+      logIpcError('agent:reset-session', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -155,7 +188,7 @@ export function registerIpcHandlers(): void {
       const commands = await agentController.listCommands(agentId)
       return { ok: true, data: commands }
     } catch (error) {
-      console.error('[IPC] agent:list-commands failed:', error)
+      logIpcError('agent:list-commands', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -165,7 +198,7 @@ export function registerIpcHandlers(): void {
       const result = await agentController.executeCommand(agentId, command, args)
       return { ok: true, data: result }
     } catch (error) {
-      console.error('[IPC] agent:execute-command failed:', error)
+      logIpcError('agent:execute-command', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -175,7 +208,7 @@ export function registerIpcHandlers(): void {
       const config = await agentController.getConfig(agentId)
       return { ok: true, data: config }
     } catch (error) {
-      console.error('[IPC] agent:get-config failed:', error)
+      logIpcError('agent:get-config', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -185,7 +218,7 @@ export function registerIpcHandlers(): void {
       const result = await agentController.updateConfig(agentId, config)
       return { ok: true, data: result }
     } catch (error) {
-      console.error('[IPC] agent:update-config failed:', error)
+      logIpcError('agent:update-config', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -195,7 +228,7 @@ export function registerIpcHandlers(): void {
       const providers = await agentController.getProviders(agentId)
       return { ok: true, data: providers }
     } catch (error) {
-      console.error('[IPC] agent:get-providers failed:', error)
+      logIpcError('agent:get-providers', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -205,7 +238,7 @@ export function registerIpcHandlers(): void {
       const status = await agentController.getMcpStatus(agentId)
       return { ok: true, data: status }
     } catch (error) {
-      console.error('[IPC] agent:mcp-status failed:', error)
+      logIpcError('agent:mcp-status', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -215,7 +248,7 @@ export function registerIpcHandlers(): void {
       const result = await agentController.connectMcp(agentId, name)
       return { ok: true, data: result }
     } catch (error) {
-      console.error('[IPC] agent:mcp-connect failed:', error)
+      logIpcError('agent:mcp-connect', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -225,17 +258,19 @@ export function registerIpcHandlers(): void {
       const result = await agentController.disconnectMcp(agentId, name)
       return { ok: true, data: result }
     } catch (error) {
-      console.error('[IPC] agent:mcp-disconnect failed:', error)
+      logIpcError('agent:mcp-disconnect', error)
       return { ok: false, error: String(error) }
     }
   })
 
   ipcMain.handle('agent:compact', async (_event, agentId: string) => {
+    console.log('[IPC] agent:compact called', { agentId })
     try {
       const result = await agentController.compactSession(agentId)
+      console.log('[IPC] agent:compact succeeded', { agentId })
       return { ok: true, data: result }
     } catch (error) {
-      console.error('[IPC] agent:compact failed:', error)
+      logIpcError('agent:compact', error, { agentId })
       return { ok: false, error: String(error) }
     }
   })
@@ -245,7 +280,7 @@ export function registerIpcHandlers(): void {
       const result = await agentController.shareSession(agentId)
       return { ok: true, data: result }
     } catch (error) {
-      console.error('[IPC] agent:share failed:', error)
+      logIpcError('agent:share', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -255,7 +290,7 @@ export function registerIpcHandlers(): void {
       const agents = await agentController.listAgentConfigs(agentId)
       return { ok: true, data: agents }
     } catch (error) {
-      console.error('[IPC] agent:list-agent-configs failed:', error)
+      logIpcError('agent:list-agent-configs', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -265,7 +300,7 @@ export function registerIpcHandlers(): void {
       const tools = await agentController.listTools(agentId)
       return { ok: true, data: tools }
     } catch (error) {
-      console.error('[IPC] agent:list-tools failed:', error)
+      logIpcError('agent:list-tools', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -275,7 +310,7 @@ export function registerIpcHandlers(): void {
       await agentController.sendMessageWithModel(agentId, text, providerID, modelID, attachments)
       return { ok: true }
     } catch (error) {
-      console.error('[IPC] agent:send-message-with-model failed:', error)
+      logIpcError('agent:send-message-with-model', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -285,7 +320,7 @@ export function registerIpcHandlers(): void {
       const messages = await agentController.getMessages(agentId)
       return { ok: true, data: messages }
     } catch (error) {
-      console.error('[IPC] agent:get-messages failed:', error)
+      logIpcError('agent:get-messages', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -295,7 +330,7 @@ export function registerIpcHandlers(): void {
       const sessions = await agentController.listSessions(directory)
       return { ok: true, data: sessions }
     } catch (error) {
-      console.error('[IPC] session:list failed:', error)
+      logIpcError('session:list', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -305,7 +340,7 @@ export function registerIpcHandlers(): void {
       const sessions = await agentController.listSessionsByProject(projectDirectory)
       return { ok: true, data: sessions }
     } catch (error) {
-      console.error('[IPC] session:list-by-project failed:', error)
+      logIpcError('session:list-by-project', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -318,7 +353,7 @@ export function registerIpcHandlers(): void {
       const result = await agentController.forkSession(options)
       return { ok: true, data: result }
     } catch (error) {
-      console.error('[IPC] session:fork failed:', error)
+      logIpcError('session:fork', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -346,7 +381,7 @@ export function registerIpcHandlers(): void {
         }
       }
     } catch (error) {
-      console.error('[IPC] agent:resume failed:', error)
+      logIpcError('agent:resume', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -384,7 +419,7 @@ export function registerIpcHandlers(): void {
       agentController.updateAgentMeta(agentId, meta)
       return { ok: true }
     } catch (error) {
-      console.error('[IPC] agent:update-meta failed:', error)
+      logIpcError('agent:update-meta', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -394,7 +429,7 @@ export function registerIpcHandlers(): void {
       const statuses = await agentController.getSessionStatuses()
       return { ok: true, data: statuses }
     } catch (error) {
-      console.error('[IPC] agent:statuses failed:', error)
+      logIpcError('agent:statuses', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -427,7 +462,7 @@ export function registerIpcHandlers(): void {
       const data = await agentController.getProvidersFromAnyRuntime()
       return { ok: true, data }
     } catch (error) {
-      console.error('[IPC] runtime:providers failed:', error)
+      logIpcError('runtime:providers', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -437,7 +472,7 @@ export function registerIpcHandlers(): void {
       const data = await agentController.listCommandsFromAnyRuntime()
       return { ok: true, data }
     } catch (error) {
-      console.error('[IPC] runtime:commands failed:', error)
+      logIpcError('runtime:commands', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -447,7 +482,7 @@ export function registerIpcHandlers(): void {
       const data = await agentController.listAgentConfigsFromAnyRuntime()
       return { ok: true, data }
     } catch (error) {
-      console.error('[IPC] runtime:agent-configs failed:', error)
+      logIpcError('runtime:agent-configs', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -457,7 +492,7 @@ export function registerIpcHandlers(): void {
       const data = await agentController.getConfigFromAnyRuntime()
       return { ok: true, data }
     } catch (error) {
-      console.error('[IPC] runtime:config failed:', error)
+      logIpcError('runtime:config', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -484,7 +519,7 @@ export function registerIpcHandlers(): void {
       const isRepo = workspaceManager.isGitRepo(directory)
       return { ok: true, data: isRepo }
     } catch (error) {
-      console.error('[IPC] workspace:validate-git failed:', error)
+      logIpcError('workspace:validate-git', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -494,7 +529,7 @@ export function registerIpcHandlers(): void {
       const root = workspaceManager.getWorktreeRoot()
       return { ok: true, data: root }
     } catch (error) {
-      console.error('[IPC] workspace:root failed:', error)
+      logIpcError('workspace:root', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -504,7 +539,7 @@ export function registerIpcHandlers(): void {
       const repoRoot = workspaceManager.getRepoRoot(directory)
       return { ok: true, data: repoRoot }
     } catch (error) {
-      console.error('[IPC] workspace:repo-root failed:', error)
+      logIpcError('workspace:repo-root', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -514,7 +549,7 @@ export function registerIpcHandlers(): void {
       const repoRoot = await workspaceManager.getCommonRepoRoot(directory)
       return { ok: true, data: repoRoot }
     } catch (error) {
-      console.error('[IPC] workspace:common-repo-root failed:', error)
+      logIpcError('workspace:common-repo-root', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -528,7 +563,7 @@ export function registerIpcHandlers(): void {
       const result = workspaceManager.createWorktree(options.repoRoot, options.projectSlug, options.taskSlug)
       return { ok: true, data: result }
     } catch (error) {
-      console.error('[IPC] workspace:create failed:', error)
+      logIpcError('workspace:create', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -543,7 +578,7 @@ export function registerIpcHandlers(): void {
       const result = workspaceManager.createFreshWorktree(options.repoRoot, options.projectSlug, options.taskSlug, options.baseRef)
       return { ok: true, data: result }
     } catch (error) {
-      console.error('[IPC] workspace:create-fresh failed:', error)
+      logIpcError('workspace:create-fresh', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -553,7 +588,7 @@ export function registerIpcHandlers(): void {
       const branch = workspaceManager.getDefaultBranch(repoRoot)
       return { ok: true, data: branch }
     } catch (error) {
-      console.error('[IPC] workspace:default-branch failed:', error)
+      logIpcError('workspace:default-branch', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -566,7 +601,7 @@ export function registerIpcHandlers(): void {
       await workspaceManager.removeWorktree(options.repoRoot, options.worktreePath)
       return { ok: true }
     } catch (error) {
-      console.error('[IPC] workspace:remove failed:', error)
+      logIpcError('workspace:remove', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -576,7 +611,7 @@ export function registerIpcHandlers(): void {
       const worktrees = workspaceManager.listWorktrees(repoRoot)
       return { ok: true, data: worktrees }
     } catch (error) {
-      console.error('[IPC] workspace:list failed:', error)
+      logIpcError('workspace:list', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -586,7 +621,7 @@ export function registerIpcHandlers(): void {
       const status = workspaceManager.getWorktreeStatus(worktreePath)
       return { ok: true, data: status }
     } catch (error) {
-      console.error('[IPC] workspace:status failed:', error)
+      logIpcError('workspace:status', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -598,7 +633,7 @@ export function registerIpcHandlers(): void {
       const projects = database.getAllProjects()
       return { ok: true, data: projects }
     } catch (error) {
-      console.error('[IPC] db:projects:list failed:', error)
+      logIpcError('db:projects:list', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -611,7 +646,7 @@ export function registerIpcHandlers(): void {
       const project = database.createProject(options.name, options.repoRoot)
       return { ok: true, data: project }
     } catch (error) {
-      console.error('[IPC] db:projects:create failed:', error)
+      logIpcError('db:projects:create', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -624,7 +659,7 @@ export function registerIpcHandlers(): void {
       const project = database.ensureProject(options.name, options.repoRoot)
       return { ok: true, data: project }
     } catch (error) {
-      console.error('[IPC] db:projects:ensure failed:', error)
+      logIpcError('db:projects:ensure', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -634,7 +669,7 @@ export function registerIpcHandlers(): void {
       const deleted = database.deleteProject(projectId)
       return { ok: true, data: deleted }
     } catch (error) {
-      console.error('[IPC] db:projects:delete failed:', error)
+      logIpcError('db:projects:delete', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -650,7 +685,7 @@ export function registerIpcHandlers(): void {
       }
       return { ok: true, data: project }
     } catch (error) {
-      console.error('[IPC] db:projects:update-settings failed:', error)
+      logIpcError('db:projects:update-settings', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -662,7 +697,7 @@ export function registerIpcHandlers(): void {
       const value = database.getPreference(key)
       return { ok: true, data: value }
     } catch (error) {
-      console.error('[IPC] db:preferences:get failed:', error)
+      logIpcError('db:preferences:get', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -672,7 +707,7 @@ export function registerIpcHandlers(): void {
       database.setPreference(key, value)
       return { ok: true }
     } catch (error) {
-      console.error('[IPC] db:preferences:set failed:', error)
+      logIpcError('db:preferences:set', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -684,7 +719,7 @@ export function registerIpcHandlers(): void {
       const labels = database.getAllCustomLabels()
       return { ok: true, data: labels }
     } catch (error) {
-      console.error('[IPC] db:labels:list failed:', error)
+      logIpcError('db:labels:list', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -694,7 +729,7 @@ export function registerIpcHandlers(): void {
       const label = database.createCustomLabel(options.id, options.name, options.colorKey)
       return { ok: true, data: label }
     } catch (error) {
-      console.error('[IPC] db:labels:create failed:', error)
+      logIpcError('db:labels:create', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -704,7 +739,7 @@ export function registerIpcHandlers(): void {
       const label = database.updateCustomLabel(options.id, options.name, options.colorKey)
       return { ok: true, data: label }
     } catch (error) {
-      console.error('[IPC] db:labels:update failed:', error)
+      logIpcError('db:labels:update', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -714,7 +749,7 @@ export function registerIpcHandlers(): void {
       const deleted = database.deleteCustomLabel(labelId)
       return { ok: true, data: deleted }
     } catch (error) {
-      console.error('[IPC] db:labels:delete failed:', error)
+      logIpcError('db:labels:delete', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -729,7 +764,7 @@ export function registerIpcHandlers(): void {
       }
       return { ok: true }
     } catch (error) {
-      console.error('[IPC] agent:notify-status failed:', error)
+      logIpcError('agent:notify-status', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -739,7 +774,7 @@ export function registerIpcHandlers(): void {
       const preferences = notificationService.getPreferences()
       return { ok: true, data: preferences }
     } catch (error) {
-      console.error('[IPC] notifications:get-preferences failed:', error)
+      logIpcError('notifications:get-preferences', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -749,7 +784,7 @@ export function registerIpcHandlers(): void {
       notificationService.setPreference(eventType, enabled)
       return { ok: true }
     } catch (error) {
-      console.error('[IPC] notifications:set-preference failed:', error)
+      logIpcError('notifications:set-preference', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -758,7 +793,7 @@ export function registerIpcHandlers(): void {
     try {
       return { ok: true, data: notificationService.getSoundEnabled() }
     } catch (error) {
-      console.error('[IPC] notifications:get-sound-enabled failed:', error)
+      logIpcError('notifications:get-sound-enabled', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -768,7 +803,7 @@ export function registerIpcHandlers(): void {
       notificationService.setSoundEnabled(enabled)
       return { ok: true }
     } catch (error) {
-      console.error('[IPC] notifications:set-sound-enabled failed:', error)
+      logIpcError('notifications:set-sound-enabled', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -778,7 +813,7 @@ export function registerIpcHandlers(): void {
       const agentId = notificationService.getPendingAgentId()
       return { ok: true, data: agentId }
     } catch (error) {
-      console.error('[IPC] notifications:get-pending-agent failed:', error)
+      logIpcError('notifications:get-pending-agent', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -819,7 +854,7 @@ export function registerIpcHandlers(): void {
       await run(cmd, [options.path])
       return { ok: true }
     } catch (error) {
-      console.error('[IPC] shell:open-in-editor failed:', error)
+      logIpcError('shell:open-in-editor', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -837,7 +872,7 @@ export function registerIpcHandlers(): void {
 
       return { ok: true }
     } catch (error) {
-      console.error('[IPC] shell:open-terminal failed:', error)
+      logIpcError('shell:open-terminal', error)
       return { ok: false, error: String(error) }
     }
   })
@@ -847,7 +882,7 @@ export function registerIpcHandlers(): void {
       await shell.openExternal(url)
       return { ok: true }
     } catch (error) {
-      console.error('[IPC] shell:open-external failed:', error)
+      logIpcError('shell:open-external', error)
       return { ok: false, error: String(error) }
     }
   })

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -718,7 +718,9 @@ class AgentController {
   }
 
   /**
-   * Compact/summarize a session.
+   * Compact/summarize a session. Opencode's /session/{id}/summarize endpoint
+   * REQUIRES providerID + modelID in the body — without them the request
+   * returns 200 but no compaction runs, leaving the UI spinning forever.
    */
   async compactSession(agentId: string): Promise<unknown> {
     const handle = this.agents.get(agentId)
@@ -727,12 +729,61 @@ class AgentController {
     const runtime = await this.ensureRuntimeForAgent(handle)
     runtimeManager.touchRuntimeActivity(runtime.id)
 
+    const model = await this.resolveCompactionModel(handle, runtime.client)
+    if (!model) {
+      throw new Error('Cannot compact: no model configured for this agent. Use the Model button to pick one.')
+    }
+
+    console.log('[AgentController.compactSession] summarize request', {
+      agentId,
+      sessionId: handle.sessionId,
+      ...model
+    })
+
     const result = await runtime.client.session.summarize({
       sessionID: handle.sessionId,
-      directory: handle.directory
+      directory: handle.directory,
+      ...model
+    })
+
+    console.log('[AgentController.compactSession] summarize response', {
+      agentId,
+      sessionId: handle.sessionId,
+      data: result.data
     })
 
     return result.data
+  }
+
+  /**
+   * Resolve the provider/model pair to use for a compaction. Prefers the
+   * agent's explicit override; falls back to the runtime's system default.
+   * Returns null when neither is available so the caller can surface an
+   * actionable error.
+   */
+  private async resolveCompactionModel(
+    handle: AgentHandle,
+    client: OpencodeClient
+  ): Promise<{ providerID: string; modelID: string } | null> {
+    if (handle.modelOverride?.providerID && handle.modelOverride.modelID) {
+      return {
+        providerID: handle.modelOverride.providerID,
+        modelID: handle.modelOverride.modelID
+      }
+    }
+
+    try {
+      const configResult = await client.config.get({})
+      const configModel = (configResult.data as { model?: string })?.model
+      if (configModel?.includes('/')) {
+        const [providerID, modelID] = configModel.split('/', 2)
+        if (providerID && modelID) return { providerID, modelID }
+      }
+    } catch (err) {
+      console.warn('[compactSession] failed to resolve default model from config', err)
+    }
+
+    return null
   }
 
   /**

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -151,7 +151,9 @@ export function App() {
     clearLabels: storeClearLabels,
     replaceLabel: storeReplaceLabel,
     renameAgent: storeRenameAgent,
-    setPrUrl: storeSetPrUrl
+    setPrUrl: storeSetPrUrl,
+    dismissAgentError: storeDismissAgentError,
+    compactSession: storeCompactSession
   } = store
 
   useEffect(() => {
@@ -316,6 +318,13 @@ export function App() {
     return store.agents.map((agent): AgentRuntime => {
       const lastMessage = extractLastAssistantMessage(getMessagesForSession(agent.sessionId))
 
+      // 'compacting' is a UI-level status: the agent's underlying server status
+      // is whatever it is (often 'idle' once compaction is queued), but the
+      // more useful thing to show is what the agent is actually doing. We also
+      // swap the task summary so the fleet table doesn't show a stale prompt.
+      const displayStatus = agent.compacting ? 'compacting' : agent.status
+      const displayTaskSummary = agent.compacting ? 'Compacting session…' : agent.taskSummary
+
       return {
         id: agent.id,
         name: agent.name,
@@ -324,8 +333,8 @@ export function App() {
         branchName: agent.branchName,
         isWorktree: agent.isWorktree,
         workspaceName: agent.workspaceName,
-        taskSummary: agent.taskSummary,
-        status: agent.status,
+        taskSummary: displayTaskSummary,
+        status: displayStatus,
         labelIds: agent.labelIds,
         model: agent.model,
         variant: agent.variant,
@@ -334,7 +343,15 @@ export function App() {
         lastActivityAtMs: agent.lastActivityAt,
         blockedSince: agent.blockedSince ? formatTimeAgo(agent.blockedSince) : undefined,
         blockedSinceMs: agent.blockedSince,
-        lastMessage
+        lastMessage,
+        lastError: agent.lastError ? {
+          name: agent.lastError.name,
+          message: agent.lastError.message,
+          occurredAt: agent.lastError.occurredAt
+        } : undefined,
+        compacting: agent.compacting,
+        contextTokens: agent.contextTokens,
+        contextLimit: agent.contextLimit
       }
     })
   }, [store.agents, tick, getMessagesForSession])
@@ -508,6 +525,7 @@ export function App() {
       const textParts: string[] = []
       const toolCalls: ToolCall[] = []
       const images: Array<{ mime: string; url: string; filename?: string }> = []
+      let compactionPart: { id: string; auto?: boolean; overflow?: boolean } | null = null
 
       for (const part of msg.parts) {
         switch (part.type) {
@@ -535,7 +553,30 @@ export function App() {
               })
             }
             break
+          case 'compaction':
+            compactionPart = {
+              id: part.id,
+              auto: part.compactionAuto,
+              overflow: part.compactionOverflow
+            }
+            break
         }
+      }
+
+      if (compactionPart) {
+        flushPendingToolCalls(msg.id, msg.createdAt)
+        // A compaction part is still "active" while the session flag is set.
+        const liveAgentForCompaction = store.agents.find((a) => a.sessionId === msg.sessionId)
+        transcriptItems.push({
+          id: `${msg.id}-compaction-${compactionPart.id}`,
+          role: 'compaction',
+          content: compactionPart.auto
+            ? 'Session compacted automatically to free context window'
+            : 'Session compacted',
+          timestamp: formatTimeAgo(msg.createdAt),
+          compactionActive: !!liveAgentForCompaction?.compacting,
+          compactionAuto: compactionPart.auto
+        })
       }
 
       const textContent = textParts.join('\n')
@@ -740,7 +781,9 @@ export function App() {
       }
 
       case 'compact': {
-        await window.api.compactSession(agentId)
+        // Route through the store so /compact gets the same abort-if-busy,
+        // spinner, and error-surfacing behavior as the in-drawer Compact buttons.
+        await storeCompactSession(agentId)
         return true
       }
 
@@ -775,7 +818,7 @@ export function App() {
         return false
       }
     }
-  }, [agentCommands, storeSetAgentModel, storeExecuteCommand])
+  }, [agentCommands, storeSetAgentModel, storeExecuteCommand, storeCompactSession])
 
   // ── Detail drawer actions ──
   const handleSendMessage = useCallback(async (text: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>) => {
@@ -880,6 +923,33 @@ export function App() {
   const handleDrawerSetPrUrl = useCallback((prUrl: string | null) => {
     if (selectedAgentId) storeSetPrUrl(selectedAgentId, prUrl)
   }, [selectedAgentId, storeSetPrUrl])
+
+  const handleDismissError = useCallback(() => {
+    if (selectedAgentId) storeDismissAgentError(selectedAgentId)
+  }, [selectedAgentId, storeDismissAgentError])
+
+  const handleCompactSession = useCallback(() => {
+    if (selectedAgentId) void storeCompactSession(selectedAgentId)
+  }, [selectedAgentId, storeCompactSession])
+
+  // Recovery path for sessions too large to compact: start a fresh session in
+  // the same worktree and ask the new agent to reconstruct context from git.
+  // The worktree still has all the uncommitted work; only the chat transcript
+  // is reset.
+  const handleStartFreshSession = useCallback(async () => {
+    if (!selectedAgentId) return
+
+    const reconstructionPrompt = `The previous session in this worktree hit a context overflow and was closed. This is a fresh start with no prior conversation history.
+
+Please reconstruct the current state of the work by:
+1. Running \`git status\` and \`git diff\` to see uncommitted changes
+2. Running \`git log --oneline -20\` to see recent commits on this branch
+3. Reading any SCRATCHPAD.md, plan.md, or similar working notes at the repo root
+
+Then give me a brief summary of what the previous session was working on and where it left off. Don't start new work yet — just orient yourself and wait for my next instruction.`
+
+    await storeResetSession(selectedAgentId, reconstructionPrompt)
+  }, [selectedAgentId, storeResetSession])
 
   const handleCreatePr = useCallback(async () => {
     if (!selectedAgentId) return
@@ -1434,6 +1504,9 @@ export function App() {
           allLabels={allLabels}
           onCreateLabel={createLabel}
           onDeleteLabel={handleDeleteLabel}
+          onDismissError={handleDismissError}
+          onCompact={handleCompactSession}
+          onStartFreshSession={handleStartFreshSession}
         />
       )}
 

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -24,6 +24,8 @@ import {
   Lightning,
   Code,
   CheckCircle,
+  Warning,
+  ArrowsInLineHorizontal,
 } from '@phosphor-icons/react'
 import type { AgentRuntime, Message, LabelDefinition, LabelColorKey } from '../types'
 import { formatBranchLabel } from '../types'
@@ -147,6 +149,15 @@ interface DetailDrawerProps {
   allLabels?: LabelDefinition[]
   onCreateLabel?: (name: string, colorKey: LabelColorKey) => Promise<LabelDefinition | null>
   onDeleteLabel?: (id: string) => Promise<boolean>
+  /** Dismiss the error banner without any corrective action. */
+  onDismissError?: () => void
+  /** Trigger server-side compaction of the transcript. Used from the banner
+   *  (when a ContextOverflowError surfaces) and from the always-visible
+   *  Compact action button. */
+  onCompact?: () => void
+  /** Recovery for sessions too large to compact — reset to a fresh session
+   *  that re-orients itself from git history. */
+  onStartFreshSession?: () => void
 }
 
 export const DetailDrawer = memo(function DetailDrawer({
@@ -180,7 +191,10 @@ export const DetailDrawer = memo(function DetailDrawer({
   onClearLabels,
   allLabels = [],
   onCreateLabel,
-  onDeleteLabel
+  onDeleteLabel,
+  onDismissError,
+  onCompact,
+  onStartFreshSession
 }: DetailDrawerProps) {
   const [inputText, _setInputText] = useState(() => draftInputs.get(agent.id) ?? '')
   const setInputText = useCallback((text: string) => {
@@ -704,6 +718,7 @@ export const DetailDrawer = memo(function DetailDrawer({
                 {agent.lastActivityAtMs ? ` · ${formatRelativeTime(agent.lastActivityAtMs)}` : ''}
               </span>
             )}
+            <ContextUsageIndicator used={agent.contextTokens} limit={agent.contextLimit} />
             <StatusBadge status={agent.status} />
             {onRemove && (
               <button
@@ -910,6 +925,14 @@ export const DetailDrawer = memo(function DetailDrawer({
           })}
         </div>
 
+        {/* Status banner — shows compaction in progress or a session-level error. */}
+        <StatusBanner
+          agent={agent}
+          onCompact={onCompact}
+          onStartFreshSession={onStartFreshSession}
+          onDismissError={onDismissError}
+        />
+
         {/* Input row: text input left, action buttons + send right */}
         <div
           className={`flex gap-2 px-3 py-2 border-t flex-1 min-h-0 transition-colors ${
@@ -1042,81 +1065,112 @@ export const DetailDrawer = memo(function DetailDrawer({
             </div>
           </div>
 
-          {/* Right column: Label, PR, Open In at top · Send/Stop at bottom */}
-          <div className="flex flex-col gap-1 shrink-0 w-[88px]">
-            {onToggleLabel && onClearLabels && (
-              <LabelDropdown
-                current={agent.labelIds}
-                onToggle={onToggleLabel}
-                onClear={onClearLabels}
-                allLabels={allLabels}
-                onCreateLabel={onCreateLabel}
-                onDeleteLabel={onDeleteLabel}
-                variant="action"
+          {/* Right column: scrollable secondary actions · pinned primary button.
+              The inner scroll region gets flex-1 + min-h-0 so it absorbs the
+              column's free space and clips — otherwise the secondary buttons'
+              natural height pushes the primary button (Send/Stop) off-screen
+              when the bottom pane is resized small. */}
+          <div className="flex flex-col gap-1 shrink-0 w-[88px] min-h-0 h-full">
+            <div className="flex flex-col gap-1 flex-1 min-h-0 overflow-y-auto">
+              {onToggleLabel && onClearLabels && (
+                <LabelDropdown
+                  current={agent.labelIds}
+                  onToggle={onToggleLabel}
+                  onClear={onClearLabels}
+                  allLabels={allLabels}
+                  onCreateLabel={onCreateLabel}
+                  onDeleteLabel={onDeleteLabel}
+                  variant="action"
+                  className="w-full"
+                />
+              )}
+              <ActionDropdownButton
+                icon={<GitPullRequest size={12} />}
+                label="PR"
                 className="w-full"
+                items={[
+                  {
+                    icon: <ArrowLineUpRight size={12} />,
+                    label: 'View PR',
+                    onClick: agent.prUrl ? () => window.api?.openExternal(agent.prUrl!) : undefined
+                  },
+                  {
+                    icon: <Link size={12} />,
+                    label: agent.prUrl ? 'Edit PR Link' : 'Add PR Link',
+                    onClick: onSetPrUrl ? () => setShowPrLinkModal(true) : undefined
+                  },
+                  {
+                    icon: <Trash size={12} />,
+                    label: 'Remove PR Link',
+                    onClick: agent.prUrl && onSetPrUrl ? () => onSetPrUrl(null) : undefined
+                  },
+                  {
+                    icon: <GitPullRequest size={12} />,
+                    label: 'Create PR',
+                    onClick: onCreatePr
+                  }
+                ]}
               />
-            )}
-            <ActionDropdownButton
-              icon={<GitPullRequest size={12} />}
-              label="PR"
-              className="w-full"
-              items={[
-                {
-                  icon: <ArrowLineUpRight size={12} />,
-                  label: 'View PR',
-                  onClick: agent.prUrl ? () => window.api?.openExternal(agent.prUrl!) : undefined
-                },
-                {
-                  icon: <Link size={12} />,
-                  label: agent.prUrl ? 'Edit PR Link' : 'Add PR Link',
-                  onClick: onSetPrUrl ? () => setShowPrLinkModal(true) : undefined
-                },
-                {
-                  icon: <Trash size={12} />,
-                  label: 'Remove PR Link',
-                  onClick: agent.prUrl && onSetPrUrl ? () => onSetPrUrl(null) : undefined
-                },
-                {
-                  icon: <GitPullRequest size={12} />,
-                  label: 'Create PR',
-                  onClick: onCreatePr
-                }
-              ]}
-            />
-            <ActionDropdownButton
-              icon={<ArrowSquareOut size={12} />}
-              label="Open In"
-              className="w-full"
-              items={[
-                { icon: <Terminal size={12} />, label: 'Terminal', onClick: onOpenTerminal },
-                { icon: <ArrowSquareOut size={12} />, label: 'Editor', onClick: onOpenInEditor }
-              ]}
-            />
-            <div className="flex-1" />
-            {/* Send / Stop toggle button */}
-            {onAbort && (agent.status === 'running' || agent.status === 'needs_approval' || agent.status === 'needs_input' || agent.status === 'stopping') ? (
-              <button
-                onClick={onAbort}
-                disabled={agent.status === 'stopping'}
-                className="flex items-center justify-center gap-1.5 w-full h-7 rounded-lg bg-kumo-danger/90 text-white text-xs font-medium transition-colors hover:bg-kumo-danger disabled:opacity-50"
-                title={agent.status === 'stopping' ? 'Stopping…' : 'Stop agent'}
-              >
-                <Stop size={12} weight="fill" />
-                {agent.status === 'stopping' ? 'Stopping…' : 'Stop'}
-              </button>
-            ) : (
-              <button
-                onClick={handleSend}
-                disabled={!inputText.trim() && attachments.length === 0}
-                className={`flex items-center justify-center gap-1.5 w-full h-7 rounded-lg text-white text-xs font-medium transition-all disabled:opacity-30 ${
-                  canReplyViaChat ? 'bg-status-input hover:bg-status-input/80' : 'bg-kumo-brand hover:bg-kumo-brand-hover'
-                }`}
-                title={canReplyViaChat ? 'Reply' : 'Send message'}
-              >
-                <ArrowUp size={12} weight="bold" />
-                {canReplyViaChat ? 'Reply' : 'Send'}
-              </button>
-            )}
+              <ActionDropdownButton
+                icon={<ArrowSquareOut size={12} />}
+                label="Open In"
+                className="w-full"
+                items={[
+                  { icon: <Terminal size={12} />, label: 'Terminal', onClick: onOpenTerminal },
+                  { icon: <ArrowSquareOut size={12} />, label: 'Editor', onClick: onOpenInEditor }
+                ]}
+              />
+              {onChangeModel && (
+                <ActionButton
+                  icon={<Brain size={12} />}
+                  label="Model"
+                  onClick={onChangeModel}
+                  className="w-full"
+                />
+              )}
+              {onCompact && (
+                <ActionButton
+                  icon={agent.compacting ? <CircleNotch size={12} className="animate-spin" /> : <ArrowsInLineHorizontal size={12} />}
+                  label={agent.compacting ? 'Compacting…' : 'Compact'}
+                  onClick={onCompact}
+                  disabled={agent.compacting}
+                  className="w-full"
+                />
+              )}
+            </div>
+            {/* Primary action button sits directly below the scroll region so
+                it's always visible, no matter how tall the content is above. */}
+            {(() => {
+              const isRunningLike = agent.status === 'running' || agent.status === 'needs_approval' || agent.status === 'needs_input' || agent.status === 'stopping'
+
+              if (onAbort && isRunningLike) {
+                return (
+                  <button
+                    onClick={onAbort}
+                    disabled={agent.status === 'stopping'}
+                    className="shrink-0 flex items-center justify-center gap-1.5 w-full h-7 rounded-lg bg-kumo-danger/90 text-white text-xs font-medium transition-colors hover:bg-kumo-danger disabled:opacity-50"
+                    title={agent.status === 'stopping' ? 'Stopping…' : 'Stop agent'}
+                  >
+                    <Stop size={12} weight="fill" />
+                    {agent.status === 'stopping' ? 'Stopping…' : 'Stop'}
+                  </button>
+                )
+              }
+
+              return (
+                <button
+                  onClick={handleSend}
+                  disabled={!inputText.trim() && attachments.length === 0}
+                  className={`shrink-0 flex items-center justify-center gap-1.5 w-full h-7 rounded-lg text-white text-xs font-medium transition-all disabled:opacity-30 ${
+                    canReplyViaChat ? 'bg-status-input hover:bg-status-input/80' : 'bg-kumo-brand hover:bg-kumo-brand-hover'
+                  }`}
+                  title={canReplyViaChat ? 'Reply' : 'Send message'}
+                >
+                  <ArrowUp size={12} weight="bold" />
+                  {canReplyViaChat ? 'Reply' : 'Send'}
+                </button>
+              )
+            })()}
           </div>
         </div>
         </div>{/* end bottom pane */}
@@ -1367,6 +1421,21 @@ const MessageBubble = memo(function MessageBubble({
     return <ToolGroupBubble message={message} verbose={verbose} rootRef={rootRef} />
   }
 
+  if (message.role === 'compaction') {
+    return (
+      <div
+        ref={rootRef}
+        className="self-center my-2 px-3 py-1.5 text-[11px] text-status-warning/90 border border-status-warning/30 bg-status-warning/10 rounded-full flex items-center gap-1.5"
+      >
+        {message.compactionActive
+          ? <CircleNotch size={11} weight="bold" className="animate-spin" />
+          : <ArrowsInLineHorizontal size={11} weight="bold" />
+        }
+        <span>{message.compactionActive ? 'Compacting session…' : message.content}</span>
+      </div>
+    )
+  }
+
   if (message.role === 'tool') {
     const toolName = message.toolName ?? extractToolName(message.content)
     const toolOutput = message.content ? extractToolOutput(message.content) : ''
@@ -1564,6 +1633,164 @@ const ToolGroupBubble = memo(function ToolGroupBubble({
   prev.message.toolCalls === next.message.toolCalls &&
   prev.verbose === next.verbose
 )
+
+/**
+ * Which banner the drawer should render, derived from the agent's transient
+ * state. Computed once at the top of StatusBanner so the JSX stays flat.
+ */
+type BannerKind = 'compacting' | 'uncompactable' | 'overflow' | 'error'
+
+function bannerKind(agent: AgentRuntime): BannerKind | null {
+  if (agent.compacting) return 'compacting'
+  if (!agent.lastError) return null
+  // When compaction itself can't run (transcript already exceeds the provider's
+  // context limit — even summarization needs to read it), opencode reports a
+  // "prompt is too long" error. Compacting is not a valid recovery for this.
+  if (agent.lastError.message?.includes('prompt is too long')) return 'uncompactable'
+  if (agent.lastError.name === 'ContextOverflowError') return 'overflow'
+  return 'error'
+}
+
+interface BannerContent {
+  title: string
+  body: string
+  containerTone: string
+  iconTone: string
+}
+
+function bannerContent(kind: BannerKind, agent: AgentRuntime): BannerContent {
+  switch (kind) {
+    case 'compacting':
+      return {
+        title: 'Compacting session…',
+        body: 'Summarizing the conversation so far. This can take a few minutes for long sessions.',
+        containerTone: 'border-kumo-brand/40 bg-kumo-brand/10',
+        iconTone: 'text-kumo-brand'
+      }
+    case 'uncompactable':
+      return {
+        title: 'Session too large to compact',
+        body: 'The transcript already exceeds the model\'s context window, so even compaction can\'t run. Your code changes are preserved in the worktree — start a fresh session below and it will reconstruct context from git history.',
+        containerTone: 'border-kumo-danger/40 bg-kumo-danger/10',
+        iconTone: 'text-kumo-danger'
+      }
+    case 'overflow':
+      return {
+        title: 'Context window full',
+        body: 'This session is too long for the model to read in one pass. Compact the conversation to free up space, or switch to a model with a larger context window.',
+        containerTone: 'border-status-warning/40 bg-status-warning/10',
+        iconTone: 'text-status-warning'
+      }
+    case 'error':
+      return {
+        title: agent.lastError!.name,
+        body: agent.lastError!.message ?? 'The server reported an error. Check the logs for details.',
+        containerTone: 'border-kumo-danger/40 bg-kumo-danger/10',
+        iconTone: 'text-kumo-danger'
+      }
+  }
+}
+
+function StatusBanner({
+  agent,
+  onCompact,
+  onStartFreshSession,
+  onDismissError
+}: {
+  agent: AgentRuntime
+  onCompact?: () => void
+  onStartFreshSession?: () => void
+  onDismissError?: () => void
+}) {
+  const kind = bannerKind(agent)
+  if (!kind) return null
+
+  const { title, body, containerTone, iconTone } = bannerContent(kind, agent)
+  const showCompact = kind === 'overflow' && !!onCompact
+  const showStartFresh = kind === 'uncompactable' && !!onStartFreshSession
+  // Every error is dismissible. The user decides when to compact, switch
+  // models, or start fresh — we just surface the problem.
+  const showDismiss = kind !== 'compacting' && !!onDismissError
+
+  return (
+    <div className={`flex items-start gap-2 px-3 py-2 border-t text-[11px] ${containerTone}`}>
+      {kind === 'compacting'
+        ? <CircleNotch size={14} weight="bold" className={`mt-0.5 shrink-0 animate-spin ${iconTone}`} />
+        : <Warning size={14} weight="fill" className={`mt-0.5 shrink-0 ${iconTone}`} />
+      }
+      <div className="flex-1 min-w-0">
+        <div className="font-medium text-kumo-default">{title}</div>
+        <div className="text-kumo-subtle leading-snug mt-0.5">{body}</div>
+      </div>
+      <div className="flex flex-col gap-1 shrink-0">
+        {showCompact && (
+          <button
+            type="button"
+            onClick={onCompact}
+            className="flex items-center gap-1 px-2 py-1 rounded-md bg-kumo-brand hover:bg-kumo-brand-hover text-white text-[11px] font-medium whitespace-nowrap"
+          >
+            <ArrowsInLineHorizontal size={11} weight="bold" />
+            Compact
+          </button>
+        )}
+        {showStartFresh && (
+          <button
+            type="button"
+            onClick={onStartFreshSession}
+            className="flex items-center gap-1 px-2 py-1 rounded-md bg-kumo-brand hover:bg-kumo-brand-hover text-white text-[11px] font-medium whitespace-nowrap"
+          >
+            <Rocket size={11} weight="bold" />
+            Start fresh session
+          </button>
+        )}
+        {showDismiss && (
+          <button
+            type="button"
+            onClick={onDismissError}
+            className="flex items-center gap-1 px-2 py-1 rounded-md border border-kumo-line hover:bg-kumo-fill text-kumo-default text-[11px] whitespace-nowrap"
+          >
+            <X size={11} />
+            Dismiss
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Thresholds for the context-usage color ramp, ordered highest → lowest. The
+ * first entry whose `minPct` the current usage meets wins. Exposed as a table
+ * rather than an if/else chain so the breakpoints are easy to tune.
+ */
+const CONTEXT_USAGE_TONES: ReadonlyArray<{ minPct: number; tone: string }> = [
+  { minPct: 95, tone: 'text-kumo-danger' },       // compact now
+  { minPct: 80, tone: 'text-status-warning' },    // compact soon
+  { minPct: 60, tone: 'text-status-warning/80' }, // worth noticing
+  { minPct: 0,  tone: 'text-kumo-subtle' }        // plenty of room
+]
+
+function formatTokenCount(n: number): string {
+  return n >= 10_000 ? `${Math.round(n / 1000)}k` : `${n}`
+}
+
+/**
+ * Compact display of context-window usage. Hidden when we don't have enough
+ * data to compute (e.g. no assistant messages yet).
+ */
+function ContextUsageIndicator({ used, limit }: { used?: number; limit?: number }) {
+  if (typeof used !== 'number' || typeof limit !== 'number' || limit <= 0) return null
+
+  const pct = Math.min(100, Math.round((used / limit) * 100))
+  const tone = CONTEXT_USAGE_TONES.find((t) => pct >= t.minPct)?.tone ?? 'text-kumo-subtle'
+  const title = `${used.toLocaleString()} / ${limit.toLocaleString()} tokens in context (${pct}%)`
+
+  return (
+    <span className={`text-[10px] font-mono whitespace-nowrap ${tone}`} title={title}>
+      {formatTokenCount(used)}/{formatTokenCount(limit)} ({pct}%)
+    </span>
+  )
+}
 
 function ActionButton({
   icon,

--- a/src/renderer/src/components/StatusBadge.tsx
+++ b/src/renderer/src/components/StatusBadge.tsx
@@ -14,10 +14,11 @@ const statusStyles: Record<AgentStatus, string> = {
   errored: 'bg-status-errored-bg text-status-errored',
   starting: 'bg-kumo-fill text-kumo-subtle',
   stopping: 'bg-kumo-fill text-kumo-subtle',
-  disconnected: 'bg-status-errored-bg text-status-errored'
+  disconnected: 'bg-status-errored-bg text-status-errored',
+  compacting: 'bg-status-warning/20 text-status-warning'
 }
 
-const pulsing = new Set<AgentStatus>(['needs_input', 'needs_approval', 'errored'])
+const pulsing = new Set<AgentStatus>(['needs_input', 'needs_approval', 'errored', 'compacting'])
 
 export function StatusBadge({ status }: StatusBadgeProps) {
   const style = statusStyles[status] ?? 'bg-kumo-fill text-kumo-subtle'

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -4,9 +4,11 @@ import type {
   OpenCodeEventPayload,
   AgentLaunchedPayload,
   AgentStatusesPayload,
+  IpcResult,
   MessageAttachment,
   PermissionRequest as PermissionRequestPayload
 } from '../types/api'
+import { lookupContextLimit } from './useModelOptions'
 
 interface HistoricalMessageInfo {
   id: string
@@ -16,12 +18,26 @@ interface HistoricalMessageInfo {
   parentID?: string
   time?: {
     created?: number
+    completed?: number
   }
   modelID?: string
   cost?: number
   tokens?: {
+    total?: number
     input: number
     output: number
+    reasoning?: number
+    cache?: {
+      read?: number
+      write?: number
+    }
+  }
+  /** Present on AssistantMessage when the provider rejected or errored on the turn
+   *  (e.g. ContextOverflowError, ProviderAuthError). */
+  error?: {
+    name?: string
+    message?: string
+    data?: unknown
   }
 }
 
@@ -75,11 +91,41 @@ export interface LiveAgent {
   prUrl: string | null
   cost: number
   tokens: { input: number; output: number }
+  /** Approximate tokens consumed in the current context window — the number
+   *  the provider will re-send on the next turn. Opencode reports tokens.total
+   *  when available; we fall back to input + cache.read otherwise. Used with
+   *  contextLimit to drive the ≥80% usage warning in the UI. */
+  contextTokens?: number
+  /** Provider-reported context window limit for the agent's current model.
+   *  Populated from assistant message metadata; cleared when the model changes. */
+  contextLimit?: number
+  /** Raw modelID from the latest assistant message (e.g. "claude-sonnet-4-20250514").
+   *  Used to look up the context limit from the provider cache. Separate from
+   *  `model` (the formatted display name) and `configuredModel` (the setting). */
+  rawModelId?: string
   /** Whether the name was auto-generated and should be replaced by the first prompt */
   autoNamed?: boolean
   /** Timestamp of last user response (sendMessage/replyToQuestion/respondToPermission).
    *  Used to guard against stale SSE events that would re-block the agent. */
   respondedAt?: number
+  /** Most recent session-level error surfaced by the server (e.g. ContextOverflowError).
+   *  Presence drives an error banner in the detail drawer; cleared by user dismiss
+   *  or by a new successful assistant turn. */
+  lastError?: LiveAgentError
+  /** True while a compactSession RPC is in flight or the server has acknowledged
+   *  compaction but session.compacted hasn't arrived yet. Drives the spinner and
+   *  disabled states on the Compact buttons so the user can see progress. */
+  compacting?: boolean
+}
+
+export interface LiveAgentError {
+  /** Error name from the server (e.g. 'ContextOverflowError', 'ProviderAuthError'). */
+  name: string
+  message?: string
+  /** Raw data payload from the server, surfaced for diagnostics. */
+  data?: unknown
+  sessionId: string
+  occurredAt: number
 }
 
 export interface LivePermission {
@@ -123,7 +169,7 @@ export interface LiveMessage {
 
 export interface LiveMessagePart {
   id: string
-  type: 'text' | 'tool' | 'reasoning' | 'step-start' | 'step-finish' | 'file' | string
+  type: 'text' | 'tool' | 'reasoning' | 'step-start' | 'step-finish' | 'file' | 'compaction' | string
   text?: string
   toolName?: string
   toolState?: string
@@ -131,6 +177,10 @@ export interface LiveMessagePart {
   fileMime?: string
   fileUrl?: string
   fileName?: string
+  /** For compaction parts — whether the compaction was auto-triggered by the server. */
+  compactionAuto?: boolean
+  /** For compaction parts — whether the compaction was triggered by a context overflow. */
+  compactionOverflow?: boolean
 }
 
 export interface FileChangeRecord {
@@ -202,6 +252,66 @@ interface PendingMessage {
   taskSummaryOverride?: string
 }
 const pendingMessages = new Map<string, PendingMessage>()
+
+// Safety timers for the `compacting` flag. We set a short "kickoff" watchdog
+// (30s): if the server doesn't produce a compaction part or set
+// session.time.compacting within that window, the RPC effectively did
+// nothing — clear the flag and surface an error so the user isn't staring at
+// a spinner forever. Once real server evidence arrives (see below), the
+// watchdog is cancelled because the session.compacted event will clear the
+// flag authoritatively.
+const compactingTimers = new Map<string, ReturnType<typeof setTimeout>>()
+const COMPACTING_KICKOFF_TIMEOUT_MS = 30_000
+
+/**
+ * Fired when the kickoff watchdog expires without any server activity: the
+ * RPC returned 200 but no compaction part or session.time.compacting update
+ * arrived. Clears the spinner flag and surfaces an actionable banner error.
+ */
+function onCompactingWatchdogExpired(agentId: string): void {
+  compactingTimers.delete(agentId)
+  const agent = state.agents.get(agentId)
+  if (!agent?.compacting) return
+  console.warn('[compacting] kickoff watchdog fired — no server activity', agentId)
+  agent.compacting = undefined
+  agent.lastError = {
+    name: 'CompactionNoResponse',
+    message: 'Compaction request was accepted but the server hasn\'t produced any activity within 30 seconds. Try again, check the npm dev console for errors, or switch models.',
+    sessionId: agent.sessionId,
+    occurredAt: Date.now()
+  }
+  emit({ agents: true })
+}
+
+/**
+ * Set or clear the agent's compacting flag. When setting true, also starts a
+ * kickoff watchdog (see onCompactingWatchdogExpired). The watchdog is
+ * cancelled by cancelCompactingWatchdog() once real server evidence arrives;
+ * at that point the flag is authoritative and will be cleared by
+ * session.compacted.
+ */
+function setCompacting(agentId: string, compacting: boolean): void {
+  const agent = state.agents.get(agentId)
+  if (!agent) return
+  if (agent.compacting === compacting) return
+  agent.compacting = compacting || undefined
+
+  cancelCompactingWatchdog(agentId)
+
+  if (compacting) {
+    const timer = setTimeout(() => onCompactingWatchdogExpired(agentId), COMPACTING_KICKOFF_TIMEOUT_MS)
+    compactingTimers.set(agentId, timer)
+  }
+  emit({ agents: true })
+}
+
+function cancelCompactingWatchdog(agentId: string): void {
+  const existing = compactingTimers.get(agentId)
+  if (existing) {
+    clearTimeout(existing)
+    compactingTimers.delete(agentId)
+  }
+}
 
 // Tracks how many step-start parts (invoked sub-agents) are currently active
 // per session. When depth > 0, message.updated model changes come from an
@@ -598,12 +708,38 @@ function identifySubAgentMessages(entries: HistoricalSessionMessage[]): Set<stri
   return subAgentIds
 }
 
+/**
+ * Compute the number of tokens currently in the context window for a turn.
+ * Prefers tokens.total when the provider reports it; otherwise approximates
+ * with input + cache.read (what gets re-sent on the next request). Returns
+ * undefined when we don't have enough data to estimate.
+ */
+function computeContextTokens(tokens: {
+  total?: number
+  input?: number
+  cache?: { read?: number }
+} | undefined): number | undefined {
+  if (!tokens) return undefined
+  if (typeof tokens.total === 'number') return tokens.total
+  const input = tokens.input ?? 0
+  const cacheRead = tokens.cache?.read ?? 0
+  const sum = input + cacheRead
+  return sum > 0 ? sum : undefined
+}
+
 function hydrateHistoricalMessages(entries: unknown): void {
   if (!Array.isArray(entries)) return
 
   const typed = entries as HistoricalSessionMessage[]
   const subAgentAssistantIds = identifySubAgentMessages(typed)
   const optimisticsCleaned = new Set<string>()
+
+  // Track the last assistant entry per session so we can lift a persisted
+  // error (e.g. ContextOverflowError) onto the agent after hydration. This
+  // makes the error banner survive across app restarts — without it, the
+  // user has to send another message to re-trigger the overflow just to see
+  // the warning.
+  const lastAssistantBySession = new Map<string, HistoricalMessageInfo>()
 
   for (const entry of typed) {
     if (!entry?.info?.id || !entry.info.sessionID || !Array.isArray(entry.parts)) continue
@@ -643,12 +779,17 @@ function hydrateHistoricalMessages(entries: unknown): void {
           input: entry.info.tokens.input,
           output: entry.info.tokens.output
         }
+        const ctx = computeContextTokens(entry.info.tokens)
+        if (ctx !== undefined) agent.contextTokens = ctx
       }
 
       // Skip model updates from sub-agent messages (see identifySubAgentMessages)
       if (entry.info.modelID && !subAgentAssistantIds.has(entry.info.id)) {
         const formatted = formatModelName(entry.info.modelID)
         agent.model = formatted
+        agent.rawModelId = entry.info.modelID
+        const limit = lookupContextLimit(entry.info.modelID)
+        if (limit !== undefined) agent.contextLimit = limit
         // Only seed configuredModel if not already set by a config fetch or
         // prior setAgentModel call, so the authoritative config value wins.
         if (!agent.configuredModel) {
@@ -659,6 +800,35 @@ function hydrateHistoricalMessages(entries: unknown): void {
       // PR URLs are only extracted during the live "Create PR" flow and
       // persisted to preferences, so historical messages are not scanned.
       // This avoids picking up URLs the user pasted in their own prompts.
+
+      // Track latest assistant message per session for post-hydration error
+      // surfacing (see loop below).
+      const prev = lastAssistantBySession.get(entry.info.sessionID)
+      if (!prev || getMessageCreatedAt(entry.info) > getMessageCreatedAt(prev)) {
+        lastAssistantBySession.set(entry.info.sessionID, entry.info)
+      }
+    }
+  }
+
+  // Surface persisted errors on the most recent assistant message as the
+  // agent's lastError. Only when the user hasn't already seen/dismissed it
+  // (agent.lastError empty) and when there's no later successful user
+  // message that would supersede it.
+  for (const [sessionId, info] of lastAssistantBySession) {
+    if (!info.error?.name) continue
+    const agent = findAgentBySession(sessionId)
+    if (!agent || agent.lastError) continue
+    console.log('[hydrateHistoricalMessages] surfacing persisted error on agent', {
+      agentId: agent.id,
+      errorName: info.error.name,
+      errorMessage: info.error.message
+    })
+    agent.lastError = {
+      name: info.error.name,
+      message: info.error.message,
+      data: info.error.data,
+      sessionId,
+      occurredAt: info.time?.completed ?? info.time?.created ?? Date.now()
     }
   }
 }
@@ -723,15 +893,6 @@ function processEvent(payload: OpenCodeEventPayload): void {
   const resolvedSessionId = resolveSessionIdForEvent(props, runtimeId)
   if (resolvedSessionId && type !== 'server.heartbeat') {
     logEvent(resolvedSessionId, type, props)
-  }
-
-  // DEBUG: trace event delivery for new sessions
-  if (type === 'message.updated' || type === 'message.part.updated') {
-    const dbgSession = (props.info as Record<string, unknown>)?.sessionID ?? (props.part as Record<string, unknown>)?.sessionID
-    const hasAgent = !!findAgentBySession(dbgSession as string)
-    const hasMsgs = state.messages.has(dbgSession as string)
-    const msgCount = state.messages.get(dbgSession as string)?.length ?? 0
-    console.debug(`[processEvent] ${type} session=${(dbgSession as string)?.slice(-8)} agent=${hasAgent} msgs=${hasMsgs}(${msgCount})`)
   }
 
   switch (type) {
@@ -799,6 +960,13 @@ function processEvent(payload: OpenCodeEventPayload): void {
         prExtractEnabled.delete(agent.id)
         resetStepDepthAndRestoreModel(sessionId, agent)
 
+        // Deliberately DO NOT clear lastError or lastDispatchedMessage here.
+        // The opencode server emits session.error immediately followed by
+        // session.idle, and if we wiped the recovery state on idle the error
+        // banner would flash and disappear before the user could act on it.
+        // These are cleared on successful assistant output or explicit user
+        // action (dismiss, new send, compact-and-retry).
+
         persistAgentMeta(agent.id, { persistedStatus: 'idle' })
         emit({ agents: true })
         dispatchPendingMessage(agent.id)
@@ -808,6 +976,8 @@ function processEvent(payload: OpenCodeEventPayload): void {
 
     case 'session.error': {
       const sessionId = props.sessionID as string
+      const errorProp = props.error as { name?: string; message?: string; data?: unknown } | undefined
+      console.error('[session.error]', { sessionId, error: errorProp, fullProps: props })
       const agent = findAgentBySession(sessionId)
       if (agent) {
         notifyIfNeeded(agent, 'errored')
@@ -816,6 +986,17 @@ function processEvent(payload: OpenCodeEventPayload): void {
         agent.respondedAt = undefined
         prExtractEnabled.delete(agent.id)
         resetStepDepthAndRestoreModel(sessionId, agent)
+
+        // Surface the error so the UI can render a banner.
+        if (errorProp?.name) {
+          agent.lastError = {
+            name: errorProp.name,
+            message: errorProp.message,
+            data: errorProp.data,
+            sessionId,
+            occurredAt: Date.now()
+          }
+        }
 
         persistAgentMeta(agent.id, { persistedStatus: 'errored' })
         emit({ agents: true })
@@ -842,14 +1023,74 @@ function processEvent(payload: OpenCodeEventPayload): void {
       break
     }
 
+    case 'tui.toast.show': {
+      // Opencode's TUI toasts are the canonical channel for provider and
+      // compactor errors. Surface error-variant toasts on the best-guess
+      // agent for the runtime (toasts don't carry a sessionID).
+      const toast = props as { title?: string; message?: string; variant?: string }
+      console.log('[tui.toast.show]', { runtimeId, variant: toast.variant, title: toast.title, message: toast.message })
+
+      if (toast.variant !== 'error' && toast.variant !== 'warning') break
+
+      const target = pickToastTargetAgent(runtimeId)
+      if (!target) {
+        console.warn('[tui.toast.show] no agent for runtime', { runtimeId })
+        break
+      }
+
+      if (toast.variant === 'error') {
+        console.error('[tui.toast.show error]', {
+          runtimeId,
+          targetAgent: target.id,
+          wasCompacting: !!target.compacting,
+          toast
+        })
+        target.lastError = {
+          name: toast.title || 'Server error',
+          message: toast.message,
+          sessionId: target.sessionId,
+          occurredAt: Date.now()
+        }
+        target.lastActivityAt = Date.now()
+        // Compactor errors (e.g. "prompt is too long") arrive here. Stop the
+        // spinner so the banner flips from "Compacting…" to the error state.
+        if (target.compacting) setCompacting(target.id, false)
+        emit({ agents: true })
+      } else {
+        // Warnings: log only — we don't want to hijack the banner for a warning.
+        console.warn('[tui.toast.show warning]', { runtimeId, targetAgent: target.id, toast })
+      }
+      break
+    }
+
     case 'session.updated': {
       const info = props.info as Record<string, unknown> | undefined
       const sessionId = info?.id as string | undefined
       if (!sessionId) break
       const agent = findAgentBySession(sessionId)
       if (agent) {
-        const time = info?.time as { updated?: number } | undefined
+        const time = info?.time as { updated?: number; compacting?: number } | undefined
         agent.lastActivityAt = typeof time?.updated === 'number' ? time.updated : Date.now()
+
+        // The server sets session.time.compacting to a timestamp while
+        // compaction is in progress and clears it when done. This is the
+        // authoritative signal — cancel the kickoff watchdog when the server
+        // takes ownership of the flag.
+        const serverIsCompacting = typeof time?.compacting === 'number'
+        if (serverIsCompacting) {
+          if (!agent.compacting) {
+            console.log('[session.updated] server started compacting', { agentId: agent.id, at: time?.compacting })
+          }
+          cancelCompactingWatchdog(agent.id)
+          if (!agent.compacting) setCompacting(agent.id, true)
+        } else if (agent.compacting && !compactingTimers.has(agent.id)) {
+          // Server has explicitly cleared its compacting timestamp and we're
+          // past the kickoff window — compaction finished (or was cancelled)
+          // but session.compacted didn't fire. Clear our flag to match.
+          console.log('[session.updated] server cleared compacting without session.compacted event', { agentId: agent.id })
+          setCompacting(agent.id, false)
+        }
+
         const title = info?.title as string | undefined
         // Only use the server-generated session title for the initial summary
         // (when taskSummary is still a placeholder). Once the user has sent a
@@ -884,9 +1125,19 @@ function processEvent(payload: OpenCodeEventPayload): void {
         // Update cost/tokens from assistant messages
         if (role === 'assistant') {
           const cost = info.cost as number | undefined
-          const tokens = info.tokens as { input: number; output: number } | undefined
+          const tokens = info.tokens as {
+            total?: number
+            input: number
+            output: number
+            cache?: { read?: number; write?: number }
+          } | undefined
           if (cost !== undefined) { agent.cost = cost; agentChanged = true }
-          if (tokens) { agent.tokens = { input: tokens.input, output: tokens.output }; agentChanged = true }
+          if (tokens) {
+            agent.tokens = { input: tokens.input, output: tokens.output }
+            const ctx = computeContextTokens(tokens)
+            if (ctx !== undefined) agent.contextTokens = ctx
+            agentChanged = true
+          }
 
           // Only update model from top-level (non-invoked) assistant messages
           const modelId = info.modelID as string | undefined
@@ -895,6 +1146,45 @@ function processEvent(payload: OpenCodeEventPayload): void {
             const formatted = formatModelName(modelId)
             agent.model = formatted
             agent.configuredModel = formatted
+            agent.rawModelId = modelId
+            const limit = lookupContextLimit(modelId)
+            if (limit !== undefined) agent.contextLimit = limit
+            agentChanged = true
+          }
+
+          // Opencode reports provider errors on the assistant message itself via
+          // the `error` field. Capture that here — it's the canonical place for
+          // ContextOverflowError and similar — since the separate session.error
+          // event doesn't always fire reliably.
+          const msgError = info.error as { name?: string; message?: string; data?: unknown } | undefined
+          if (msgError?.name) {
+            console.error('[message.updated] assistant message carries error', {
+              agentId: agent.id,
+              sessionId,
+              messageId,
+              errorName: msgError.name,
+              errorMessage: msgError.message,
+              errorData: msgError.data
+            })
+            agent.lastError = {
+              name: msgError.name,
+              message: msgError.message,
+              data: msgError.data,
+              sessionId,
+              occurredAt: Date.now()
+            }
+            agentChanged = true
+          }
+
+          // Only clear a sticky error when we see a truly completed assistant
+          // message with no error attached. `message.updated` also fires for the
+          // placeholder shell before the provider responds, which is when the
+          // overflow error lands — clearing on every update would erase the
+          // banner before the user sees it.
+          const time = info.time as { completed?: number } | undefined
+          const messageComplete = typeof time?.completed === 'number' && !msgError
+          if (messageComplete && agent.lastError) {
+            agent.lastError = undefined
             agentChanged = true
           }
         }
@@ -933,6 +1223,19 @@ function processEvent(payload: OpenCodeEventPayload): void {
       const messageId = part.messageID as string
       const partId = part.id as string
       const partType = part.type as string
+
+      // A `compaction` part is the server's authoritative signal that the
+      // compactor is actively running for this session. Cancel the kickoff
+      // watchdog (compaction has demonstrably started) and set the spinner
+      // flag for auto-compactions that the user didn't initiate.
+      if (partType === 'compaction') {
+        const agent = findAgentBySession(sessionId)
+        if (agent) {
+          console.log('[compaction part] server acknowledged compaction', { agentId: agent.id, auto: part.auto })
+          cancelCompactingWatchdog(agent.id)
+          if (!agent.compacting) setCompacting(agent.id, true)
+        }
+      }
 
       // Track invoked-agent nesting depth so model updates from sub-agents
       // don't overwrite the parent agent's displayed model.
@@ -993,6 +1296,10 @@ function processEvent(payload: OpenCodeEventPayload): void {
             newPart.fileMime = part.mime as string | undefined
             newPart.fileUrl = part.url as string | undefined
             newPart.fileName = part.filename as string | undefined
+          }
+          if (partType === 'compaction') {
+            newPart.compactionAuto = part.auto as boolean | undefined
+            newPart.compactionOverflow = part.overflow as boolean | undefined
           }
           message.parts.push(newPart)
         }
@@ -1263,26 +1570,22 @@ function processEvent(payload: OpenCodeEventPayload): void {
     case 'session.compacted': {
       // The server compacted the session's context window — old messages and
       // parts were pruned server-side. Clear local messages so the UI doesn't
-      // show ghost messages that the agent can no longer reference.
+      // show ghost messages that the agent can no longer reference, then
+      // re-fetch the post-compaction transcript.
       const sessionId = props.sessionID as string
       const agent = findAgentBySession(sessionId)
+      console.log('[session.compacted] received', { sessionId, agentId: agent?.id })
       if (agent) {
         state.messages.delete(sessionId)
         agent.lastActivityAt = Date.now()
-
-        // Re-fetch the current messages so the drawer shows the post-compaction state
-        if (window.api) {
-          void window.api.getMessages(agent.id).then((result) => {
-            if (!result.ok || !result.data) return
-            const entries = result.data as HistoricalSessionMessage[]
-            if (Array.isArray(entries) && entries.length > 0) {
-              hydrateHistoricalMessages(entries)
-              emit({ messages: true })
-            }
-          })
+        // Compaction resolves ContextOverflowError — the context window now
+        // has room for the replayed transcript, so clear the banner.
+        if (agent.lastError?.name === 'ContextOverflowError') {
+          agent.lastError = undefined
         }
-
+        setCompacting(agent.id, false)
         emit({ agents: true, messages: true })
+        void refetchSessionMessages(agent.id)
       }
       break
     }
@@ -1527,7 +1830,11 @@ function handleSessionReset(payload: { id: string; sessionId: string; oldSession
   agent.prUrl = null
   agent.cost = 0
   agent.tokens = { input: 0, output: 0 }
+  agent.contextTokens = undefined
+  agent.rawModelId = undefined
+  // contextLimit stays cached — the model doesn't change on reset.
   agent.lastActivityAt = Date.now()
+  agent.lastError = undefined
   taskSummaryLocked.delete(payload.id)
   prExtractEnabled.delete(payload.id)
 
@@ -1552,6 +1859,11 @@ function removeAgentState(agentId: string): void {
   taskSummaryLocked.delete(agentId)
   prExtractEnabled.delete(agentId)
   pendingMessages.delete(agentId)
+  const compactingTimer = compactingTimers.get(agentId)
+  if (compactingTimer) {
+    clearTimeout(compactingTimer)
+    compactingTimers.delete(agentId)
+  }
   sessionStepDepth.delete(agent.sessionId)
   state.agents.delete(agentId)
   state.messages.delete(agent.sessionId)
@@ -1904,6 +2216,25 @@ function findAgentByRuntime(runtimeId: string): LiveAgent | undefined {
 }
 
 /**
+ * Pick the most likely target agent for a runtime-scoped event (e.g. a TUI
+ * toast) when multiple agents share the runtime. Prefers agents that look
+ * actively engaged: compacting, then running, then any. Returns undefined
+ * only when the runtime has no agents attached.
+ */
+function pickToastTargetAgent(runtimeId: string): LiveAgent | undefined {
+  let compacting: LiveAgent | undefined
+  let busy: LiveAgent | undefined
+  let fallback: LiveAgent | undefined
+  for (const agent of state.agents.values()) {
+    if (agent.runtimeId !== runtimeId) continue
+    if (agent.compacting) { compacting = compacting ?? agent; continue }
+    if (agent.status === 'running') { busy = busy ?? agent; continue }
+    fallback = fallback ?? agent
+  }
+  return compacting ?? busy ?? fallback
+}
+
+/**
  * Check whether an agent has pending questions or permissions in the store.
  * Used to prevent session.status events from clobbering blocked states
  * when the server sends a 'busy' status while questions/permissions are still pending.
@@ -1981,6 +2312,50 @@ function dispatchPendingMessage(agentId: string): void {
       emit({ agents: true })
     }
   })
+}
+
+/**
+ * Resolve once an agent transitions to a non-busy status (idle, errored,
+ * completed) or the timeout elapses. Polls the in-memory store rather than
+ * subscribing to events so callers don't have to deal with subscription
+ * lifecycles. The store state is updated synchronously by processEvent, so
+ * a short poll interval is sufficient.
+ */
+function waitForAgentSettled(agentId: string, timeoutMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    const start = Date.now()
+    const poll = () => {
+      const agent = state.agents.get(agentId)
+      if (!agent) return resolve()
+      const isSettled = agent.status === 'idle' || agent.status === 'errored' || agent.status === 'completed'
+      if (isSettled) return resolve()
+      if (Date.now() - start >= timeoutMs) {
+        console.warn('[waitForAgentSettled] timed out', { agentId, lastStatus: agent.status })
+        return resolve()
+      }
+      setTimeout(poll, 100)
+    }
+    poll()
+  })
+}
+
+/**
+ * Re-fetch the session transcript from the server after compaction, since
+ * compaction prunes messages server-side and our local cache needs to be
+ * replaced with the post-compaction state.
+ */
+async function refetchSessionMessages(agentId: string): Promise<void> {
+  const agent = state.agents.get(agentId)
+  if (!agent || !window.api) return
+
+  const result = await window.api.getMessages(agentId)
+  if (result.ok && result.data) {
+    const entries = result.data as HistoricalSessionMessage[]
+    if (Array.isArray(entries) && entries.length > 0) {
+      hydrateHistoricalMessages(entries)
+      emit({ messages: true })
+    }
+  }
 }
 
 function mapSessionStatus(statusType: string): AgentStatus {
@@ -2316,6 +2691,11 @@ export function useAgentStore() {
       return { ok: true, queued: true }
     }
 
+    // Sending a new message supersedes any stale error banner.
+    if (agent?.lastError) {
+      agent.lastError = undefined
+    }
+
     const previousStatus = agent?.status
     const previousBlockedSince = agent?.blockedSince
     const previousLabelIds = agent?.labelIds ? [...agent.labelIds] : []
@@ -2340,6 +2720,7 @@ export function useAgentStore() {
 
     // Rollback optimistic state if the send failed
     if (result && !result.ok) {
+      console.error('[sendMessage] send failed, rolling back optimistic state', { agentId, error: result.error })
       prExtractEnabled.delete(agentId)
       const agentAfter = state.agents.get(agentId)
       if (agentAfter && agentAfter.status === 'running') {
@@ -2696,6 +3077,70 @@ export function useAgentStore() {
     emit({ agents: true })
   }, [])
 
+  /**
+   * Dismiss the current error banner without any corrective action. The user
+   * decides when (and whether) to compact, switch models, or retry.
+   */
+  const dismissAgentError = useCallback((agentId: string) => {
+    const agent = state.agents.get(agentId)
+    if (!agent?.lastError) return
+    agent.lastError = undefined
+    emit({ agents: true })
+  }, [])
+
+  /**
+   * Trigger server-side compaction on the user's behalf. Aborts any running
+   * turn first — compactSession 400s on a busy session. Shows a spinner while
+   * the RPC and the provider-side summarization run; cleared when the server
+   * emits session.compacted (success), the RPC fails, or the watchdog fires.
+   */
+  const compactSession = useCallback(async (agentId: string): Promise<IpcResult | undefined> => {
+    if (!window.api) return
+    const agent = state.agents.get(agentId)
+    if (!agent) {
+      console.error('[compactSession] agent not found', agentId)
+      return
+    }
+
+    console.log('[compactSession] requested', { agentId, sessionId: agent.sessionId, status: agent.status })
+
+    const isBusy = agent.status === 'running' || agent.status === 'needs_approval' || agent.status === 'needs_input' || agent.status === 'stopping'
+    if (isBusy) {
+      console.log('[compactSession] aborting busy session first', { agentId, status: agent.status })
+      const abortResult = await window.api.abortAgent(agentId)
+      if (!abortResult.ok) {
+        console.error('[compactSession] abort failed', { agentId, error: abortResult.error })
+        return abortResult
+      }
+      await waitForAgentSettled(agentId, 10_000)
+    }
+
+    setCompacting(agentId, true)
+    agent.lastActivityAt = Date.now()
+
+    const result = await window.api.compactSession(agentId)
+    if (result?.ok) {
+      console.log('[compactSession] RPC accepted, waiting for server activity', { agentId })
+    } else {
+      console.error('[compactSession] RPC failed', { agentId, error: result?.error })
+      setCompacting(agentId, false)
+      const agentAfter = state.agents.get(agentId)
+      if (agentAfter) {
+        // Surface the real error in the banner so the user sees why compaction
+        // failed (e.g. provider auth, rate limit, session too large).
+        agentAfter.lastError = {
+          name: 'CompactionFailed',
+          message: result?.error ?? 'Compaction request was rejected by the server.',
+          sessionId: agentAfter.sessionId,
+          occurredAt: Date.now()
+        }
+        agentAfter.lastActivityAt = Date.now()
+        emit({ agents: true })
+      }
+    }
+    return result
+  }, [])
+
   const setPrUrl = useCallback((agentId: string, prUrl: string | null) => {
     const agent = state.agents.get(agentId)
     if (!agent) return
@@ -2728,6 +3173,8 @@ export function useAgentStore() {
     clearLabels,
     replaceLabel,
     setPrUrl,
+    dismissAgentError,
+    compactSession,
     selectDirectory,
     getMessagesForSession,
     getFileChangesForSession,
@@ -2739,7 +3186,8 @@ export function useAgentStore() {
     executeCommand, prepareFreshAgent, resetSession,
     respondToPermission, replyToQuestion, rejectQuestion,
     abortAgent, removeAgent, renameAgent, setAgentModel,
-    toggleLabel, clearLabels, setPrUrl, selectDirectory,
+    toggleLabel, clearLabels, setPrUrl,
+    dismissAgentError, compactSession, selectDirectory,
     getMessagesForSession, getFileChangesForSession,
     getEventsForSession, getToolCallsForSession
   ])

--- a/src/renderer/src/hooks/useModelOptions.ts
+++ b/src/renderer/src/hooks/useModelOptions.ts
@@ -10,8 +10,37 @@ export interface ProviderData {
   providers: Array<{
     id: string
     name: string
-    models: Record<string, { id: string; name: string }>
+    models: Record<string, {
+      id: string
+      name: string
+      limit?: { context?: number; input?: number; output?: number }
+    }>
   }>
+}
+
+/**
+ * Global cache mapping `${providerId}/${modelId}` and bare `modelId` to the
+ * provider-reported context window. Populated from the provider fetch and
+ * queried by callers that need to compute "% of context used" for an agent.
+ */
+const contextLimitCache = new Map<string, number>()
+
+export function recordContextLimitsFromProviders(data: ProviderData): void {
+  for (const provider of data.providers) {
+    for (const model of Object.values(provider.models)) {
+      const limit = model.limit?.context
+      if (typeof limit !== 'number' || limit <= 0) continue
+      contextLimitCache.set(`${provider.id}/${model.id}`, limit)
+      // Also index by bare id so callers that don't carry the provider prefix
+      // can still look up a limit when it's unambiguous.
+      if (!contextLimitCache.has(model.id)) contextLimitCache.set(model.id, limit)
+    }
+  }
+}
+
+export function lookupContextLimit(modelKey: string | undefined): number | undefined {
+  if (!modelKey) return undefined
+  return contextLimitCache.get(modelKey)
 }
 
 export const STATIC_MODEL_OPTIONS: ModelOption[] = [
@@ -94,6 +123,8 @@ export function useModelOptions(): { options: ModelOption[]; loading: boolean } 
         const providerData = providersResult.ok && providersResult.data
           ? providersResult.data as ProviderData
           : null
+
+        if (providerData) recordContextLimitsFromProviders(providerData)
 
         const configModel = configResult.ok && configResult.data
           ? (configResult.data as { model?: string }).model

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -12,6 +12,7 @@ export type AgentStatus =
   | 'errored'
   | 'disconnected'
   | 'stopping'
+  | 'compacting'
 
 // ── Labels: user-applied workflow tags ──
 
@@ -85,6 +86,20 @@ export interface AgentRuntime {
   blockedSince?: string
   blockedSinceMs?: number
   lastMessage?: string
+  /** Most recent session-level error from the server (e.g. ContextOverflowError). */
+  lastError?: AgentRuntimeError
+  /** True while a compaction RPC is running (shows spinner, disables compact buttons). */
+  compacting?: boolean
+  /** Approximate tokens currently sitting in the model's context window. */
+  contextTokens?: number
+  /** Provider-reported context window size for the active model. */
+  contextLimit?: number
+}
+
+export interface AgentRuntimeError {
+  name: string
+  message?: string
+  occurredAt: number
 }
 
 // ── Column visibility ──
@@ -188,13 +203,17 @@ export interface MessageImage {
 
 export interface Message {
   id: string
-  role: 'user' | 'assistant' | 'tool' | 'tool-group'
+  role: 'user' | 'assistant' | 'tool' | 'tool-group' | 'compaction'
   content: string
   timestamp: string
   toolName?: string
   toolState?: 'running' | 'completed' | 'failed'
   toolCalls?: ToolCall[]
   images?: MessageImage[]
+  /** For compaction rows: whether compaction is still running. */
+  compactionActive?: boolean
+  /** For compaction rows: whether the compaction was automatic (true) or user-initiated (false). */
+  compactionAuto?: boolean
 }
 
 export function isBlocked(status: AgentStatus): boolean {
@@ -219,7 +238,8 @@ export function statusLabel(status: AgentStatus): string {
     completed: 'Completed',
     errored: 'Errored',
     disconnected: 'Disconnected',
-    stopping: 'Stopping'
+    stopping: 'Stopping',
+    compacting: 'Compacting'
   }
   return labels[status]
 }
@@ -257,12 +277,13 @@ const STATUS_PRIORITY: Record<AgentStatus, number> = {
   needs_input: 0,
   needs_approval: 1,
   running: 2,
-  starting: 3,
-  idle: 4,
-  stopping: 5,
-  errored: 6,
-  completed: 7,
-  disconnected: 8
+  compacting: 3,
+  starting: 4,
+  idle: 5,
+  stopping: 6,
+  errored: 7,
+  completed: 8,
+  disconnected: 9
 }
 
 export function compareStatusPriority(a: AgentStatus, b: AgentStatus): number {


### PR DESCRIPTION
## Summary

Compaction previously ran silently: the server accepted the RPC but emitted no events, so users stared at a spinner until a 10-minute watchdog cleared. The root cause was our call omitting the required `providerID`/`modelID` body — opencode returned 200 and did nothing.

This PR fixes that, adds proactive feedback before and during compaction, and surfaces context-overflow and compactor errors in a banner instead of leaving them in the terminal.

## What's in here

### Compaction actually runs
- `AgentController.compactSession` now resolves provider/model from the agent's override or the runtime's system default and passes them to `session.summarize`. Throws an actionable error if neither is available.

### Visible compaction state
- New `compacting` status (orange pulse in the status badge).
- Fleet table task column swaps to "Compacting session…" while active.
- Compaction banner in the detail drawer with a spinner and description.
- 30-second kickoff watchdog flips to `CompactionNoResponse` if the server never acknowledges. Real server evidence (compaction part or `session.time.compacting`) cancels the watchdog; `session.compacted` clears the flag.
- Inline pill in the transcript when the server emits a `CompactionPart`.

### Context-overflow banner (persists across restarts)
- Detects `ContextOverflowError` from both `session.error` and assistant `message.updated` events.
- Hydrates `lastError` from historical messages on session load, so the banner appears immediately without re-triggering the error.
- Dismiss clears it; compaction resolves it; a fresh assistant turn supersedes it.

### Uncompactable sessions
- When the transcript itself exceeds the provider limit, surfaces a red "Session too large to compact" banner with a **Start fresh session** button that resets the session and asks the new agent to reconstruct context from git history.

### Context-usage indicator
- Header shows \`73k/200k (37%)\` for any agent with assistant output, tracked from tokens.total or input + cache.read.
- Color escalates: subtle <60%, amber 60–80%, warning 80–95%, danger ≥95%.

### Unified entry points
- \`/compact\` slash command, the banner's **Compact** button, and the action-stack **Compact** button all route through the same store action. All three share the abort-if-busy, spinner, and error-surfacing behavior.

### Rich error logging
- Main-process IPC handlers log error name/message/stack/cause/status/body via a new \`logIpcError\` helper (applied to all 64 handlers).
- Renderer logs every compaction lifecycle event, tui toast, session error, and historical-error hydration.

## Testing

- \`npm run typecheck\` clean.
- \`npm test\` — 212 passing, no new failures.
- Manual: triggered a ContextOverflowError on a 1,300-message Opus session, watched the banner appear immediately, clicked Compact, saw the transcript pill, session compacted successfully, banner cleared.