### PR TITLE
Portal right-column dropdowns, add Context column to fleet table

### DIFF
--- a/src/renderer/src/components/ContextUsageIndicator.tsx
+++ b/src/renderer/src/components/ContextUsageIndicator.tsx
@@ -1,0 +1,45 @@
+/**
+ * Thresholds for the context-usage color ramp, ordered highest → lowest. The
+ * first entry whose `minPct` the current usage meets wins. Exposed as a table
+ * rather than an if/else chain so the breakpoints are easy to tune.
+ */
+const CONTEXT_USAGE_TONES: ReadonlyArray<{ minPct: number; tone: string }> = [
+  { minPct: 95, tone: 'text-kumo-danger' },       // compact now
+  { minPct: 80, tone: 'text-status-warning' },    // compact soon
+  { minPct: 60, tone: 'text-status-warning/80' }, // worth noticing
+  { minPct: 0,  tone: 'text-kumo-subtle' }        // plenty of room
+]
+
+function formatTokenCount(n: number): string {
+  return n >= 10_000 ? `${Math.round(n / 1000)}k` : `${n}`
+}
+
+interface ContextUsageIndicatorProps {
+  used?: number
+  limit?: number
+  /** Display variant. 'full' shows `73k/200k (37%)`; 'compact' shows just the
+   *  percentage (useful in narrow table columns). */
+  variant?: 'full' | 'compact'
+}
+
+/**
+ * Compact display of context-window usage. Hidden when we don't have enough
+ * data to compute (e.g. no assistant messages yet).
+ */
+export function ContextUsageIndicator({ used, limit, variant = 'full' }: ContextUsageIndicatorProps) {
+  if (typeof used !== 'number' || typeof limit !== 'number' || limit <= 0) return null
+
+  const pct = Math.min(100, Math.round((used / limit) * 100))
+  const tone = CONTEXT_USAGE_TONES.find((t) => pct >= t.minPct)?.tone ?? 'text-kumo-subtle'
+  const title = `${used.toLocaleString()} / ${limit.toLocaleString()} tokens in context (${pct}%)`
+
+  const label = variant === 'compact'
+    ? `${pct}%`
+    : `${formatTokenCount(used)}/${formatTokenCount(limit)} (${pct}%)`
+
+  return (
+    <span className={`text-[10px] font-mono whitespace-nowrap ${tone}`} title={title}>
+      {label}
+    </span>
+  )
+}

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -34,12 +34,13 @@ import { loadSettings, SETTINGS_CHANGED_EVENT, MAX_QUICK_ACTIONS, isQuickActionV
 import { useImageAttachments } from '../hooks/useImageAttachments'
 import { StatusBadge } from './StatusBadge'
 import { LabelDropdown } from './LabelDropdown'
+import { ContextUsageIndicator } from './ContextUsageIndicator'
+import { PortaledMenu } from './PortaledMenu'
 import { TextInputModal } from './TextInputModal'
 import { Markdown } from './Markdown'
 import { FilesChanged } from './FilesChanged'
 import { ToolsUsage } from './ToolsUsage'
 import { EventLog } from './EventLog'
-import { useDismiss } from '../hooks/useDismiss'
 import type { FileChange } from './FilesChanged'
 import type { ToolCall } from './ToolsUsage'
 import type { EventEntry } from './EventLog'
@@ -1040,7 +1041,7 @@ export const DetailDrawer = memo(function DetailDrawer({
               className="w-full flex-1 min-h-0 px-3 py-2.5 bg-transparent text-kumo-default text-sm outline-none placeholder:text-kumo-subtle resize-none"
             />
 
-            {/* Bottom row: hints */}
+            {/* Bottom row: hints + context usage */}
             <div className="flex items-center px-2 pb-1.5 shrink-0">
               <button
                 type="button"
@@ -1061,6 +1062,9 @@ export const DetailDrawer = memo(function DetailDrawer({
               />
               <span className="text-[10px] text-kumo-subtle/60 ml-2">
                 ↵ send · ⇧↵ newline
+              </span>
+              <span className="ml-auto">
+                <ContextUsageIndicator used={agent.contextTokens} limit={agent.contextLimit} />
               </span>
             </div>
           </div>
@@ -1758,40 +1762,6 @@ function StatusBanner({
   )
 }
 
-/**
- * Thresholds for the context-usage color ramp, ordered highest → lowest. The
- * first entry whose `minPct` the current usage meets wins. Exposed as a table
- * rather than an if/else chain so the breakpoints are easy to tune.
- */
-const CONTEXT_USAGE_TONES: ReadonlyArray<{ minPct: number; tone: string }> = [
-  { minPct: 95, tone: 'text-kumo-danger' },       // compact now
-  { minPct: 80, tone: 'text-status-warning' },    // compact soon
-  { minPct: 60, tone: 'text-status-warning/80' }, // worth noticing
-  { minPct: 0,  tone: 'text-kumo-subtle' }        // plenty of room
-]
-
-function formatTokenCount(n: number): string {
-  return n >= 10_000 ? `${Math.round(n / 1000)}k` : `${n}`
-}
-
-/**
- * Compact display of context-window usage. Hidden when we don't have enough
- * data to compute (e.g. no assistant messages yet).
- */
-function ContextUsageIndicator({ used, limit }: { used?: number; limit?: number }) {
-  if (typeof used !== 'number' || typeof limit !== 'number' || limit <= 0) return null
-
-  const pct = Math.min(100, Math.round((used / limit) * 100))
-  const tone = CONTEXT_USAGE_TONES.find((t) => pct >= t.minPct)?.tone ?? 'text-kumo-subtle'
-  const title = `${used.toLocaleString()} / ${limit.toLocaleString()} tokens in context (${pct}%)`
-
-  return (
-    <span className={`text-[10px] font-mono whitespace-nowrap ${tone}`} title={title}>
-      {formatTokenCount(used)}/{formatTokenCount(limit)} ({pct}%)
-    </span>
-  )
-}
-
 function ActionButton({
   icon,
   label,
@@ -1854,7 +1824,8 @@ function ActionDropdownButton({
   items: DropdownItem[]
   className?: string
 }) {
-  const { open, toggle, close, containerRef } = useDismiss()
+  const [open, setOpen] = useState(false)
+  const buttonRef = useRef<HTMLButtonElement>(null)
 
   const visibleItems = items.filter((i) => i.onClick)
   if (visibleItems.length === 0) return null
@@ -1873,34 +1844,39 @@ function ActionDropdownButton({
   }
 
   return (
-    <div ref={containerRef} className={`relative inline-flex ${extraClass ?? ''}`}>
+    <>
       <button
-        onClick={toggle}
-        className="flex items-center gap-1 w-full px-2.5 py-1.5 text-[11px] font-medium rounded-md border whitespace-nowrap bg-kumo-control border-kumo-line text-kumo-default hover:bg-kumo-fill transition-colors"
+        ref={buttonRef}
+        onClick={() => setOpen((o) => !o)}
+        className={`flex items-center gap-1 w-full px-2.5 py-1.5 text-[11px] font-medium rounded-md border whitespace-nowrap bg-kumo-control border-kumo-line text-kumo-default hover:bg-kumo-fill transition-colors ${extraClass ?? ''}`}
       >
         {icon}
         {label}
         <CaretDown size={10} className="ml-0.5" />
       </button>
-      {open && (
-        <div className="absolute bottom-full right-0 mb-1 z-[100] min-w-[140px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl">
-          {visibleItems.map((item) => (
-            <button
-              key={item.label}
-              disabled={item.disabled}
-              onClick={() => {
-                item.onClick?.()
-                close()
-              }}
-              className={`flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] rounded transition-colors text-left text-kumo-default hover:bg-kumo-fill ${item.disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
-            >
-              {item.icon}
-              {item.label}
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
+      <PortaledMenu
+        open={open}
+        triggerRef={buttonRef}
+        placement="top-right"
+        onDismiss={() => setOpen(false)}
+        className="min-w-[140px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl"
+      >
+        {visibleItems.map((item) => (
+          <button
+            key={item.label}
+            disabled={item.disabled}
+            onClick={() => {
+              item.onClick?.()
+              setOpen(false)
+            }}
+            className={`flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] rounded transition-colors text-left text-kumo-default hover:bg-kumo-fill ${item.disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+          >
+            {item.icon}
+            {item.label}
+          </button>
+        ))}
+      </PortaledMenu>
+    </>
   )
 }
 

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -25,6 +25,20 @@ import { LabelDropdown } from './LabelDropdown'
 import { TextInputModal } from './TextInputModal'
 import { Tooltip } from './Tooltip'
 import { PrTooltipContent } from './PrTooltip'
+import { ContextUsageIndicator } from './ContextUsageIndicator'
+
+/**
+ * Return the agent's context-window fill fraction (0–1) or -1 when we don't
+ * have enough data. Used to sort rows by how close they are to overflow;
+ * agents without metrics sink to the bottom in ascending sorts.
+ */
+function contextFraction(agent: AgentRuntime): number {
+  const { contextTokens, contextLimit } = agent
+  if (typeof contextTokens !== 'number' || typeof contextLimit !== 'number' || contextLimit <= 0) {
+    return -1
+  }
+  return contextTokens / contextLimit
+}
 import { useDismiss } from '../hooks/useDismiss'
 import {
   Lightning,
@@ -289,6 +303,14 @@ export function FleetTable({
           leftVal = (left.lastMessage || '').toLowerCase()
           rightVal = (right.lastMessage || '').toLowerCase()
           break
+        case 'context': {
+          // Sort by usage fraction so the agents closest to overflow surface
+          // at one end of the sorted list. Rows with no usage data sort last.
+          const leftPct = contextFraction(left)
+          const rightPct = contextFraction(right)
+          if (leftPct === rightPct) return compareStatusPriority(left.status, right.status)
+          return sortDirection === 'asc' ? leftPct - rightPct : rightPct - leftPct
+        }
         default:
           return 0
       }
@@ -372,7 +394,7 @@ export function FleetTable({
                 selected={agent.id === selectedId}
                 visibleColumns={visibleColumns}
                 onSelect={() => onSelect(agent.id)}
-                onJumpToLastUserMessage={() => onSelect(agent.id, 'last-user-message')}
+                onSelectLastMessage={() => onSelect(agent.id, 'last-user-message')}
                 onContextMenu={(event) => handleContextMenu(event, agent.id)}
                 onApprove={onApprove ? () => onApprove(agent.id) : undefined}
                 onReply={onReply ? () => onReply(agent.id) : undefined}
@@ -682,7 +704,7 @@ function AgentRow({
   selected,
   visibleColumns,
   onSelect,
-  onJumpToLastUserMessage,
+  onSelectLastMessage,
   onContextMenu,
   onApprove,
   onReply,
@@ -710,7 +732,7 @@ function AgentRow({
   selected: boolean
   visibleColumns: Set<ColumnKey>
   onSelect: () => void
-  onJumpToLastUserMessage: () => void
+  onSelectLastMessage: () => void
   onContextMenu: (event: React.MouseEvent) => void
   onApprove?: () => void
   onReply?: () => void
@@ -838,20 +860,16 @@ function AgentRow({
         </td>
       )}
       {show('task') && (
-        <td className="px-3 py-2 truncate text-kumo-default">
-          {agent.taskSummary && (
-            <span
-              className="cursor-pointer hover:text-kumo-strong"
-              title={`${agent.taskSummary}\n\nClick to jump to your last message`}
-              onClick={(event) => { event.stopPropagation(); onJumpToLastUserMessage() }}
-            >
-              {agent.taskSummary}
-            </span>
-          )}
+        <td className="px-3 py-2 truncate text-kumo-default" title={agent.taskSummary || undefined}>
+          {agent.taskSummary}
         </td>
       )}
       {show('lastMessage') && (
-        <td className="px-3 py-2 truncate text-kumo-subtle text-[11px]" title={agent.lastMessage || undefined}>
+        <td
+          className="px-3 py-2 truncate text-kumo-subtle text-[11px] cursor-pointer hover:text-kumo-default"
+          title={agent.lastMessage ? `${agent.lastMessage}\n\nClick to jump to your last message` : undefined}
+          onClick={(event) => { event.stopPropagation(); onSelectLastMessage() }}
+        >
           {agent.lastMessage || <span className="text-kumo-muted italic">--</span>}
         </td>
       )}
@@ -871,6 +889,14 @@ function AgentRow({
               {agent.model}
             </button>
           )}
+        </td>
+      )}
+      {show('context') && (
+        <td className="px-3 py-2 overflow-hidden">
+          <ContextUsageIndicator
+            used={agent.contextTokens}
+            limit={agent.contextLimit}
+          />
         </td>
       )}
       <td className="px-3 py-2 overflow-hidden">

--- a/src/renderer/src/components/LabelDropdown.tsx
+++ b/src/renderer/src/components/LabelDropdown.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
   CaretDown,
   Check,
@@ -12,7 +12,7 @@ import {
   X
 } from '@phosphor-icons/react'
 import { getLabelDefinition, LABEL_COLORS, type LabelDefinition, type LabelColorKey } from '../types'
-import { useDismiss } from '../hooks/useDismiss'
+import { PortaledMenu, type MenuPlacement } from './PortaledMenu'
 
 const BUILTIN_ICONS: Record<string, React.ReactNode> = {
   draft: <PencilSimpleLine size={12} />,
@@ -40,11 +40,19 @@ interface LabelDropdownProps {
 }
 
 export function LabelDropdown({ current, onToggle, onClear, onReplace, allLabels, onCreateLabel, onDeleteLabel, variant = 'row', onOpenChange, className: extraClass }: LabelDropdownProps) {
-  const { open, toggle, close, containerRef } = useDismiss(onOpenChange)
+  const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLDivElement>(null)
   const [creating, setCreating] = useState(false)
   const [newName, setNewName] = useState('')
   const [newColor, setNewColor] = useState<LabelColorKey>('blue')
   const [replacingLabelId, setReplacingLabelId] = useState<string | null>(null)
+
+  useEffect(() => {
+    onOpenChange?.(open)
+  }, [open, onOpenChange])
+
+  const close = () => setOpen(false)
+  const toggle = () => setOpen((prev) => !prev)
 
   const currentSet = new Set(current)
 
@@ -107,12 +115,15 @@ export function LabelDropdown({ current, onToggle, onClear, onReplace, allLabels
   const isReplacing = replacingLabelId !== null
   const replacingDef = replacingLabelId ? getLabelDefinition(replacingLabelId, allLabels) : null
 
-  let menuPosition: string
+  // Map each visual variant to a menu placement relative to its trigger.
+  // 'action' opens upward-left (it sits in the bottom action rail); the others
+  // open downward from their respective sides.
+  let placement: MenuPlacement
   let trigger: React.ReactNode
 
   switch (variant) {
     case 'action':
-      menuPosition = 'absolute bottom-full left-0 mb-1'
+      placement = 'top-left'
       trigger = (
         <button
           onClick={handleOpen}
@@ -126,7 +137,7 @@ export function LabelDropdown({ current, onToggle, onClear, onReplace, allLabels
       break
 
     case 'inline':
-      menuPosition = 'absolute top-full left-0 mt-1'
+      placement = 'bottom-left'
       trigger = (
         <div className="inline-flex items-center gap-0.5">
           {sortedCurrent.map((def) => {
@@ -155,7 +166,7 @@ export function LabelDropdown({ current, onToggle, onClear, onReplace, allLabels
       break
 
     default:
-      menuPosition = 'absolute top-full right-0 mt-1'
+      placement = 'bottom-right'
       trigger = (
         <button
           onClick={handleOpen}
@@ -173,7 +184,7 @@ export function LabelDropdown({ current, onToggle, onClear, onReplace, allLabels
       // Replace mode: pick a replacement for the clicked label, or remove it
       const otherLabels = allLabels.filter((l) => l.id !== replacingLabelId)
       return (
-        <div className={`${menuPosition} z-[100] min-w-[160px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl`}>
+        <div className="min-w-[160px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl">
           <div className="px-2.5 py-1 text-[10px] text-kumo-subtle font-medium">
             Replace {replacingDef.name}
           </div>
@@ -293,7 +304,7 @@ export function LabelDropdown({ current, onToggle, onClear, onReplace, allLabels
 
     // Normal multi-select mode
     return (
-      <div className={`${menuPosition} z-[100] min-w-[160px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl`}>
+      <div className="min-w-[160px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl">
         {current.length > 0 && (
           <button
             onClick={(event) => { event.stopPropagation(); onClear() }}
@@ -409,9 +420,16 @@ export function LabelDropdown({ current, onToggle, onClear, onReplace, allLabels
   }
 
   return (
-    <div ref={containerRef} className={`relative inline-flex ${extraClass ?? ''}`}>
+    <div ref={triggerRef} className={`relative inline-flex ${extraClass ?? ''}`}>
       {trigger}
-      {open && renderMenu()}
+      <PortaledMenu
+        open={open}
+        triggerRef={triggerRef}
+        placement={placement}
+        onDismiss={close}
+      >
+        {renderMenu()}
+      </PortaledMenu>
     </div>
   )
 }

--- a/src/renderer/src/components/PortaledMenu.tsx
+++ b/src/renderer/src/components/PortaledMenu.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+/** Where to anchor the menu relative to the trigger button. */
+export type MenuPlacement =
+  /** Above the trigger, right edge aligned. */
+  | 'top-right'
+  /** Above the trigger, left edge aligned. */
+  | 'top-left'
+  /** Below the trigger, right edge aligned. */
+  | 'bottom-right'
+  /** Below the trigger, left edge aligned. */
+  | 'bottom-left'
+
+interface MenuCoords {
+  top?: number
+  bottom?: number
+  left?: number
+  right?: number
+}
+
+function computeCoords(rect: DOMRect, placement: MenuPlacement, gap: number): MenuCoords {
+  // Use viewport-relative coords so `position: fixed` in the portaled menu
+  // sits exactly where the trigger would have placed an absolute child, but
+  // without any overflow-clipping from the trigger's ancestors.
+  switch (placement) {
+    case 'top-right':
+      return { bottom: window.innerHeight - rect.top + gap, right: window.innerWidth - rect.right }
+    case 'top-left':
+      return { bottom: window.innerHeight - rect.top + gap, left: rect.left }
+    case 'bottom-right':
+      return { top: rect.bottom + gap, right: window.innerWidth - rect.right }
+    case 'bottom-left':
+      return { top: rect.bottom + gap, left: rect.left }
+  }
+}
+
+interface PortaledMenuProps {
+  open: boolean
+  triggerRef: React.RefObject<HTMLElement | null>
+  placement: MenuPlacement
+  onDismiss: () => void
+  /** Gap in px between trigger and menu (default 4). */
+  gap?: number
+  /** Anything clicked inside this ref is treated as "inside" and does not
+   *  dismiss. Use for nested popovers or input fields that live within the
+   *  menu body. */
+  children: React.ReactNode
+  className?: string
+}
+
+/**
+ * Renders its children at document.body, positioned relative to a trigger
+ * element. Handles click-outside and Escape-to-close. Reposition on scroll
+ * and window resize so the menu tracks its trigger.
+ */
+export function PortaledMenu({
+  open,
+  triggerRef,
+  placement,
+  onDismiss,
+  gap = 4,
+  children,
+  className
+}: PortaledMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [coords, setCoords] = useState<MenuCoords | null>(null)
+
+  // Compute position synchronously after the browser lays out the trigger,
+  // so the menu appears in the right place on the first paint after open.
+  useLayoutEffect(() => {
+    if (!open) {
+      setCoords(null)
+      return
+    }
+    const rect = triggerRef.current?.getBoundingClientRect()
+    if (rect) setCoords(computeCoords(rect, placement, gap))
+  }, [open, placement, gap, triggerRef])
+
+  // Keep the menu pinned to its trigger when the user scrolls or resizes.
+  useEffect(() => {
+    if (!open) return
+    const reposition = () => {
+      const rect = triggerRef.current?.getBoundingClientRect()
+      if (rect) setCoords(computeCoords(rect, placement, gap))
+    }
+    window.addEventListener('resize', reposition)
+    window.addEventListener('scroll', reposition, true)
+    return () => {
+      window.removeEventListener('resize', reposition)
+      window.removeEventListener('scroll', reposition, true)
+    }
+  }, [open, placement, gap, triggerRef])
+
+  // Click-outside + Escape dismissal. Check both the trigger and the portaled
+  // menu — clicks inside either count as "inside".
+  useEffect(() => {
+    if (!open) return
+    const onClick = (event: MouseEvent) => {
+      const target = event.target as Node
+      if (triggerRef.current?.contains(target)) return
+      if (menuRef.current?.contains(target)) return
+      onDismiss()
+    }
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onDismiss()
+    }
+    document.addEventListener('mousedown', onClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open, triggerRef, onDismiss])
+
+  if (!open || !coords) return null
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      className={`fixed z-[200] ${className ?? ''}`}
+      style={coords}
+    >
+      {children}
+    </div>,
+    document.body
+  )
+}

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -8,7 +8,7 @@ import type {
   MessageAttachment,
   PermissionRequest as PermissionRequestPayload
 } from '../types/api'
-import { lookupContextLimit } from './useModelOptions'
+import { ensureProvidersLoaded, lookupContextLimit, subscribeToContextLimits } from './useModelOptions'
 
 interface HistoricalMessageInfo {
   id: string
@@ -311,6 +311,27 @@ function cancelCompactingWatchdog(agentId: string): void {
     clearTimeout(existing)
     compactingTimers.delete(agentId)
   }
+}
+
+/**
+ * Fill in contextLimit for any agent whose rawModelId is now in the provider
+ * cache but whose limit wasn't known when its messages were hydrated (typical
+ * on cold start, where session messages arrive before the provider fetch).
+ * Subscribed in the hook's useEffect to avoid touching useModelOptions during
+ * module initialization — the two modules have a circular import via
+ * formatModelName.
+ */
+function backfillContextLimits(): void {
+  let changed = false
+  for (const agent of state.agents.values()) {
+    if (agent.contextLimit !== undefined || !agent.rawModelId) continue
+    const limit = lookupContextLimit(agent.rawModelId)
+    if (limit !== undefined) {
+      agent.contextLimit = limit
+      changed = true
+    }
+  }
+  if (changed) emit({ agents: true })
 }
 
 // Tracks how many step-start parts (invoked sub-agents) are currently active
@@ -789,7 +810,16 @@ function hydrateHistoricalMessages(entries: unknown): void {
         agent.model = formatted
         agent.rawModelId = entry.info.modelID
         const limit = lookupContextLimit(entry.info.modelID)
-        if (limit !== undefined) agent.contextLimit = limit
+        if (limit !== undefined) {
+          agent.contextLimit = limit
+        } else {
+          console.debug('[hydrate] no context limit found in cache', {
+            agentId: agent.id,
+            modelId: entry.info.modelID,
+            hasTokens: !!entry.info.tokens,
+            contextTokens: agent.contextTokens
+          })
+        }
         // Only seed configuredModel if not already set by a config fetch or
         // prior setAgentModel call, so the authoritative config value wins.
         if (!agent.configuredModel) {
@@ -2570,8 +2600,17 @@ export function useAgentStore() {
           state.initializing = false
           emit({ agents: true })
         }
-      })
+      }),
+      // Backfill contextLimit for agents whose modelID was hydrated before the
+      // provider fetch completed (common on cold start).
+      subscribeToContextLimits(backfillContextLimits)
     ]
+
+    // Kick off the provider fetch so context-window limits are populated for
+    // agents that will hydrate shortly. useModelOptions would do this too, but
+    // only when a consumer mounts — the fleet table's Context column needs
+    // the data even if the user never opens the Launch or Settings modal.
+    void ensureProvidersLoaded()
 
     // Run initial fetch. If restoration already completed before we
     // mounted (fast startup or no persisted agents), clear initializing

--- a/src/renderer/src/hooks/useModelOptions.ts
+++ b/src/renderer/src/hooks/useModelOptions.ts
@@ -25,16 +25,37 @@ export interface ProviderData {
  */
 const contextLimitCache = new Map<string, number>()
 
+/** Observers notified when new context limits are recorded — typically the
+ *  agent store, which backfills limits onto agents whose modelID was hydrated
+ *  before the provider fetch completed. */
+const contextLimitObservers = new Set<() => void>()
+
+export function subscribeToContextLimits(listener: () => void): () => void {
+  contextLimitObservers.add(listener)
+  return () => contextLimitObservers.delete(listener)
+}
+
 export function recordContextLimitsFromProviders(data: ProviderData): void {
+  let changed = false
   for (const provider of data.providers) {
     for (const model of Object.values(provider.models)) {
       const limit = model.limit?.context
       if (typeof limit !== 'number' || limit <= 0) continue
-      contextLimitCache.set(`${provider.id}/${model.id}`, limit)
+      const key = `${provider.id}/${model.id}`
+      if (contextLimitCache.get(key) !== limit) {
+        contextLimitCache.set(key, limit)
+        changed = true
+      }
       // Also index by bare id so callers that don't carry the provider prefix
       // can still look up a limit when it's unambiguous.
-      if (!contextLimitCache.has(model.id)) contextLimitCache.set(model.id, limit)
+      if (!contextLimitCache.has(model.id)) {
+        contextLimitCache.set(model.id, limit)
+        changed = true
+      }
     }
+  }
+  if (changed) {
+    for (const listener of contextLimitObservers) listener()
   }
 }
 
@@ -105,6 +126,52 @@ export function resolveSystemDefaultLabel(
  * Falls back to a static list if no runtimes are available.
  * Resolves the system default model name from the opencode config.
  */
+/**
+ * Fetch providers + system config once and cache the results so repeated
+ * callers (useModelOptions across multiple modals, the agent store's boot
+ * backfill) share a single network call. The first call triggers the fetch;
+ * subsequent calls during the same in-flight request await the same promise.
+ */
+interface ProviderFetchResult {
+  providerData: ProviderData | null
+  configModel: string | undefined
+}
+
+let providerFetchPromise: Promise<ProviderFetchResult> | null = null
+
+export function ensureProvidersLoaded(): Promise<ProviderFetchResult> {
+  if (providerFetchPromise) return providerFetchPromise
+
+  providerFetchPromise = (async () => {
+    try {
+      const [providersResult, configResult] = await Promise.all([
+        window.api.listAllProviders(),
+        window.api.getSystemConfig(),
+      ])
+
+      const providerData = providersResult.ok && providersResult.data
+        ? providersResult.data as ProviderData
+        : null
+
+      if (providerData) recordContextLimitsFromProviders(providerData)
+
+      const configModel = configResult.ok && configResult.data
+        ? (configResult.data as { model?: string }).model
+        : undefined
+
+      return { providerData, configModel }
+    } catch (err) {
+      console.warn('[ensureProvidersLoaded] fetch failed', err)
+      // Reset so a later caller can retry. Without this, a transient failure
+      // would permanently disable provider-dependent features.
+      providerFetchPromise = null
+      return { providerData: null, configModel: undefined }
+    }
+  })()
+
+  return providerFetchPromise
+}
+
 export function useModelOptions(): { options: ModelOption[]; loading: boolean } {
   const [options, setOptions] = useState<ModelOption[]>(STATIC_MODEL_OPTIONS)
   const [loading, setLoading] = useState(true)
@@ -112,45 +179,22 @@ export function useModelOptions(): { options: ModelOption[]; loading: boolean } 
   useEffect(() => {
     let cancelled = false
 
-    const fetchData = async (): Promise<void> => {
-      try {
-        const [providersResult, configResult] = await Promise.all([
-          window.api.listAllProviders(),
-          window.api.getSystemConfig(),
-        ])
-        if (cancelled) return
+    void ensureProvidersLoaded().then(({ providerData, configModel }) => {
+      if (cancelled) return
 
-        const providerData = providersResult.ok && providersResult.data
-          ? providersResult.data as ProviderData
-          : null
-
-        if (providerData) recordContextLimitsFromProviders(providerData)
-
-        const configModel = configResult.ok && configResult.data
-          ? (configResult.data as { model?: string }).model
-          : undefined
-
-        let opts: ModelOption[]
-        if (providerData) {
-          const dynamicOptions = buildOptionsFromProviders(providerData)
-          opts = dynamicOptions.length > 1 ? dynamicOptions : [...STATIC_MODEL_OPTIONS]
-        } else {
-          opts = [...STATIC_MODEL_OPTIONS]
-        }
-
-        // Resolve the system default label
-        const defaultLabel = resolveSystemDefaultLabel(configModel, providerData)
-        opts[0] = { value: 'auto', label: defaultLabel }
-
-        setOptions(opts)
-      } catch {
-        // Fall back to static list silently
-      } finally {
-        if (!cancelled) setLoading(false)
+      let opts: ModelOption[]
+      if (providerData) {
+        const dynamicOptions = buildOptionsFromProviders(providerData)
+        opts = dynamicOptions.length > 1 ? dynamicOptions : [...STATIC_MODEL_OPTIONS]
+      } else {
+        opts = [...STATIC_MODEL_OPTIONS]
       }
-    }
 
-    void fetchData()
+      opts[0] = { value: 'auto', label: resolveSystemDefaultLabel(configModel, providerData) }
+      setOptions(opts)
+      setLoading(false)
+    })
+
     return () => { cancelled = true }
   }, [])
 

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -104,7 +104,7 @@ export interface AgentRuntimeError {
 
 // ── Column visibility ──
 
-export type ColumnKey = 'agent' | 'status' | 'label' | 'task' | 'branch' | 'model' | 'lastMessage'
+export type ColumnKey = 'agent' | 'status' | 'label' | 'task' | 'branch' | 'model' | 'lastMessage' | 'context'
 
 export interface ColumnDef {
   key: ColumnKey
@@ -122,6 +122,9 @@ export const ALL_COLUMNS: ColumnDef[] = [
   { key: 'lastMessage', label: 'Last Message', defaultVisible: true,  flex: 4 },
   { key: 'branch',      label: 'Branch',       defaultVisible: true,  flex: 2 },
   { key: 'model',       label: 'Model',        defaultVisible: true,  flex: 2 },
+  // Context usage is hidden by default to keep the table compact; power users
+  // can enable it via the column picker when they care about compaction timing.
+  { key: 'context',     label: 'Context',      defaultVisible: false, flex: 2 },
 ]
 
 const COLUMN_VIS_KEY = 'oc-orchestrator:column-visibility'


### PR DESCRIPTION
## Summary

Two UX polish items layered on top of the compaction work in #154.

### Portaled dropdowns
The Label, PR, and Open In dropdowns in the detail drawer sit in a narrow right column inside a scrollable container. Their menus clipped against both the input box to the left and the scroll region above.

- New \`PortaledMenu\` helper renders the menu at \`document.body\` with viewport-relative coordinates computed from the trigger's \`getBoundingClientRect()\`.
- Handles click-outside, Escape, and reposition on scroll/resize.
- Four placements (\`top-left\`, \`top-right\`, \`bottom-left\`, \`bottom-right\`) so each dropdown variant anchors where it used to.
- \`ActionDropdownButton\` (PR, Open In) and all three \`LabelDropdown\` variants (\`row\`, \`action\`, \`inline\`) now route through this helper.

### Context column in the fleet table
- New \`Context\` column showing \`73k/200k (37%)\` with the same color ramp as the drawer indicator.
- Hidden by default — enable via the column picker when fleet-wide compaction timing matters.
- Sortable by usage fraction so agents closest to overflow surface at one end.

### Fix: context usage didn't populate until a modal opened
The provider fetch that populates the context-limit cache lived inside \`useModelOptions\`, which only ran when a Settings or Launch modal mounted. Agents that came back from a restart never got their limits filled.

- Extract the fetch into a shared \`ensureProvidersLoaded\` cache.
- Kick it off at agent-store boot so the Context column and header indicator populate even if the user never opens a modal.
- When provider data lands, \`backfillContextLimits\` fills in the limit on already-hydrated agents via a small observer pattern.
- Extract \`ContextUsageIndicator\` into its own file so the drawer and fleet table share one implementation.

## Testing
- \`npm run typecheck\` clean
- \`npm test\` — 212 passing
- Manual: opened all three dropdowns in a shortened drawer, menus render without clipping. Enabled the Context column from the column picker, values populated for every agent on cold start.