### PR TITLE
Fix invisible context bar fill at warning thresholds

### DIFF
--- a/src/renderer/src/components/ContextUsageIndicator.tsx
+++ b/src/renderer/src/components/ContextUsageIndicator.tsx
@@ -7,10 +7,10 @@
  * bar variant and the text variants stay visually consistent.
  */
 const CONTEXT_USAGE_TONES: ReadonlyArray<{ minPct: number; text: string; bar: string }> = [
-  { minPct: 95, text: 'text-kumo-danger',        bar: 'bg-kumo-danger' },        // compact now
-  { minPct: 80, text: 'text-status-warning',     bar: 'bg-status-warning' },     // compact soon
-  { minPct: 60, text: 'text-status-warning/80',  bar: 'bg-status-warning/80' },  // worth noticing
-  { minPct: 0,  text: 'text-kumo-subtle',        bar: 'bg-kumo-subtle' }         // plenty of room
+  { minPct: 95, text: 'text-kumo-danger',       bar: 'bg-kumo-danger' },       // compact now
+  { minPct: 80, text: 'text-kumo-warning',      bar: 'bg-kumo-warning' },      // compact soon
+  { minPct: 60, text: 'text-kumo-warning/80',   bar: 'bg-kumo-warning/80' },   // worth noticing
+  { minPct: 0,  text: 'text-kumo-subtle',       bar: 'bg-kumo-subtle' }        // plenty of room
 ]
 
 function formatTokenCount(n: number): string {

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -1429,7 +1429,7 @@ const MessageBubble = memo(function MessageBubble({
     return (
       <div
         ref={rootRef}
-        className="self-center my-2 px-3 py-1.5 text-[11px] text-status-warning/90 border border-status-warning/30 bg-status-warning/10 rounded-full flex items-center gap-1.5"
+        className="self-center my-2 px-3 py-1.5 text-[11px] text-kumo-warning/90 border border-kumo-warning/30 bg-kumo-warning/10 rounded-full flex items-center gap-1.5"
       >
         {message.compactionActive
           ? <CircleNotch size={11} weight="bold" className="animate-spin" />
@@ -1682,8 +1682,8 @@ function bannerContent(kind: BannerKind, agent: AgentRuntime): BannerContent {
       return {
         title: 'Context window full',
         body: 'This session is too long for the model to read in one pass. Compact the conversation to free up space, or switch to a model with a larger context window.',
-        containerTone: 'border-status-warning/40 bg-status-warning/10',
-        iconTone: 'text-status-warning'
+        containerTone: 'border-kumo-warning/40 bg-kumo-warning/10',
+        iconTone: 'text-kumo-warning'
       }
     case 'error':
       return {

--- a/src/renderer/src/components/StatusBadge.tsx
+++ b/src/renderer/src/components/StatusBadge.tsx
@@ -15,7 +15,7 @@ const statusStyles: Record<AgentStatus, string> = {
   starting: 'bg-kumo-fill text-kumo-subtle',
   stopping: 'bg-kumo-fill text-kumo-subtle',
   disconnected: 'bg-status-errored-bg text-status-errored',
-  compacting: 'bg-status-warning/20 text-status-warning'
+  compacting: 'bg-kumo-warning/20 text-kumo-warning'
 }
 
 const pulsing = new Set<AgentStatus>(['needs_input', 'needs_approval', 'errored', 'compacting'])


### PR DESCRIPTION
## Summary

The context usage indicator referenced Tailwind classes `bg-status-warning` and `text-status-warning`, but the theme only defines `--color-kumo-warning`. Between 60 and 94 percent the bar rendered with no fill and the percent label lost its color.

`StatusBadge`'s `compacting` state and `DetailDrawer`'s compaction chip and overflow banner had the same dead-token bug.

Switched all four sites to `kumo-warning`, matching how the rest of the app names semantic warning tones.

## Before / after

At 60% context fill the bar track stayed empty and only the `60%` label was visible in default grey. After the fix the bar fills to 60% in the warning tone.