### PR TITLE
Show dock badge count for agents needing attention

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -828,6 +828,17 @@ export function registerIpcHandlers(): void {
     return { ok: true, data: os.homedir() }
   })
 
+  ipcMain.handle('app:set-badge-count', async (_event, count: number) => {
+    try {
+      const safeCount = Math.max(0, Math.floor(count))
+      notificationService.updateBadgeCount(safeCount)
+      return { ok: true }
+    } catch (error) {
+      logIpcError('app:set-badge-count', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
   // ── Shell Integration ──
 
   /** Promisified execFile — avoids shell interpretation of arguments */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -224,6 +224,9 @@ const api = {
   getHomeDirectory: (): Promise<IpcResult<string>> =>
     ipcRenderer.invoke('app:home-directory'),
 
+  setBadgeCount: (count: number): Promise<IpcResult> =>
+    ipcRenderer.invoke('app:set-badge-count', count),
+
   // ── Shell Integration ──
   notifyAgentStatus: (agentId: string, status: string, agentName: string, projectName?: string, preview?: string): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:notify-status', agentId, status, agentName, projectName, preview),

--- a/src/renderer/src/demoApi.ts
+++ b/src/renderer/src/demoApi.ts
@@ -369,6 +369,7 @@ export function createDemoApi(): OrchestratorApi {
     // ── App Info ──
     getVersion: () => ok('1.0.0'),
     getHomeDirectory: () => ok('/Users/dev'),
+    setBadgeCount: noop,
 
     // ── Shell Integration ──
     notifyAgentStatus: noop,

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -456,6 +456,30 @@ function getSnapshot(): AgentStoreState {
   return state
 }
 
+// ── Dock Badge ──
+
+const BADGE_STATUSES: ReadonlySet<AgentStatus> = new Set<AgentStatus>([
+  'needs_input',
+  'needs_approval',
+  'errored'
+])
+
+let lastBadgeCount = -1
+
+// Subscribed at module load rather than from a React effect so the badge
+// reflects global state even when no component is observing the store.
+function syncBadgeCount(): void {
+  let count = 0
+  for (const agent of state.agents.values()) {
+    if (BADGE_STATUSES.has(agent.status)) count++
+  }
+  if (count === lastBadgeCount) return
+  lastBadgeCount = count
+  window.api?.setBadgeCount(count)
+}
+
+listeners.add(syncBadgeCount)
+
 // ── Event Logging ──
 
 function generateEventSummary(type: string, props: Record<string, unknown>): string {

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -91,6 +91,7 @@ export interface OrchestratorApi {
   // ── App Info ──
   getVersion: () => Promise<IpcResult<string>>
   getHomeDirectory: () => Promise<IpcResult<string>>
+  setBadgeCount: (count: number) => Promise<IpcResult>
 
   // ── Shell Integration ──
   notifyAgentStatus: (agentId: string, status: string, agentName: string, projectName?: string, preview?: string) => Promise<IpcResult>


### PR DESCRIPTION
Wire up the existing (unused) badge plumbing so the app icon displays a count of agents in needs_input, needs_approval, or errored states. The renderer subscribes to store changes at module load and pushes the count to the main process through a new app:set-badge-count IPC handler, which delegates to the notificationService that was already calling app.setBadgeCount() but had no callers.

macOS and Linux (Unity) show the number on the dock icon; Windows is a no-op, which matches Electron's setBadgeCount behaviour.