### PR TITLE
Show context usage as a progress bar in the fleet table

### DIFF
--- a/src/renderer/src/components/ContextUsageIndicator.tsx
+++ b/src/renderer/src/components/ContextUsageIndicator.tsx
@@ -2,12 +2,15 @@
  * Thresholds for the context-usage color ramp, ordered highest → lowest. The
  * first entry whose `minPct` the current usage meets wins. Exposed as a table
  * rather than an if/else chain so the breakpoints are easy to tune.
+ *
+ * Each entry carries both a text tone and a matching background tone so the
+ * bar variant and the text variants stay visually consistent.
  */
-const CONTEXT_USAGE_TONES: ReadonlyArray<{ minPct: number; tone: string }> = [
-  { minPct: 95, tone: 'text-kumo-danger' },       // compact now
-  { minPct: 80, tone: 'text-status-warning' },    // compact soon
-  { minPct: 60, tone: 'text-status-warning/80' }, // worth noticing
-  { minPct: 0,  tone: 'text-kumo-subtle' }        // plenty of room
+const CONTEXT_USAGE_TONES: ReadonlyArray<{ minPct: number; text: string; bar: string }> = [
+  { minPct: 95, text: 'text-kumo-danger',        bar: 'bg-kumo-danger' },        // compact now
+  { minPct: 80, text: 'text-status-warning',     bar: 'bg-status-warning' },     // compact soon
+  { minPct: 60, text: 'text-status-warning/80',  bar: 'bg-status-warning/80' },  // worth noticing
+  { minPct: 0,  text: 'text-kumo-subtle',        bar: 'bg-kumo-subtle' }         // plenty of room
 ]
 
 function formatTokenCount(n: number): string {
@@ -17,9 +20,11 @@ function formatTokenCount(n: number): string {
 interface ContextUsageIndicatorProps {
   used?: number
   limit?: number
-  /** Display variant. 'full' shows `73k/200k (37%)`; 'compact' shows just the
-   *  percentage (useful in narrow table columns). */
-  variant?: 'full' | 'compact'
+  /** Display variant.
+   *  - 'full': `73k/200k (37%)` text
+   *  - 'compact': `37%` text
+   *  - 'bar': horizontal progress bar with percentage underneath */
+  variant?: 'full' | 'compact' | 'bar'
 }
 
 /**
@@ -30,15 +35,26 @@ export function ContextUsageIndicator({ used, limit, variant = 'full' }: Context
   if (typeof used !== 'number' || typeof limit !== 'number' || limit <= 0) return null
 
   const pct = Math.min(100, Math.round((used / limit) * 100))
-  const tone = CONTEXT_USAGE_TONES.find((t) => pct >= t.minPct)?.tone ?? 'text-kumo-subtle'
+  const tones = CONTEXT_USAGE_TONES.find((t) => pct >= t.minPct) ?? CONTEXT_USAGE_TONES[CONTEXT_USAGE_TONES.length - 1]
   const title = `${used.toLocaleString()} / ${limit.toLocaleString()} tokens in context (${pct}%)`
+
+  if (variant === 'bar') {
+    return (
+      <div className="flex flex-col items-stretch gap-0.5 w-full" title={title}>
+        <div className="h-1 rounded-sm bg-kumo-fill overflow-hidden">
+          <div className={`h-full ${tones.bar} transition-all`} style={{ width: `${pct}%` }} />
+        </div>
+        <span className={`text-[10px] font-mono ${tones.text}`}>{pct}%</span>
+      </div>
+    )
+  }
 
   const label = variant === 'compact'
     ? `${pct}%`
     : `${formatTokenCount(used)}/${formatTokenCount(limit)} (${pct}%)`
 
   return (
-    <span className={`text-[10px] font-mono whitespace-nowrap ${tone}`} title={title}>
+    <span className={`text-[10px] font-mono whitespace-nowrap ${tones.text}`} title={title}>
       {label}
     </span>
   )

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -900,6 +900,7 @@ function AgentRow({
           <ContextUsageIndicator
             used={agent.contextTokens}
             limit={agent.contextLimit}
+            variant="bar"
           />
         </td>
       )}


### PR DESCRIPTION
## Summary

A bar is faster to scan across a fleet than reading \`73k/200k (37%)\` numbers on every row. The Context column now renders a thin horizontal fill bar with the percentage underneath.

## Details

- New \`variant: 'bar'\` on \`ContextUsageIndicator\` — fill bar on top, percentage text below.
- Color ramp matches the existing text variants: subtle under 60%, amber 60–80%, warning 80–95%, danger 95%+. Both the fill and the percentage text use the same tone for each threshold.
- Fleet table's Context column switches to the \`bar\` variant.
- Drawer header and under-input indicator keep the \`full\` variant (\`73k/200k (37%)\`) since they sit inline with other text where a bar would look out of place.

## Testing

- \`npm run typecheck\` clean
- \`npm test\` — 212 passing
- Manual: enabled the Context column, bar fills and tone shifts at the 60/80/95 thresholds