### PR TITLE
Show live sub-agent progress inside task tool bubbles

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -15,7 +15,8 @@ import { useAgentStore, setViewedAgentId, type LiveAgent } from './hooks/useAgen
 import { useCustomLabels } from './hooks/useCustomLabels'
 import { type AgentRuntime, type Interrupt, type Message, type ColumnKey, type ColumnWidths, type SortDirection, loadColumnVisibility, saveColumnVisibility, loadColumnWidths, saveColumnWidths, loadSort, saveSort, compareStatusPriority } from './types'
 import type { FileChange } from './components/FilesChanged'
-import type { ToolCall } from './components/ToolsUsage'
+import type { ToolCall, ChildTranscriptEntry } from './components/ToolsUsage'
+import type { LiveMessage } from './hooks/useAgentStore'
 import type { EventEntry } from './components/EventLog'
 import { loadSettings, parseSlashCommand, type QuickAction } from './data/settings'
 
@@ -38,6 +39,68 @@ function mapToolState(toolState?: string): ToolCall['state'] {
   if (toolState === 'completed') return 'completed'
   if (toolState === 'error' || toolState === 'failed') return 'failed'
   return 'running'
+}
+
+/** Flatten a sub-agent's live messages into the compact transcript shape that
+ *  a `task` tool bubble renders inline. We keep every text chunk and every
+ *  tool invocation in chronological order; stale/step-start/finish parts are
+ *  skipped because they don't help the user see progress. Called per-task-
+ *  tool-call whenever the parent transcript rebuilds, so this stays cheap. */
+function buildChildTranscript(messages: LiveMessage[]): ChildTranscriptEntry[] {
+  const entries: ChildTranscriptEntry[] = []
+  for (const msg of messages) {
+    for (const part of msg.parts) {
+      if (part.type === 'text' && part.text) {
+        entries.push({
+          id: part.id,
+          kind: 'text',
+          label: part.text
+        })
+      } else if (part.type === 'tool' && part.toolName) {
+        entries.push({
+          id: part.id,
+          kind: 'tool',
+          label: part.toolName,
+          toolState: mapToolState(part.toolState),
+          toolSummary: summarizeChildToolInput(part.toolName, part.toolInput)
+        })
+      }
+    }
+  }
+  return entries
+}
+
+/** Single-line summary of a sub-agent tool's input. Mirrors the parent
+ *  bubble's formatter (DetailDrawer.summarizeToolInput) but collapsed onto
+ *  one line and truncated, because we're rendering inside a nested list. */
+function summarizeChildToolInput(name: string, input: string | undefined): string | undefined {
+  if (!input) return undefined
+  try {
+    const parsed = JSON.parse(input) as Record<string, unknown>
+    const pick = (...keys: string[]): string | undefined => {
+      for (const key of keys) {
+        const value = parsed[key]
+        if (typeof value === 'string' && value.trim()) return value
+      }
+      return undefined
+    }
+    const raw = (() => {
+      switch (name.toLowerCase()) {
+        case 'bash': return pick('command')
+        case 'read': case 'write': case 'edit': return pick('filePath', 'file_path', 'path')
+        case 'grep': return pick('pattern')
+        case 'glob': return pick('pattern')
+        case 'webfetch': return pick('url')
+        case 'task': return pick('description', 'prompt')
+        default: return undefined
+      }
+    })()
+    if (!raw) return undefined
+    const oneLine = raw.replace(/\s+/g, ' ').trim()
+    return oneLine.length > 80 ? oneLine.slice(0, 80) + '…' : oneLine
+  } catch {
+    return undefined
+  }
 }
 
 function extractLastAssistantMessage(messages: { role: string; parts: { type: string; text?: string }[] }[]): string | undefined {
@@ -545,7 +608,11 @@ export function App() {
               state: mapToolState(part.toolState),
               input: part.toolInput,
               output: part.text ?? undefined,
-              timestamp: msg.createdAt
+              timestamp: msg.createdAt,
+              childSessionId: part.childSessionId,
+              childTranscript: part.childSessionId
+                ? buildChildTranscript(getMessagesForSession(part.childSessionId))
+                : undefined
             })
             break
           case 'file':

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -1584,13 +1584,27 @@ const ToolGroupBubble = memo(function ToolGroupBubble({
   verbose?: boolean
   rootRef?: (node: HTMLElement | null) => void
 }) {
-  const [expanded, setExpanded] = useState(verbose)
   const toolCalls = message.toolCalls ?? []
+
+  // Auto-expand the bubble when a `task` tool is still running so the user
+  // can see sub-agent progress without having to click. Otherwise the bubble
+  // looks frozen ("tool completed" only appears at the very end) and the user
+  // has no feedback until the child session finishes — which for CI-watching
+  // tasks can be many minutes.
+  const hasRunningTask = toolCalls.some((tool) => tool.name === 'task' && tool.state === 'running')
+  const [expanded, setExpanded] = useState(verbose || hasRunningTask)
 
   // Sync with verbose prop changes (e.g. user toggles verbose mode)
   useEffect(() => {
     if (verbose) setExpanded(true)
   }, [verbose])
+
+  // Once a task starts running inside this group, force the bubble open.
+  // We don't collapse it again when the task finishes — the user may want to
+  // scroll back through the progress.
+  useEffect(() => {
+    if (hasRunningTask) setExpanded(true)
+  }, [hasRunningTask])
 
   return (
     <div ref={rootRef} className="max-w-[95%] self-start">
@@ -1620,6 +1634,14 @@ const ToolGroupBubble = memo(function ToolGroupBubble({
                   {summarizeToolInput(tool.name, tool.input)}
                 </pre>
               )}
+              {/* Live sub-agent progress for the `task` tool. The child
+                  session's messages are already flowing through EventBridge →
+                  useAgentStore; we just mirror them inline so the user can
+                  watch what the sub-agent is doing. Rendered above the final
+                  output so the transcript reads top-to-bottom. */}
+              {tool.name === 'task' && tool.childTranscript && tool.childTranscript.length > 0 && (
+                <ChildTaskTranscript entries={tool.childTranscript} running={tool.state === 'running'} />
+              )}
               {tool.output && (
                 <pre className="mt-2 whitespace-pre-wrap break-all font-mono text-[10px] text-kumo-subtle bg-kumo-overlay rounded-md px-2 py-1.5 overflow-x-auto">
                   {tool.output}
@@ -1637,6 +1659,48 @@ const ToolGroupBubble = memo(function ToolGroupBubble({
   prev.message.toolCalls === next.message.toolCalls &&
   prev.verbose === next.verbose
 )
+
+function ChildTaskTranscript({
+  entries,
+  running
+}: {
+  entries: NonNullable<ToolCall['childTranscript']>
+  running: boolean
+}) {
+  return (
+    <div className="mt-2 rounded-md border border-kumo-line bg-kumo-overlay px-2 py-1.5">
+      <div className="mb-1 flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-kumo-subtle">
+        {running && <CircleNotch size={10} className="animate-spin text-kumo-link" />}
+        <span>sub-agent {running ? 'working' : 'transcript'}</span>
+      </div>
+      <div className="flex flex-col gap-1">
+        {entries.map((entry) => (
+          <div key={entry.id} className="text-[10px] font-mono leading-tight">
+            {entry.kind === 'text' ? (
+              <div className="whitespace-pre-wrap break-words text-kumo-default">
+                {entry.label}
+              </div>
+            ) : (
+              <div className="flex items-start gap-1.5 text-kumo-subtle">
+                <span className={`shrink-0 ${toolIconStyle(entry.toolState)}`}>
+                  {entry.toolState === 'completed'
+                    ? '✓'
+                    : entry.toolState === 'failed'
+                    ? '✗'
+                    : '…'}
+                </span>
+                <span className="text-kumo-link">{entry.label}</span>
+                {entry.toolSummary && (
+                  <span className="truncate text-kumo-subtle">{entry.toolSummary}</span>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
 
 /**
  * Which banner the drawer should render, derived from the agent's transient

--- a/src/renderer/src/components/ToolsUsage.tsx
+++ b/src/renderer/src/components/ToolsUsage.tsx
@@ -8,6 +8,28 @@ export interface ToolCall {
   input?: string
   output?: string
   timestamp: number
+  /** For the `task` tool — sessionId of the sub-agent, so the UI can
+   *  render live progress by reading the child session's messages. */
+  childSessionId?: string
+  /** For the `task` tool — a flattened snapshot of the sub-agent's
+   *  transcript, computed by the app whenever the parent message list
+   *  rebuilds. Populated only when `childSessionId` is set. */
+  childTranscript?: ChildTranscriptEntry[]
+}
+
+/** Compact representation of a sub-agent's live activity for display inside
+ *  a `task` tool bubble. We flatten text and tool calls into a linear list
+ *  because the nested rendering doesn't need the full message grouping. */
+export interface ChildTranscriptEntry {
+  id: string
+  kind: 'text' | 'tool'
+  /** For text entries: the assistant's text. For tool entries: the tool name. */
+  label: string
+  /** For tool entries: the lifecycle state (so we can show a spinner). */
+  toolState?: 'running' | 'completed' | 'failed'
+  /** For tool entries: a short input summary (matches the parent bubble's
+   *  `summarizeToolInput` output). */
+  toolSummary?: string
 }
 
 interface ToolsUsageProps {

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -53,6 +53,7 @@ interface HistoricalMessagePart {
     title?: string
     raw?: string
     input?: unknown
+    metadata?: Record<string, unknown>
   }
   reasoning?: string
   reason?: string
@@ -181,6 +182,12 @@ export interface LiveMessagePart {
   compactionAuto?: boolean
   /** For compaction parts — whether the compaction was triggered by a context overflow. */
   compactionOverflow?: boolean
+  /** For task-tool parts — sessionId of the sub-agent. The task tool reports
+   *  this via ctx.metadata({ metadata: { sessionId } }) when the sub-session
+   *  starts; all streaming progress is emitted against this child sessionId
+   *  (not the parent), so the UI has to read from that bucket to show live
+   *  output while the task runs. */
+  childSessionId?: string
 }
 
 export interface FileChangeRecord {
@@ -581,6 +588,16 @@ function getToolState(partState: Record<string, unknown> | undefined): string | 
   return typeof status === 'string' ? status : undefined
 }
 
+/** Extract a sub-agent sessionId from a tool part's state.metadata.
+ *  The task tool sets `metadata: { sessionId }` via ctx.metadata() both when
+ *  the sub-session is created (running) and in the final return (completed),
+ *  so we can read it at any point in the tool's lifecycle. */
+function getChildSessionId(partState: Record<string, unknown> | undefined): string | undefined {
+  const metadata = partState?.metadata as Record<string, unknown> | undefined
+  const sessionId = metadata?.sessionId
+  return typeof sessionId === 'string' ? sessionId : undefined
+}
+
 function stringifyToolInput(input: unknown): string | undefined {
   if (input === undefined) return undefined
   try {
@@ -663,6 +680,9 @@ function upsertMessagePart(message: LiveMessage, nextPart: LiveMessagePart): voi
     existingPart.text = nextPart.text
     existingPart.toolName = nextPart.toolName
     existingPart.toolState = nextPart.toolState
+    // Don't clobber a known childSessionId with undefined — the parent tool
+    // part may receive updates that omit metadata.
+    if (nextPart.childSessionId) existingPart.childSessionId = nextPart.childSessionId
     return
   }
 
@@ -681,6 +701,7 @@ function mapHistoricalPart(part: HistoricalMessagePart): LiveMessagePart {
     nextPart.toolState = part.state?.status
     nextPart.toolInput = stringifyToolInput(part.state?.input)
     nextPart.text = part.text ?? part.state?.output ?? part.state?.error ?? part.state?.title ?? part.state?.raw
+    nextPart.childSessionId = getChildSessionId(part.state as Record<string, unknown> | undefined)
   }
 
   if (part.type === 'file') {
@@ -1305,6 +1326,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
           if (partType === 'tool') {
             existingPart.toolState = getToolState(toolState)
             existingPart.toolInput = stringifyToolInput(toolState?.input)
+            existingPart.childSessionId = getChildSessionId(toolState) ?? existingPart.childSessionId
           }
           if (partType === 'file') {
             existingPart.fileMime = part.mime as string | undefined
@@ -1321,6 +1343,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
             newPart.toolName = part.tool as string | undefined
             newPart.toolState = getToolState(toolState)
             newPart.toolInput = stringifyToolInput(toolState?.input)
+            newPart.childSessionId = getChildSessionId(toolState)
           }
           if (partType === 'file') {
             newPart.fileMime = part.mime as string | undefined


### PR DESCRIPTION
## Summary

The `task` tool runs each sub-agent in a separate child session and only reports its `output` string once the child completes. Until then the tool bubble showed just the task description, so a long-running sub-agent (e.g. watching a CI pipeline) looked frozen for minutes — the user couldn't see any intermediate output.

## Fix

The child session's `message.part.updated` events already stream through `EventBridge` and land in `useAgentStore` keyed on the child sessionId, so no new plumbing is needed — the UI just has to read from that bucket.

- Extract `state.metadata.sessionId` off tool parts into a new `childSessionId` field (`useAgentStore.ts`, both live and historical paths)
- Add `childSessionId` + `childTranscript` to `ToolCall` (`ToolsUsage.tsx`)
- Flatten the child session's messages into a compact transcript per task tool call (`App.tsx`)
- Render the transcript inline inside the task bubble with a new `ChildTaskTranscript` component (`DetailDrawer.tsx`)
- Auto-expand task bubbles while running so progress is visible without a click

## Verification

- `npm run typecheck` passes
- `npm run lint` — 0 errors (pre-existing `no-console` warnings only)
- `npm test` — 212 pass, 6 skipped (unchanged)