### PR TITLE
Clear stale drawer scroll request on plain row clicks

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -77,6 +77,10 @@ export function App() {
     setSelectedAgentIdRaw(id)
     if (id && scrollTarget) {
       setDrawerScrollRequest((prev) => ({ target: scrollTarget, seq: (prev?.seq ?? 0) + 1 }))
+    } else {
+      // Clear any stale scroll request so plain row clicks (or drawer close)
+      // don't trigger a jump when the drawer remounts for a new agent.
+      setDrawerScrollRequest(null)
     }
   }, [])
   const [showLaunchModal, setShowLaunchModal] = useState(false)


### PR DESCRIPTION
After clicking the Task text on agent A, the scroll request stays in state with its bumped seq. Closing the drawer and clicking a plain row on agent B remounts DetailDrawer with a fresh lastHandledScrollSeqRef (-1), so the stale request re-fires and the drawer jumps to agent B's last user message instead of scrolling to the bottom.

setSelectedAgentId now clears the scroll request whenever it's called without a scroll target, so only the Task text click triggers a jump.