### PR TITLE
Add in-app workspace view with diff, light edits, and ask-about-selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.9.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "@opencode-ai/sdk": "1.3.3",
         "@phosphor-icons/react": "^2.1.7",
         "electron": "41.1.0",
+        "monaco-editor": "^0.55.1",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
         "sql.js": "1.14.1"
@@ -1618,6 +1620,29 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@npmcli/agent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
@@ -2569,6 +2594,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -4273,6 +4305,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dotenv": {
@@ -6395,6 +6436,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -7495,6 +7548,16 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
       }
     },
     "node_modules/ms": {
@@ -8663,6 +8726,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -38,9 +38,11 @@
     "node": "24.14.0"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "@opencode-ai/sdk": "1.3.3",
     "@phosphor-icons/react": "^2.1.7",
     "electron": "41.1.0",
+    "monaco-editor": "^0.55.1",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "sql.js": "1.14.1"

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -79,6 +79,11 @@ function createWindow(): BrowserWindow {
     if (mainWindowRef === mainWindow) {
       mainWindowRef = null
     }
+    // Tear down any remaining file watchers belonging to this window so
+    // we don't leak fs.watch handles after reload.
+    void import('./services/file-watcher').then(({ unsubscribeAllForWindow }) => {
+      unsubscribeAllForWindow(mainWindow)
+    })
   })
 
   mainWindow.webContents.setWindowOpenHandler((details) => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,11 +1,12 @@
-import { ipcMain, dialog, shell } from 'electron'
+import { ipcMain, dialog, shell, BrowserWindow } from 'electron'
 import { execFile } from 'child_process'
 import os from 'os'
 import { agentController } from './services/agent-controller'
 import { runtimeManager } from './services/runtime-manager'
-import { workspaceManager } from './services/workspace-manager'
+import { workspaceManager, FileWriteConflictError } from './services/workspace-manager'
 import { database } from './services/database'
 import { notificationService, type NotifiableEventType } from './services/notification-service'
+import { subscribeFileChanges, unsubscribeFileChanges } from './services/file-watcher'
 import { getAppVersion } from './version'
 
 interface Attachment {
@@ -624,6 +625,106 @@ export function registerIpcHandlers(): void {
       logIpcError('workspace:status', error)
       return { ok: false, error: String(error) }
     }
+  })
+
+  /**
+   * Resolve an agent's worktree directory from its ID. Used by the git/file
+   * IPC handlers below so the renderer never passes an absolute filesystem
+   * path — it only supplies the agentId, and the main process owns the
+   * mapping to on-disk location.
+   */
+  const resolveAgentWorktree = (agentId: string): string => {
+    const agent = agentController.getAgent(agentId)
+    if (!agent) throw new Error(`Unknown agent: ${agentId}`)
+    return agent.directory
+  }
+
+  ipcMain.handle('workspace:git-status', async (_event, agentId: string) => {
+    try {
+      const worktree = resolveAgentWorktree(agentId)
+      const files = workspaceManager.getGitStatus(worktree)
+      return { ok: true, data: files }
+    } catch (error) {
+      logIpcError('workspace:git-status', error, { agentId })
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  ipcMain.handle('workspace:git-diff', async (_event, agentId: string, relativePath: string) => {
+    try {
+      const worktree = resolveAgentWorktree(agentId)
+      const sides = workspaceManager.getDiffSides(worktree, relativePath)
+      return { ok: true, data: sides }
+    } catch (error) {
+      logIpcError('workspace:git-diff', error, { agentId, relativePath })
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  ipcMain.handle('file:read', async (_event, agentId: string, relativePath: string) => {
+    try {
+      const worktree = resolveAgentWorktree(agentId)
+      const result = workspaceManager.readFileSafe(worktree, relativePath)
+      return { ok: true, data: result }
+    } catch (error) {
+      logIpcError('file:read', error, { agentId, relativePath })
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  /**
+   * Writes a file in the agent's worktree. `expectedMtimeMs` must match the
+   * mtime the renderer observed at read time, or the write is rejected with
+   * a CONFLICT error so the UI can prompt the user. Pass `null` to skip the
+   * check (after the user explicitly chose Overwrite in the conflict modal).
+   */
+  ipcMain.handle('file:write', async (
+    _event,
+    agentId: string,
+    relativePath: string,
+    content: string,
+    expectedMtimeMs: number | null
+  ) => {
+    try {
+      const worktree = resolveAgentWorktree(agentId)
+      const result = workspaceManager.writeFileSafe(worktree, relativePath, content, expectedMtimeMs)
+      return { ok: true, data: result }
+    } catch (error) {
+      if (error instanceof FileWriteConflictError) {
+        return {
+          ok: false,
+          error: 'CONFLICT',
+          data: { currentMtimeMs: error.currentMtimeMs }
+        }
+      }
+      logIpcError('file:write', error, { agentId, relativePath })
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  /**
+   * Subscribes a renderer to change events on one file. The renderer supplies
+   * a stable subscriptionId so it can correlate incoming `file:changed`
+   * broadcasts with a specific open editor. Re-subscribing with the same id
+   * replaces the existing watch (cheap way to switch files).
+   */
+  ipcMain.handle('file:watch', async (event, agentId: string, subscriptionId: string, relativePath: string) => {
+    try {
+      const worktree = resolveAgentWorktree(agentId)
+      const abs = workspaceManager.resolveWorktreeRelativePath(worktree, relativePath)
+      const window = BrowserWindow.fromWebContents(event.sender)
+      if (!window) throw new Error('Watch request came from a detached renderer')
+      subscribeFileChanges(window, subscriptionId, abs)
+      return { ok: true }
+    } catch (error) {
+      logIpcError('file:watch', error, { agentId, relativePath, subscriptionId })
+      return { ok: false, error: String(error) }
+    }
+  })
+
+  ipcMain.handle('file:unwatch', async (_event, subscriptionId: string) => {
+    unsubscribeFileChanges(subscriptionId)
+    return { ok: true }
   })
 
   // ── Database: Projects ──

--- a/src/main/services/file-watcher.ts
+++ b/src/main/services/file-watcher.ts
@@ -1,0 +1,116 @@
+import fs from 'fs'
+import type { BrowserWindow } from 'electron'
+
+/**
+ * Narrow file watcher: one `fs.watch` per (agentId, relativePath) subscription.
+ * Sends `file:changed` events to the subscribing renderer when the on-disk
+ * file is modified, debounced so save operations (which often fire change +
+ * rename in quick succession) coalesce into a single notification.
+ *
+ * Deliberately NOT a recursive worktree watcher. A large repo's worktree
+ * generates huge event volumes during test runs, builds, and lockfile churn.
+ * We only care about the file(s) the user has open in the editor.
+ *
+ * Keyed by a caller-provided subscription id so the renderer can correlate
+ * replies to open editors (e.g. different files in different tabs later).
+ */
+
+interface Subscription {
+  id: string
+  window: BrowserWindow
+  absPath: string
+  watcher: fs.FSWatcher
+  debounceTimer?: NodeJS.Timeout
+}
+
+const DEBOUNCE_MS = 150
+const subscriptions = new Map<string, Subscription>()
+
+export function subscribeFileChanges(
+  window: BrowserWindow,
+  subscriptionId: string,
+  absPath: string
+): void {
+  // Replace any existing subscription with the same id — e.g. the renderer
+  // switches files in the editor and reuses the id.
+  unsubscribeFileChanges(subscriptionId)
+
+  // Watching a non-existent file throws. This happens for brand-new files
+  // the user is about to create; the renderer can retry after first save.
+  let watcher: fs.FSWatcher
+  try {
+    watcher = fs.watch(absPath)
+  } catch (error) {
+    // Best-effort: emit an immediate error so the renderer knows the watch
+    // didn't take. The UI can fall back to on-focus polling.
+    window.webContents.send('file:changed', {
+      subscriptionId,
+      event: 'error',
+      error: String(error)
+    })
+    return
+  }
+
+  const sub: Subscription = { id: subscriptionId, window, absPath, watcher }
+
+  watcher.on('change', (eventType) => {
+    if (sub.debounceTimer) clearTimeout(sub.debounceTimer)
+    sub.debounceTimer = setTimeout(() => {
+      sub.debounceTimer = undefined
+      if (window.isDestroyed()) {
+        unsubscribeFileChanges(subscriptionId)
+        return
+      }
+      // Stat to get the new mtime so the renderer can decide if this is a
+      // real change (mtime bumped) vs a no-op touch.
+      let mtimeMs: number | null = null
+      try {
+        mtimeMs = fs.statSync(absPath).mtimeMs
+      } catch {
+        // File may have been deleted.
+        window.webContents.send('file:changed', {
+          subscriptionId,
+          event: 'deleted',
+          absPath
+        })
+        return
+      }
+      window.webContents.send('file:changed', {
+        subscriptionId,
+        event: eventType === 'rename' ? 'renamed' : 'changed',
+        absPath,
+        mtimeMs
+      })
+    }, DEBOUNCE_MS)
+  })
+
+  watcher.on('error', (error) => {
+    if (!window.isDestroyed()) {
+      window.webContents.send('file:changed', {
+        subscriptionId,
+        event: 'error',
+        error: String(error)
+      })
+    }
+    unsubscribeFileChanges(subscriptionId)
+  })
+
+  subscriptions.set(subscriptionId, sub)
+}
+
+export function unsubscribeFileChanges(subscriptionId: string): void {
+  const sub = subscriptions.get(subscriptionId)
+  if (!sub) return
+  if (sub.debounceTimer) clearTimeout(sub.debounceTimer)
+  try { sub.watcher.close() } catch { /* ignore */ }
+  subscriptions.delete(subscriptionId)
+}
+
+/** Tear down all subscriptions belonging to a window (on window close). */
+export function unsubscribeAllForWindow(window: BrowserWindow): void {
+  for (const [id, sub] of subscriptions) {
+    if (sub.window === window) {
+      unsubscribeFileChanges(id)
+    }
+  }
+}

--- a/src/main/services/workspace-manager.ts
+++ b/src/main/services/workspace-manager.ts
@@ -26,6 +26,48 @@ export interface WorktreeStatus {
   changedFiles: number
 }
 
+/** One row in the git status porcelain v2 output, normalized for the UI. */
+export interface GitStatusFile {
+  /** Forward-slash relative path from the worktree root. */
+  path: string
+  /** Original path if this is a rename/copy entry. */
+  oldPath?: string
+  /** One of: added, modified, deleted, renamed, copied, untracked, unmerged, typechange. */
+  status: 'added' | 'modified' | 'deleted' | 'renamed' | 'copied' | 'untracked' | 'unmerged' | 'typechange'
+  /** Whether the change is staged in the index. */
+  staged: boolean
+  /** Whether there are further unstaged changes on top of any staged changes. */
+  unstaged: boolean
+}
+
+export interface FileReadResult {
+  content: string
+  mtimeMs: number
+  size: number
+  encoding: 'utf-8' | 'binary'
+  truncated: boolean
+}
+
+/** Max bytes we'll read into the editor. Anything larger gets truncated with a warning. */
+const MAX_READABLE_FILE_SIZE = 5 * 1024 * 1024
+
+/** Probe up to this many bytes looking for a NUL before declaring a file binary. */
+const BINARY_SNIFF_SIZE = 8192
+
+/**
+ * Thrown by writeFileSafe when the on-disk file changed since the caller read
+ * it (mtime mismatch) or was deleted out from under us. IPC handlers catch
+ * this specifically and surface a structured CONFLICT response to the UI so
+ * the user can pick overwrite / discard / cancel.
+ */
+export class FileWriteConflictError extends Error {
+  readonly code = 'CONFLICT' as const
+  constructor(message: string, readonly currentMtimeMs: number | null) {
+    super(message)
+    this.name = 'FileWriteConflictError'
+  }
+}
+
 export interface DirectoryContext {
   repoName: string
   branchName: string
@@ -35,6 +77,43 @@ export interface DirectoryContext {
 
 // eslint-disable-next-line no-control-regex
 const GIT_REF_INVALID_CHARS = /[\x00-\x1f\x7f ~^:?*[\]\\]/
+
+/** Normalize a git-reported path to forward slashes for consistent UI display. */
+function normalizePath(value: string): string {
+  return value.replace(/\\/g, '/')
+}
+
+/**
+ * Interpret the 2-char XY status field from `git status --porcelain=v2`.
+ * X = index (staged) state, Y = worktree (unstaged) state. Either side can
+ * be '.' meaning "no change". We pick the more interesting of the two
+ * for a single-line UI display.
+ */
+function interpretPorcelainXY(xy: string): {
+  status: GitStatusFile['status'] | null
+  staged: boolean
+  unstaged: boolean
+} {
+  if (xy.length < 2) return { status: null, staged: false, unstaged: false }
+  const x = xy[0]
+  const y = xy[1]
+  const staged = x !== '.' && x !== ' ' && x !== '?'
+  const unstaged = y !== '.' && y !== ' ' && y !== '?'
+
+  // Prefer whichever side has a real status code. Staged often wins for UI
+  // purposes because the hunks will show up in the staged diff.
+  const pick = staged ? x : y
+  switch (pick) {
+    case 'M': return { status: 'modified', staged, unstaged }
+    case 'A': return { status: 'added', staged, unstaged }
+    case 'D': return { status: 'deleted', staged, unstaged }
+    case 'R': return { status: 'renamed', staged, unstaged }
+    case 'C': return { status: 'copied', staged, unstaged }
+    case 'T': return { status: 'typechange', staged, unstaged }
+    case 'U': return { status: 'unmerged', staged, unstaged }
+    default: return { status: null, staged, unstaged }
+  }
+}
 
 function validateGitRef(ref: string): string {
   const trimmed = ref.trim()
@@ -473,6 +552,274 @@ class WorkspaceManager {
       console.error(`[WorkspaceManager] Failed to get worktree status: ${message}`)
       throw new Error(`Failed to get worktree status: ${message}`)
     }
+  }
+
+  /**
+   * Returns the list of files with uncommitted changes in a worktree,
+   * parsed from `git status --porcelain=v2 -z`.
+   *
+   * Porcelain v2 is used because:
+   *   - NUL-delimited output avoids filename quoting issues
+   *   - Rename/copy entries carry both paths explicitly
+   *   - The XY status field is documented and stable
+   */
+  getGitStatus(worktreePath: string): GitStatusFile[] {
+    const output = execFileSync('git', ['status', '--porcelain=v2', '-z', '--untracked-files=all'], {
+      cwd: worktreePath,
+      encoding: 'utf-8',
+      stdio: 'pipe'
+    })
+
+    const files: GitStatusFile[] = []
+    // NUL-delimited records. Rename/copy records consume an extra field for the
+    // original path, so we can't just split on NUL — we have to parse token by token.
+    let i = 0
+    while (i < output.length) {
+      const end = output.indexOf('\0', i)
+      if (end === -1) break
+      const record = output.slice(i, end)
+      i = end + 1
+
+      if (!record) continue
+
+      const recordType = record[0]
+      if (recordType === '1') {
+        // Changed entry: "1 XY sub <mH> <mI> <mW> <hH> <hI> <path>"
+        const parts = record.split(' ')
+        const xy = parts[1] ?? ''
+        const filePath = parts.slice(8).join(' ')
+        const { status, staged, unstaged } = interpretPorcelainXY(xy)
+        if (status) files.push({ path: normalizePath(filePath), status, staged, unstaged })
+      } else if (recordType === '2') {
+        // Renamed/copied entry: "2 XY sub <mH> <mI> <mW> <hH> <hI> <score> <path>"
+        // followed by NUL and then <origPath>.
+        const parts = record.split(' ')
+        const xy = parts[1] ?? ''
+        const newPath = parts.slice(9).join(' ')
+        // Consume the orig-path record that immediately follows.
+        const origEnd = output.indexOf('\0', i)
+        const origPath = origEnd === -1 ? '' : output.slice(i, origEnd)
+        if (origEnd !== -1) i = origEnd + 1
+        const { status, staged, unstaged } = interpretPorcelainXY(xy)
+        files.push({
+          path: normalizePath(newPath),
+          oldPath: normalizePath(origPath),
+          status: status ?? 'renamed',
+          staged,
+          unstaged
+        })
+      } else if (recordType === 'u') {
+        // Unmerged: "u XY sub <m1> <m2> <m3> <mW> <h1> <h2> <h3> <path>"
+        const parts = record.split(' ')
+        const filePath = parts.slice(10).join(' ')
+        files.push({ path: normalizePath(filePath), status: 'unmerged', staged: false, unstaged: true })
+      } else if (recordType === '?') {
+        // Untracked: "? <path>"
+        const filePath = record.slice(2)
+        files.push({ path: normalizePath(filePath), status: 'untracked', staged: false, unstaged: true })
+      }
+      // '!' ignored entries are skipped (we don't ask for them).
+    }
+
+    return files
+  }
+
+  /**
+   * Returns the working-tree version of a file (for the diff "after" side) and
+   * the HEAD version (for the "before" side). Used by the diff viewer.
+   *
+   * For untracked files, `before` is an empty string. For deleted files,
+   * `after` is an empty string.
+   */
+  getDiffSides(worktreePath: string, relativePath: string): { before: string; after: string } {
+    const safePath = relativePath.replace(/^\/+/, '')
+    let before = ''
+    let after = ''
+
+    // HEAD version — may not exist if file is untracked or added since HEAD.
+    try {
+      before = execFileSync('git', ['show', `HEAD:${safePath}`], {
+        cwd: worktreePath,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'ignore'],
+        maxBuffer: MAX_READABLE_FILE_SIZE * 2
+      })
+    } catch {
+      before = ''
+    }
+
+    // Working tree version — may not exist if file was deleted.
+    const abs = path.join(worktreePath, safePath)
+    try {
+      if (fs.existsSync(abs)) {
+        const stat = fs.statSync(abs)
+        if (stat.size <= MAX_READABLE_FILE_SIZE) {
+          after = fs.readFileSync(abs, 'utf-8')
+        }
+      }
+    } catch {
+      after = ''
+    }
+
+    return { before, after }
+  }
+
+  /**
+   * Safely reads a file from a worktree. Guards against path traversal and
+   * symlink escapes by realpath-resolving both the root and target and
+   * verifying containment.
+   */
+  readFileSafe(worktreePath: string, relativePath: string): FileReadResult {
+    const abs = this.resolveInsideWorktree(worktreePath, relativePath)
+    const stat = fs.statSync(abs)
+
+    if (stat.isDirectory()) {
+      throw new Error(`Path is a directory: ${relativePath}`)
+    }
+
+    const truncated = stat.size > MAX_READABLE_FILE_SIZE
+    const readSize = truncated ? MAX_READABLE_FILE_SIZE : stat.size
+    const buffer = Buffer.alloc(readSize)
+
+    const fd = fs.openSync(abs, 'r')
+    try {
+      fs.readSync(fd, buffer, 0, readSize, 0)
+    } finally {
+      fs.closeSync(fd)
+    }
+
+    // Binary sniff: look for a NUL byte in the first chunk of what we read.
+    // This catches most real binaries (images, pdfs, compiled artifacts)
+    // without false-positiving on UTF-8 text. Cheap because we already have
+    // the bytes in memory.
+    const sniffEnd = Math.min(readSize, BINARY_SNIFF_SIZE)
+    const nulIdx = buffer.indexOf(0)
+    if (nulIdx !== -1 && nulIdx < sniffEnd) {
+      return { content: '', mtimeMs: stat.mtimeMs, size: stat.size, encoding: 'binary', truncated: false }
+    }
+
+    return {
+      content: buffer.toString('utf-8'),
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+      encoding: 'utf-8',
+      truncated
+    }
+  }
+
+  /**
+   * Writes a file inside a worktree with optimistic concurrency. The caller
+   * passes `expectedMtimeMs` — the mtime observed at read time. If the file
+   * on disk has since changed (e.g. the agent wrote to it), the write is
+   * rejected with a conflict error so the UI can prompt the user before
+   * clobbering.
+   *
+   * Pass `expectedMtimeMs: null` to force-write unconditionally (used after
+   * the user picks "overwrite" in the conflict modal).
+   *
+   * The write is atomic: we write to a sibling temp file and rename, which
+   * avoids leaving a half-written file if the process dies mid-write.
+   */
+  writeFileSafe(
+    worktreePath: string,
+    relativePath: string,
+    content: string,
+    expectedMtimeMs: number | null
+  ): { mtimeMs: number; size: number } {
+    const abs = this.resolveInsideWorktree(worktreePath, relativePath)
+
+    // Concurrency check: if the file exists, its mtime must match what the
+    // caller saw. If it doesn't exist yet (new file from the UI side) the
+    // caller is expected to pass `expectedMtimeMs: null` to skip the check.
+    if (expectedMtimeMs !== null) {
+      let currentStat: fs.Stats
+      try {
+        currentStat = fs.statSync(abs)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          // File vanished since we read it. Treat as conflict — the user
+          // probably wants to know before we re-create it.
+          throw new FileWriteConflictError('file was deleted on disk', null)
+        }
+        throw error
+      }
+      if (currentStat.mtimeMs !== expectedMtimeMs) {
+        throw new FileWriteConflictError(
+          'file changed on disk since it was read',
+          currentStat.mtimeMs
+        )
+      }
+    }
+
+    // Atomic write: temp file in the same directory, then rename. Same-
+    // directory rename is atomic on POSIX and NTFS, so a crash mid-write
+    // leaves the original intact.
+    const dir = path.dirname(abs)
+    const base = path.basename(abs)
+    const tmp = path.join(dir, `.${base}.oco-tmp.${process.pid}.${Date.now()}`)
+
+    fs.writeFileSync(tmp, content, { encoding: 'utf-8' })
+    try {
+      fs.renameSync(tmp, abs)
+    } catch (error) {
+      // Best-effort cleanup of the temp file if the rename failed.
+      try { fs.unlinkSync(tmp) } catch { /* ignore */ }
+      throw error
+    }
+
+    const finalStat = fs.statSync(abs)
+    return { mtimeMs: finalStat.mtimeMs, size: finalStat.size }
+  }
+
+  /**
+   * Public wrapper around the internal path resolver. IPC handlers use this
+   * to validate renderer-supplied paths before handing them to other
+   * services (file watcher, etc).
+   */
+  resolveWorktreeRelativePath(worktreePath: string, relativePath: string): string {
+    return this.resolveInsideWorktree(worktreePath, relativePath)
+  }
+
+  /**
+   * Resolves a user-supplied relative path inside a worktree, following
+   * symlinks and rejecting anything that escapes the root. Returns the
+   * absolute realpath suitable for direct fs use.
+   *
+   * Symlink handling: we realpath the *parent* directory and then append the
+   * basename. This way a symlink pointing outside the worktree gets rejected
+   * before we read through it. We also realpath the worktree root so the
+   * containment check works even if the root itself is a symlink.
+   */
+  private resolveInsideWorktree(worktreePath: string, relativePath: string): string {
+    if (!relativePath || typeof relativePath !== 'string') {
+      throw new Error('relativePath is required')
+    }
+    // Strip leading slashes and resolve `..` components without touching disk.
+    const normalized = path.posix.normalize(relativePath.replace(/\\/g, '/').replace(/^\/+/, ''))
+    if (normalized === '..' || normalized.startsWith('../') || normalized.includes('/../')) {
+      throw new Error(`Path escapes worktree: ${relativePath}`)
+    }
+
+    const rootReal = fs.realpathSync(worktreePath)
+    const joined = path.join(rootReal, normalized)
+
+    // Realpath the *final* path if it exists (to follow symlinks and validate),
+    // otherwise realpath the parent directory and append the basename.
+    let resolved: string
+    try {
+      resolved = fs.realpathSync(joined)
+    } catch {
+      const parent = path.dirname(joined)
+      const parentReal = fs.realpathSync(parent)
+      resolved = path.join(parentReal, path.basename(joined))
+    }
+
+    const rootWithSep = rootReal.endsWith(path.sep) ? rootReal : rootReal + path.sep
+    if (resolved !== rootReal && !resolved.startsWith(rootWithSep)) {
+      throw new Error(`Path escapes worktree: ${relativePath}`)
+    }
+
+    return resolved
   }
 
   /**

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -165,6 +165,38 @@ const api = {
   getWorktreeStatus: (worktreePath: string): Promise<IpcResult> =>
     ipcRenderer.invoke('workspace:status', worktreePath),
 
+  getGitStatus: (agentId: string): Promise<IpcResult<Array<{ path: string; oldPath?: string; status: string; staged: boolean; unstaged: boolean }>>> =>
+    ipcRenderer.invoke('workspace:git-status', agentId),
+
+  getGitDiff: (agentId: string, relativePath: string): Promise<IpcResult<{ before: string; after: string }>> =>
+    ipcRenderer.invoke('workspace:git-diff', agentId, relativePath),
+
+  readFile: (agentId: string, relativePath: string): Promise<IpcResult<{ content: string; mtimeMs: number; size: number; encoding: 'utf-8' | 'binary'; truncated: boolean }>> =>
+    ipcRenderer.invoke('file:read', agentId, relativePath),
+
+  writeFile: (
+    agentId: string,
+    relativePath: string,
+    content: string,
+    expectedMtimeMs: number | null
+  ): Promise<IpcResult<{ mtimeMs: number; size: number; currentMtimeMs?: number | null }>> =>
+    ipcRenderer.invoke('file:write', agentId, relativePath, content, expectedMtimeMs),
+
+  watchFile: (agentId: string, subscriptionId: string, relativePath: string): Promise<IpcResult> =>
+    ipcRenderer.invoke('file:watch', agentId, subscriptionId, relativePath),
+
+  unwatchFile: (subscriptionId: string): Promise<IpcResult> =>
+    ipcRenderer.invoke('file:unwatch', subscriptionId),
+
+  /** Subscribe to file-changed events broadcast by the main process watcher.
+   *  The main-process file watcher pushes every change (debounced 150ms) as
+   *  a `file:changed` event; callers correlate by subscriptionId. */
+  onFileChanged: (callback: (data: { subscriptionId: string; event: 'changed' | 'renamed' | 'deleted' | 'error'; absPath?: string; mtimeMs?: number; error?: string }) => void): (() => void) => {
+    const handler = (_event: unknown, data: Parameters<typeof callback>[0]): void => callback(data)
+    ipcRenderer.on('file:changed', handler)
+    return () => ipcRenderer.removeListener('file:changed', handler)
+  },
+
   // ── Database: Projects ──
   listProjects: (): Promise<IpcResult> =>
     ipcRenderer.invoke('db:projects:list'),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -11,6 +11,7 @@ import { SettingsModal, type SettingsTabId } from './components/SettingsModal'
 import { CommandPalette } from './components/CommandPalette'
 import { ModelPickerModal } from './components/ModelPickerModal'
 import { McpModal } from './components/McpModal'
+import { WorkspaceView } from './components/WorkspaceView'
 import { useAgentStore, setViewedAgentId, type LiveAgent } from './hooks/useAgentStore'
 import { useCustomLabels } from './hooks/useCustomLabels'
 import { type AgentRuntime, type Interrupt, type Message, type ColumnKey, type ColumnWidths, type SortDirection, loadColumnVisibility, saveColumnVisibility, loadColumnWidths, saveColumnWidths, loadSort, saveSort, compareStatusPriority } from './types'
@@ -160,6 +161,12 @@ export function App() {
   const [showModelPicker, setShowModelPicker] = useState(false)
   const [modelPickerAgentId, setModelPickerAgentId] = useState<string | null>(null)
   const [showMcpModal, setShowMcpModal] = useState(false)
+  // When set, the full-window Workspace (code review) view is open for this agent.
+  // Taking over the whole viewport, it reuses the selected agent's send-message path
+  // so highlight-to-ask questions flow through the normal chat pipeline.
+  const [workspaceAgentId, setWorkspaceAgentId] = useState<string | null>(null)
+  // Initial file to select on workspace open (e.g. clicked from Files Changed).
+  const [workspaceInitialFile, setWorkspaceInitialFile] = useState<string | null>(null)
   const [updateInfo, setUpdateInfo] = useState<{ currentVersion: string; latestVersion: string } | null>(null)
   const [appVersion, setAppVersion] = useState('')
   const [dismissedInterruptIds, setDismissedInterruptIds] = useState<Set<string> | null>(null)
@@ -205,6 +212,7 @@ export function App() {
     getMessagesForSession,
     getFileChangesForSession,
     getEventsForSession,
+    hydrateFileChangesFromGit: storeHydrateFileChangesFromGit,
     sendMessage: storeSendMessage,
     replyToQuestion: storeReplyToQuestion,
     resetSession: storeResetSession,
@@ -327,6 +335,16 @@ export function App() {
   useEffect(() => {
     setViewedAgentId(selectedAgentId)
   }, [selectedAgentId])
+
+  // ── Hydrate Files Changed from git when an agent is selected ──
+  // Restored/dev-reloaded agents never emit the SSE events that populate the
+  // session's file-change list, so the Files Changed tab stays empty even
+  // when the worktree has real uncommitted work. Seeding from git status on
+  // select fixes that. The store itself guards against repeated hydration.
+  useEffect(() => {
+    if (!selectedAgentId) return
+    void storeHydrateFileChangesFromGit(selectedAgentId)
+  }, [selectedAgentId, storeHydrateFileChangesFromGit])
 
   // ── Fetch app version ──
   useEffect(() => {
@@ -1041,6 +1059,36 @@ Then give me a brief summary of what the previous session was working on and whe
     window.api.openInEditor({ path: liveAgent.directory, editor: settings.editor as 'vscode' | 'cursor' | 'windsurf' | 'goland' })
   }, [selectedAgentId, findLiveAgent])
 
+  const handleOpenWorkspace = useCallback((filePath?: string) => {
+    if (!selectedAgentId) return
+    setWorkspaceInitialFile(filePath ?? null)
+    setWorkspaceAgentId(selectedAgentId)
+  }, [selectedAgentId])
+
+  const handleCloseWorkspace = useCallback(() => {
+    setWorkspaceAgentId(null)
+    setWorkspaceInitialFile(null)
+  }, [])
+
+  /** Send a message to the agent whose Workspace view is currently open. Used
+   *  by the highlight-to-ask popover so quoted citations flow through the
+   *  normal send pipeline (history, /commands, @mentions). After sending we
+   *  pop back to the transcript and scroll to the bottom so the user can
+   *  watch the reply stream in, which is the whole point of asking. */
+  const handleWorkspaceSendMessage = useCallback(async (text: string) => {
+    if (!workspaceAgentId) return
+    await storeSendMessage(workspaceAgentId, text)
+    // Open the drawer for this agent and jump the transcript to the latest
+    // user message (our citation). setSelectedAgentId with a scroll target
+    // signals the drawer to switch to the transcript tab and scroll.
+    setSelectedAgentId(workspaceAgentId, 'last-user-message')
+  }, [workspaceAgentId, storeSendMessage, setSelectedAgentId])
+
+  const workspaceAgent = useMemo(() => {
+    if (!workspaceAgentId) return null
+    return store.agents.find((agent) => agent.id === workspaceAgentId) ?? null
+  }, [workspaceAgentId, store.agents])
+
   const handleOpenTerminalForDrawer = useCallback(() => {
     if (!selectedAgentId) return
     const liveAgent = findLiveAgent(selectedAgentId)
@@ -1284,10 +1332,23 @@ Then give me a brief summary of what the previous session was working on and whe
       const target = event.target as HTMLElement
       if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return
 
+      // Workspace view owns its own keyboard; don't fight it.
+      if (workspaceAgentId) return
+
       // Cmd+K -> command palette
       if (event.key === 'k' && (event.metaKey || event.ctrlKey)) {
         event.preventDefault()
         setShowCommandPalette((prev) => !prev)
+        return
+      }
+
+      // Cmd+E -> open Workspace code review for the selected agent
+      if (event.key === 'e' && (event.metaKey || event.ctrlKey)) {
+        if (selectedAgentId) {
+          event.preventDefault()
+          setWorkspaceInitialFile(null)
+          setWorkspaceAgentId(selectedAgentId)
+        }
         return
       }
 
@@ -1407,7 +1468,7 @@ Then give me a brief summary of what the previous session was working on and whe
         return
       }
     },
-    [filteredAgents, selectedAgentId, showLaunchModal, showSettings, showCommandPalette, showSessionBrowser, findPermissionForAgent, store, handleQuickLaunch]
+    [filteredAgents, selectedAgentId, showLaunchModal, showSettings, showCommandPalette, showSessionBrowser, workspaceAgentId, findPermissionForAgent, store, handleQuickLaunch]
   )
 
   useEffect(() => {
@@ -1568,6 +1629,7 @@ Then give me a brief summary of what the previous session was working on and whe
            onOpenQuickActionSettings={() => { setSettingsTab('quick-actions'); setShowSettings(true) }}
            onSetPrUrl={handleDrawerSetPrUrl}
            onOpenInEditor={handleOpenInEditor}
+           onOpenWorkspace={handleOpenWorkspace}
           onChangeModel={handleDrawerChangeModel}
           onOpenTerminal={handleOpenTerminalForDrawer}
           onToggleLabel={handleDrawerToggleLabel}
@@ -1642,6 +1704,19 @@ Then give me a brief summary of what the previous session was working on and whe
         <McpModal
           agentId={selectedAgentId}
           onClose={() => setShowMcpModal(false)}
+        />
+      )}
+
+      {workspaceAgent && (
+        <WorkspaceView
+          agentId={workspaceAgent.id}
+          agentName={workspaceAgent.name}
+          projectName={workspaceAgent.projectName}
+          branchName={workspaceAgent.branchName}
+          agentStatus={workspaceAgent.status}
+          initialFilePath={workspaceInitialFile}
+          onClose={handleCloseWorkspace}
+          onSendMessage={handleWorkspaceSendMessage}
         />
       )}
 

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -41,6 +41,7 @@ import { Markdown } from './Markdown'
 import { FilesChanged } from './FilesChanged'
 import { ToolsUsage } from './ToolsUsage'
 import { EventLog } from './EventLog'
+import { HighlightAskPopover, type HighlightSelection } from './HighlightAskPopover'
 import type { FileChange } from './FilesChanged'
 import type { ToolCall } from './ToolsUsage'
 import type { EventEntry } from './EventLog'
@@ -143,6 +144,12 @@ interface DetailDrawerProps {
   onOpenQuickActionSettings?: () => void
   onSetPrUrl?: (prUrl: string | null) => void
   onOpenInEditor?: () => void
+  /** Open the full-window Workspace view (git-status-backed diff viewer +
+   *  highlight-to-ask) for this agent. Offered alongside the external-editor
+   *  option so users can review work inline without leaving the app. Accepts
+   *  an optional file path to pre-select (used when the user clicks a row
+   *  in Files Changed). */
+  onOpenWorkspace?: (filePath?: string) => void
   onChangeModel?: () => void
   onOpenTerminal?: () => void
   onToggleLabel?: (labelId: string) => void
@@ -186,6 +193,7 @@ export const DetailDrawer = memo(function DetailDrawer({
   onOpenQuickActionSettings,
   onSetPrUrl,
   onOpenInEditor,
+  onOpenWorkspace,
   onChangeModel,
   onOpenTerminal,
   onToggleLabel,
@@ -214,6 +222,9 @@ export const DetailDrawer = memo(function DetailDrawer({
   const [cursorPos, setCursorPos] = useState(0)
   const [visibleMessageCount, setVisibleMessageCount] = useState(VISIBLE_MESSAGE_WINDOW)
   const [showPrLinkModal, setShowPrLinkModal] = useState(false)
+  // Highlight-to-ask popover state. Anchored near the selection end; nulled
+  // out on send/close/selection-cleared.
+  const [highlightPopover, setHighlightPopover] = useState<{ anchor: { x: number; y: number }; selection: HighlightSelection } | null>(null)
 
   // Input history cycling: -1 = not browsing, 0+ = offset from most recent
   const historyIndexRef = useRef(-1)
@@ -388,6 +399,80 @@ export const DetailDrawer = memo(function DetailDrawer({
   useEffect(() => {
     textareaRef.current?.focus()
   }, [agent.id])
+
+  // ── Highlight-to-ask in the transcript ────────────────────────────────
+  // Track text selections made inside the transcript content region. When a
+  // non-empty selection settles (mouseup / keyup), anchor the popover near
+  // its end and let the user compose a question quoting the selected text.
+  //
+  // Why this shape and not `selectionchange`: fires too aggressively during
+  // a drag, and we only want the popover once the user is done highlighting.
+  // We still reset on selection clear so switching focus to the composer
+  // doesn't leave a stale popover floating.
+  useEffect(() => {
+    if (activeTab !== 'transcript') {
+      setHighlightPopover(null)
+      return
+    }
+    const content = transcriptContentRef.current
+    if (!content) return
+
+    const captureSelection = () => {
+      const selection = window.getSelection()
+      if (!selection || selection.isCollapsed || selection.rangeCount === 0) return
+
+      const range = selection.getRangeAt(0)
+      if (!content.contains(range.commonAncestorContainer)) return
+
+      const text = selection.toString().trim()
+      if (!text) return
+
+      const rect = range.getBoundingClientRect()
+      if (rect.width === 0 && rect.height === 0) return
+
+      setHighlightPopover({
+        anchor: { x: rect.left, y: rect.bottom + 6 },
+        selection: {
+          text,
+          source: 'message transcript'
+        }
+      })
+    }
+
+    const onMouseUp = () => {
+      // Defer by a frame so the browser finalizes the selection first.
+      requestAnimationFrame(captureSelection)
+    }
+    const onKeyUp = (event: KeyboardEvent) => {
+      if (event.shiftKey || event.key.startsWith('Arrow')) {
+        requestAnimationFrame(captureSelection)
+      }
+    }
+
+    content.addEventListener('mouseup', onMouseUp)
+    content.addEventListener('keyup', onKeyUp)
+    return () => {
+      content.removeEventListener('mouseup', onMouseUp)
+      content.removeEventListener('keyup', onKeyUp)
+    }
+  }, [activeTab])
+
+  const handleHighlightSend = useCallback((message: string) => {
+    if (onSendMessage) {
+      onSendMessage(message)
+    }
+    setHighlightPopover(null)
+    // Clear the selection so the popover doesn't immediately re-trigger.
+    window.getSelection()?.removeAllRanges()
+    // Re-engage follow-to-bottom so the user watches the agent's reply land
+    // even if they'd scrolled up to inspect the quoted passage.
+    followBottomRef.current = true
+    setShowJumpToLatest(false)
+    requestAnimationFrame(() => {
+      const container = transcriptScrollRef.current
+      if (container) container.scrollTop = container.scrollHeight
+    })
+  }, [onSendMessage])
 
   const scrollToBottom = (el: HTMLDivElement) => { el.scrollTop = el.scrollHeight }
 
@@ -650,9 +735,15 @@ export const DetailDrawer = memo(function DetailDrawer({
     setTimeout(onClose, 200)
   }
 
+  // Dedupe files by path so the tab badge matches what the user sees in the
+  // list. Multiple SSE events for the same file (e.g. agent edits foo.ts
+  // five times) would otherwise inflate the count even though FilesChanged
+  // itself collapses them on render.
+  const uniqueFileCount = new Set(files.map((file) => file.path)).size
+
   const tabs: { key: TabKey; label: string; count?: number }[] = [
     { key: 'transcript', label: 'Transcript', count: messages.length },
-    { key: 'files', label: 'Files Changed', count: files.length },
+    { key: 'files', label: 'Files Changed', count: uniqueFileCount },
     { key: 'tools', label: 'Tools', count: tools.length },
     { key: 'events', label: 'Events', count: events.length }
   ]
@@ -861,7 +952,12 @@ export const DetailDrawer = memo(function DetailDrawer({
               </div>
             )}
 
-            {activeTab === 'files' && <FilesChanged files={files} />}
+            {activeTab === 'files' && (
+              <FilesChanged
+                files={files}
+                onFileClick={onOpenWorkspace ? (path) => onOpenWorkspace(path) : undefined}
+              />
+            )}
             {activeTab === 'tools' && <ToolsUsage tools={tools} verbose={isVerbose} />}
             {activeTab === 'events' && <EventLog events={events} verbose={isVerbose} />}
           </div>
@@ -1120,6 +1216,7 @@ export const DetailDrawer = memo(function DetailDrawer({
                 label="Open In"
                 className="w-full"
                 items={[
+                  ...(onOpenWorkspace ? [{ icon: <Code size={12} />, label: 'Review changes (⌘E)', onClick: () => onOpenWorkspace() }] : []),
                   { icon: <Terminal size={12} />, label: 'Terminal', onClick: onOpenTerminal },
                   { icon: <ArrowSquareOut size={12} />, label: 'Editor', onClick: onOpenInEditor }
                 ]}
@@ -1192,6 +1289,14 @@ export const DetailDrawer = memo(function DetailDrawer({
             setShowPrLinkModal(false)
           }}
           onClose={() => setShowPrLinkModal(false)}
+        />
+      )}
+      {highlightPopover && onSendMessage && (
+        <HighlightAskPopover
+          anchor={highlightPopover.anchor}
+          selection={highlightPopover.selection}
+          onSend={handleHighlightSend}
+          onClose={() => setHighlightPopover(null)}
         />
       )}
     </div>

--- a/src/renderer/src/components/FilesChanged.tsx
+++ b/src/renderer/src/components/FilesChanged.tsx
@@ -9,6 +9,10 @@ export interface FileChange {
 
 interface FilesChangedProps {
   files: FileChange[]
+  /** Click handler for a file row. When provided, rows become buttons and
+   *  clicking launches the caller into whatever viewer they supply (in
+   *  practice, the Workspace diff view focused on that file). */
+  onFileClick?: (path: string) => void
 }
 
 const actionStyles: Record<FileChange['action'], string> = {
@@ -50,7 +54,7 @@ function extractFilename(filePath: string): string {
   return segments[segments.length - 1] || filePath
 }
 
-export const FilesChanged = memo(function FilesChanged({ files }: FilesChangedProps) {
+export const FilesChanged = memo(function FilesChanged({ files, onFileClick }: FilesChangedProps) {
   const sorted = useMemo(() => {
     const latestByPath = new Map<string, FileChange>()
     for (const file of files) {
@@ -76,38 +80,52 @@ export const FilesChanged = memo(function FilesChanged({ files }: FilesChangedPr
       <div className="text-[11px] text-kumo-subtle px-1 pb-1">
         {sorted.length} file{sorted.length !== 1 ? 's' : ''} changed
       </div>
-      {sorted.map((file, index) => (
-        <div
-          key={`${file.path}-${index}`}
-          className="flex items-center gap-2.5 px-2.5 py-2 rounded-md bg-kumo-control border border-kumo-line hover:border-kumo-fill-hover transition-colors group"
-        >
-          <span className={`shrink-0 ${actionStyles[file.action].split(' ').find((cls) => cls.startsWith('text-'))}`}>
-            {actionIcon(file.action)}
-          </span>
-
-          <div className="flex-1 min-w-0">
-            <div
-              className="text-xs text-kumo-default truncate"
-              title={file.path}
-            >
-              {extractFilename(file.path)}
-            </div>
-            <div className="text-[10px] text-kumo-subtle truncate" title={file.path}>
-              {file.path}
-            </div>
-          </div>
-
-          <span
-            className={`shrink-0 inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium border ${actionStyles[file.action]}`}
+      {sorted.map((file, index) => {
+        const clickable = !!onFileClick && file.action !== 'deleted'
+        const Tag = clickable ? 'button' : 'div'
+        const clickProps = clickable
+          ? {
+              type: 'button' as const,
+              onClick: () => onFileClick?.(file.path),
+              title: `${file.path} · click to view diff`
+            }
+          : {}
+        return (
+          <Tag
+            key={`${file.path}-${index}`}
+            {...clickProps}
+            className={`flex items-center gap-2.5 px-2.5 py-2 rounded-md bg-kumo-control border border-kumo-line transition-colors group text-left w-full ${
+              clickable ? 'hover:border-kumo-brand/50 hover:bg-kumo-fill-hover cursor-pointer' : 'hover:border-kumo-fill-hover'
+            }`}
           >
-            {actionLabels[file.action]}
-          </span>
+            <span className={`shrink-0 ${actionStyles[file.action].split(' ').find((cls) => cls.startsWith('text-'))}`}>
+              {actionIcon(file.action)}
+            </span>
 
-          <span className="shrink-0 text-[10px] text-kumo-subtle font-mono">
-            {formatRelativeTime(file.timestamp)}
-          </span>
-        </div>
-      ))}
+            <div className="flex-1 min-w-0">
+              <div
+                className="text-xs text-kumo-default truncate"
+                title={file.path}
+              >
+                {extractFilename(file.path)}
+              </div>
+              <div className="text-[10px] text-kumo-subtle truncate" title={file.path}>
+                {file.path}
+              </div>
+            </div>
+
+            <span
+              className={`shrink-0 inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium border ${actionStyles[file.action]}`}
+            >
+              {actionLabels[file.action]}
+            </span>
+
+            <span className="shrink-0 text-[10px] text-kumo-subtle font-mono">
+              {formatRelativeTime(file.timestamp)}
+            </span>
+          </Tag>
+        )
+      })}
     </div>
   )
 })

--- a/src/renderer/src/components/HighlightAskPopover.tsx
+++ b/src/renderer/src/components/HighlightAskPopover.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { ChatCircleDots, PaperPlaneTilt, X } from '@phosphor-icons/react'
+
+/** The selection being quoted into the agent message. */
+export interface HighlightSelection {
+  /** Exact text the user selected. Already trimmed of leading/trailing whitespace-only
+   *  lines but inner structure preserved. */
+  text: string
+  /** Human-readable source label (e.g. "src/foo.ts:42-50" or "message from assistant"). */
+  source: string
+  /** Optional language hint for the quoted code fence. If absent, no language tag is applied. */
+  language?: string
+}
+
+interface HighlightAskPopoverProps {
+  /** Absolute viewport position where the popover anchors (typically near the selection end). */
+  anchor: { x: number; y: number }
+  /** What the user highlighted — shown in a preview strip at the top of the popover. */
+  selection: HighlightSelection
+  /** Called when the user sends. Receives the full composed message (citation + question). */
+  onSend: (message: string) => void
+  /** Dismiss without sending. */
+  onClose: () => void
+}
+
+const MAX_PREVIEW_CHARS = 160
+/** Popover width in px. Mirrors the `w-[400px]` class below; kept in sync
+ *  manually so the off-screen clamp math can reason about dimensions. */
+const POPOVER_WIDTH = 400
+/** Conservative height estimate used only for clamping — real height varies
+ *  with preview size. Slightly oversized so the popover never touches the
+ *  window edge. */
+const POPOVER_MAX_HEIGHT = 220
+/** Minimum distance from viewport edges so the popover doesn't butt against
+ *  the screen corner. */
+const VIEWPORT_MARGIN = 8
+
+/**
+ * Floating composer that shows a preview of a code/text selection and lets the
+ * user ask a quick question about it. Composes the final message as a
+ * markdown-quoted citation followed by the user's question, so the agent sees
+ * the snippet with full context when replying.
+ *
+ * Used from two entry points:
+ *   - Monaco editor/diff selection in the Workspace view
+ *   - Text selection inside the DetailDrawer Messages tab
+ */
+export function HighlightAskPopover({ anchor, selection, onSend, onClose }: HighlightAskPopoverProps) {
+  const [question, setQuestion] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Autofocus the textarea on open. Using requestAnimationFrame avoids
+  // losing focus to the selection-change event that triggered the popover.
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => textareaRef.current?.focus())
+    return () => cancelAnimationFrame(frame)
+  }, [])
+
+  // Dismiss on outside click / Escape.
+  useEffect(() => {
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null
+      if (!target) return
+      if (containerRef.current?.contains(target)) return
+      onClose()
+    }
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation()
+        onClose()
+      }
+    }
+    window.addEventListener('pointerdown', handlePointerDown, true)
+    window.addEventListener('keydown', handleKey, true)
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown, true)
+      window.removeEventListener('keydown', handleKey, true)
+    }
+  }, [onClose])
+
+  const handleSend = useCallback(() => {
+    const trimmed = question.trim()
+    if (!trimmed) return
+    const message = composeCitationMessage(selection, trimmed)
+    onSend(message)
+  }, [question, selection, onSend])
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Skip composition events (IME candidates) so Enter doesn't send mid-typing.
+    if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
+      event.preventDefault()
+      handleSend()
+    }
+  }
+
+  // Clamp so the popover never slides off-screen. The caller picks the
+  // anchor near the selection end, and we just ensure it fits.
+  const clampedX = Math.max(
+    VIEWPORT_MARGIN,
+    Math.min(anchor.x, window.innerWidth - POPOVER_WIDTH - VIEWPORT_MARGIN)
+  )
+  const clampedY = Math.max(
+    VIEWPORT_MARGIN,
+    Math.min(anchor.y, window.innerHeight - POPOVER_MAX_HEIGHT - VIEWPORT_MARGIN)
+  )
+
+  const previewText = selection.text.length > MAX_PREVIEW_CHARS
+    ? selection.text.slice(0, MAX_PREVIEW_CHARS) + '…'
+    : selection.text
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ left: clampedX, top: clampedY }}
+      className="fixed z-[9999] w-[400px] rounded-lg border border-neutral-700 bg-neutral-900 shadow-2xl shadow-black/60"
+      role="dialog"
+      aria-label="Ask about highlighted text"
+    >
+      <div className="flex items-center justify-between px-3 py-2 border-b border-neutral-800">
+        <div className="flex items-center gap-1.5 text-xs text-neutral-400">
+          <ChatCircleDots weight="duotone" className="h-3.5 w-3.5" />
+          <span className="font-medium">Ask about selection</span>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-neutral-500 hover:text-neutral-300"
+          aria-label="Close"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <div className="px-3 py-2 border-b border-neutral-800">
+        <div className="text-[10px] uppercase tracking-wide text-neutral-500 mb-1 font-mono">{selection.source}</div>
+        <pre className="text-[11px] text-neutral-300 bg-neutral-950 rounded border border-neutral-800 px-2 py-1.5 max-h-36 overflow-auto whitespace-pre font-mono leading-snug">
+          {previewText}
+        </pre>
+      </div>
+
+      <div className="p-2">
+        <textarea
+          ref={textareaRef}
+          value={question}
+          onChange={(event) => setQuestion(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="What do you want to ask?"
+          rows={3}
+          className="w-full resize-none bg-neutral-950 border border-neutral-800 rounded px-2 py-1.5 text-sm text-neutral-100 placeholder:text-neutral-600 focus:outline-none focus:ring-1 focus:ring-sky-500/50 focus:border-sky-500/50"
+        />
+        <div className="flex items-center justify-between mt-2">
+          <span className="text-[10px] text-neutral-500">Enter to send · Shift+Enter for newline</span>
+          <button
+            type="button"
+            onClick={handleSend}
+            disabled={!question.trim()}
+            className="flex items-center gap-1 px-2 py-1 rounded bg-sky-600 hover:bg-sky-500 text-white text-xs font-medium disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <PaperPlaneTilt weight="fill" className="h-3 w-3" />
+            Send
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Compose a markdown-quoted citation block plus the user's question. */
+export function composeCitationMessage(selection: HighlightSelection, question: string): string {
+  const fence = selection.language ? '```' + selection.language : '```'
+  return [
+    `> \`${selection.source}\``,
+    '>',
+    `> ${fence}`,
+    ...selection.text.split('\n').map((line) => `> ${line}`),
+    '> ```',
+    '',
+    question
+  ].join('\n')
+}

--- a/src/renderer/src/components/WorkspaceView.tsx
+++ b/src/renderer/src/components/WorkspaceView.tsx
@@ -1,0 +1,997 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { editor } from 'monaco-editor'
+import { DiffEditor, loader } from '@monaco-editor/react'
+import * as monacoNs from 'monaco-editor'
+import {
+  ArrowLeft,
+  ArrowsClockwise,
+  CaretDown,
+  CaretUp,
+  CheckCircle,
+  CircleNotch,
+  FileText,
+  FloppyDisk,
+  FolderSimple,
+  Warning
+} from '@phosphor-icons/react'
+import { HighlightAskPopover, type HighlightSelection } from './HighlightAskPopover'
+import { languageForPath } from '../lib/language'
+
+// Wire the Monaco loader to the bundled copy so it doesn't try to fetch from a
+// CDN at runtime — we can't hit the network reliably in a packaged Electron
+// app, and the CDN fetch would be a privacy leak anyway.
+loader.config({ monaco: monacoNs })
+
+interface WorkspaceViewProps {
+  agentId: string
+  agentName: string
+  projectName: string
+  branchName: string
+  /** Current agent status. Used to show a warning when editing would race with
+   *  live agent writes in a later PR; for now purely informational. */
+  agentStatus: string
+  /** Pre-select a specific file on open (e.g. when the user clicked a file
+   *  entry in the Files Changed tab). Falls back to the first file in the
+   *  git-status result when null/undefined. */
+  initialFilePath?: string | null
+  /** Called when the user backs out of the workspace view, returning to the fleet. */
+  onClose: () => void
+  /** Hands a composed message (from the highlight-to-ask popover) back to the
+   *  main send path, so it uses the same history/attachments/command pipeline
+   *  as the chat input. */
+  onSendMessage: (text: string) => void
+}
+
+interface GitStatusFile {
+  path: string
+  oldPath?: string
+  status: string
+  staged: boolean
+  unstaged: boolean
+}
+
+interface DiffSides {
+  before: string
+  after: string
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  added: 'text-emerald-400',
+  modified: 'text-sky-400',
+  deleted: 'text-rose-400',
+  renamed: 'text-amber-400',
+  copied: 'text-amber-400',
+  typechange: 'text-amber-400',
+  unmerged: 'text-rose-400',
+  untracked: 'text-neutral-400'
+}
+
+const STATUS_GLYPHS: Record<string, string> = {
+  added: 'A',
+  modified: 'M',
+  deleted: 'D',
+  renamed: 'R',
+  copied: 'C',
+  typechange: 'T',
+  unmerged: 'U',
+  untracked: '?'
+}
+
+/** Autosave debounce: 1s after the last keystroke. Long enough to batch a
+ *  paste or rapid typing, short enough that you don't lose work if the app
+ *  crashes. */
+const AUTOSAVE_DEBOUNCE_MS = 1000
+
+/** Stable subscription id for the file watcher — we reuse it on file switch
+ *  so the main process just rebinds the single watch rather than accumulating
+ *  handles. Scoped per WorkspaceView instance so multiple open views don't
+ *  trample. */
+function makeWatchSubscriptionId(): string {
+  return `workspace-view-${Math.random().toString(36).slice(2, 10)}`
+}
+
+/**
+ * Full-window review surface for an agent's uncommitted work. Shows a git-
+ * status-backed file list on the left and a Monaco diff viewer on the right.
+ *
+ * The modified (right-hand) side is editable — light edits save on autosave
+ * debounce (1s after last keystroke) plus Cmd+S. The original (HEAD) side
+ * is always read-only; the concept of editing historical content doesn't
+ * make sense for this workflow.
+ *
+ * Selecting text in either side surfaces a "Ask about this" popover that
+ * composes a citation-quoted question and routes it through the normal
+ * chat send path.
+ *
+ * Conflict handling: a narrow fs watcher observes the currently-open file.
+ * When it fires:
+ *   - If the editor buffer is clean (no unsaved edits), silently reload.
+ *   - If the buffer is dirty, show a banner letting the user choose between
+ *     discarding their edits and keeping them (which will overwrite on next
+ *     save).
+ * On save, if the on-disk mtime advanced since we last read, we surface a
+ * conflict modal so the user isn't clobbered silently.
+ */
+export function WorkspaceView({
+  agentId,
+  agentName,
+  projectName,
+  branchName,
+  agentStatus,
+  initialFilePath,
+  onClose,
+  onSendMessage
+}: WorkspaceViewProps) {
+  const [files, setFiles] = useState<GitStatusFile[]>([])
+  const [loadingStatus, setLoadingStatus] = useState(true)
+  const [statusError, setStatusError] = useState<string | null>(null)
+  // Seed selection from the caller's initial path; falls back to first file
+  // after the git-status fetch completes if the initial path isn't in the
+  // status list (e.g. file was since staged/committed elsewhere).
+  const [selectedPath, setSelectedPath] = useState<string | null>(initialFilePath ?? null)
+  const [diffSides, setDiffSides] = useState<DiffSides | null>(null)
+  const [loadingDiff, setLoadingDiff] = useState(false)
+  const [diffError, setDiffError] = useState<string | null>(null)
+
+  // ── Editing state ─────────────────────────────────────────────────────────
+  // Whether the buffer has unsaved edits relative to what's on disk.
+  const [isDirty, setIsDirty] = useState(false)
+  // mtime observed when we last read the file; used for optimistic-concurrency
+  // checks on save. Refs not state because it's pure IO metadata — no render
+  // depends on it directly.
+  const mtimeAtReadRef = useRef<number | null>(null)
+  // The text we last successfully read or saved. Used to decide "is the
+  // current editor value dirty?" on each change event.
+  const lastSyncedContentRef = useRef<string>('')
+  // External-change banner: populated when the file watcher fires while the
+  // buffer is dirty. Clearing it (Keep mine / Reload) closes the banner.
+  const [externalChange, setExternalChange] = useState<{ mtimeMs: number | null } | null>(null)
+  // Transient save state for the header indicator.
+  const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'conflict' | 'error'>('idle')
+  const [saveError, setSaveError] = useState<string | null>(null)
+  // Conflict modal state: shown after a rejected save so the user can pick
+  // Overwrite / Discard mine / Cancel without losing their edits.
+  const [conflictModal, setConflictModal] = useState<{ currentMtimeMs: number | null } | null>(null)
+
+  const [popover, setPopover] = useState<{ anchor: { x: number; y: number }; selection: HighlightSelection } | null>(null)
+
+  const diffEditorRef = useRef<editor.IStandaloneDiffEditor | null>(null)
+  const autosaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // One stable watcher subscription id per view instance.
+  const watchSubIdRef = useRef<string>(makeWatchSubscriptionId())
+
+  // ── Fetch git status ─────────────────────────────────────────────────────
+  const refreshStatus = useCallback(async () => {
+    setLoadingStatus(true)
+    setStatusError(null)
+    try {
+      const result = await window.api.getGitStatus(agentId)
+      if (!result.ok || !result.data) {
+        setStatusError(result.error ?? 'Failed to load git status')
+        setFiles([])
+      } else {
+        const sorted = [...result.data].sort((a, b) => a.path.localeCompare(b.path))
+        setFiles(sorted)
+        // Auto-select the first file on initial load if nothing selected yet.
+        setSelectedPath((current) => current ?? sorted[0]?.path ?? null)
+      }
+    } catch (error) {
+      setStatusError(String(error))
+      setFiles([])
+    } finally {
+      setLoadingStatus(false)
+    }
+  }, [agentId])
+
+  useEffect(() => {
+    void refreshStatus()
+  }, [refreshStatus])
+
+  // ── Fetch diff for selected file ─────────────────────────────────────────
+  // Called on every file switch or reload-from-disk. Re-stamps mtime and
+  // re-primes the lastSynced reference, invalidating any stale dirty flag.
+  const loadDiff = useCallback(async (filePath: string) => {
+    setLoadingDiff(true)
+    setDiffError(null)
+    try {
+      const diffResult = await window.api.getGitDiff(agentId, filePath)
+      if (!diffResult.ok || !diffResult.data) {
+        setDiffError(diffResult.error ?? 'Failed to load diff')
+        setDiffSides(null)
+        mtimeAtReadRef.current = null
+        return
+      }
+      setDiffSides(diffResult.data)
+
+      // Pull the mtime via readFile so we have a concurrency stamp for
+      // saves. This is a separate round-trip from the diff (which comes
+      // from git-show), but it's cheap and it's the only way to get the
+      // working-tree mtime. For deleted files readFile fails; that's
+      // expected — no editing there, so we just fall back to the diff's
+      // "after" side (which will be empty) for the synced content.
+      const readResult = await window.api.readFile(agentId, filePath).catch(() => null)
+      if (readResult?.ok && readResult.data) {
+        mtimeAtReadRef.current = readResult.data.mtimeMs
+        lastSyncedContentRef.current = readResult.data.content
+      } else {
+        mtimeAtReadRef.current = null
+        lastSyncedContentRef.current = diffResult.data.after
+      }
+
+      setIsDirty(false)
+      setExternalChange(null)
+      setSaveState('idle')
+      setSaveError(null)
+    } catch (error) {
+      setDiffError(String(error))
+      setDiffSides(null)
+      mtimeAtReadRef.current = null
+    } finally {
+      setLoadingDiff(false)
+    }
+  }, [agentId])
+
+  useEffect(() => {
+    if (!selectedPath) {
+      setDiffSides(null)
+      mtimeAtReadRef.current = null
+      return
+    }
+    void loadDiff(selectedPath)
+  }, [selectedPath, loadDiff])
+
+  const selectedFile = useMemo(() => files.find((file) => file.path === selectedPath) ?? null, [files, selectedPath])
+
+  // Deleted files can't be edited — we have nothing in the working tree to
+  // save back. Also the diff is empty on the modified side so Monaco would
+  // happily accept edits that go nowhere useful.
+  const canEdit = !!selectedFile && selectedFile.status !== 'deleted'
+
+  // ── Save ──────────────────────────────────────────────────────────────────
+  /**
+   * Write the current modified-side buffer to disk. `force` overrides the
+   * mtime concurrency check (used by the "Overwrite" action in the conflict
+   * modal). Returns a promise so callers (Cmd+S, autosave, conflict modal)
+   * can await completion and coordinate state transitions.
+   */
+  const saveFile = useCallback(async (force: boolean = false): Promise<void> => {
+    if (!selectedPath || !canEdit) return
+    const editorInstance = diffEditorRef.current
+    if (!editorInstance) return
+    const model = editorInstance.getModifiedEditor().getModel()
+    if (!model) return
+    const content = model.getValue()
+
+    // Nothing to do if buffer matches disk.
+    if (content === lastSyncedContentRef.current && !force) {
+      setIsDirty(false)
+      return
+    }
+
+    setSaveState('saving')
+    setSaveError(null)
+    try {
+      const expectedMtime = force ? null : mtimeAtReadRef.current
+      const result = await window.api.writeFile(agentId, selectedPath, content, expectedMtime)
+      if (!result.ok) {
+        if (result.error === 'CONFLICT') {
+          // Surface the conflict modal so the user picks. We leave isDirty
+          // true so their edits aren't lost; they can discard, overwrite,
+          // or cancel.
+          setSaveState('conflict')
+          setConflictModal({ currentMtimeMs: result.data?.currentMtimeMs ?? null })
+          return
+        }
+        setSaveState('error')
+        setSaveError(result.error ?? 'Save failed')
+        return
+      }
+      if (!result.data) return
+      mtimeAtReadRef.current = result.data.mtimeMs
+      lastSyncedContentRef.current = content
+      setIsDirty(false)
+      setSaveState('saved')
+      // Auto-clear the "saved" indicator after a moment so it doesn't linger.
+      setTimeout(() => {
+        setSaveState((prev) => (prev === 'saved' ? 'idle' : prev))
+      }, 1200)
+    } catch (error) {
+      setSaveState('error')
+      setSaveError(String(error))
+    }
+  }, [agentId, selectedPath, canEdit])
+
+  // ── Autosave: 1s debounce after last edit ─────────────────────────────────
+  // We keep a ref-based timer so re-renders don't clobber it. When the buffer
+  // goes clean (dirty=false) we cancel any pending save — nothing to save.
+  useEffect(() => {
+    if (!isDirty) {
+      if (autosaveTimerRef.current) {
+        clearTimeout(autosaveTimerRef.current)
+        autosaveTimerRef.current = null
+      }
+      return
+    }
+    if (autosaveTimerRef.current) clearTimeout(autosaveTimerRef.current)
+    autosaveTimerRef.current = setTimeout(() => {
+      autosaveTimerRef.current = null
+      void saveFile(false)
+    }, AUTOSAVE_DEBOUNCE_MS)
+    return () => {
+      if (autosaveTimerRef.current) {
+        clearTimeout(autosaveTimerRef.current)
+        autosaveTimerRef.current = null
+      }
+    }
+  }, [isDirty, saveFile])
+
+  // Save any pending edits on file switch / unmount. Without this, switching
+  // files during the 1s debounce window would drop the save (diff reload
+  // clears dirty=false, cancelling the pending timer).
+  //
+  // We read isDirty and saveFile via refs so the effect only re-runs on
+  // file switch — otherwise it would re-arm on every keystroke, flushing
+  // mid-typing. The refs are updated by the effect below.
+  const isDirtyRef = useRef(isDirty)
+  const saveFileRef = useRef(saveFile)
+  useEffect(() => {
+    isDirtyRef.current = isDirty
+    saveFileRef.current = saveFile
+  })
+  useEffect(() => {
+    return () => {
+      if (isDirtyRef.current) {
+        void saveFileRef.current(false)
+      }
+    }
+  }, [selectedPath])
+
+  // Cmd+S shortcut — explicit save request, bypasses debounce.
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === 's') {
+        event.preventDefault()
+        if (canEdit) void saveFile(false)
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [canEdit, saveFile])
+
+  // ── File watcher: detect external changes to the open file ──────────────
+  // One fs.watch per open file. On change we either silently reload (clean
+  // buffer) or show a banner letting the user choose (dirty buffer). The
+  // subscription id stays stable across file switches so the main process
+  // rebinds the single watch rather than accumulating handles.
+  useEffect(() => {
+    if (!selectedPath) return
+    const subId = watchSubIdRef.current
+    let disposed = false
+
+    const unsubscribe = window.api.onFileChanged((data) => {
+      if (data.subscriptionId !== subId) return
+      if (disposed) return
+      if (data.event === 'error' || data.event === 'renamed') {
+        // Bail — the watch is no longer valid. Next save will see the error.
+        return
+      }
+      if (data.event === 'deleted') {
+        // File vanished. Tell the user; their buffer is effectively orphaned.
+        setExternalChange({ mtimeMs: null })
+        return
+      }
+
+      // Ignore events where the mtime matches what we think it is — this
+      // catches the echo of our own writes landing.
+      if (data.mtimeMs && mtimeAtReadRef.current && data.mtimeMs === mtimeAtReadRef.current) {
+        return
+      }
+
+      if (isDirty) {
+        // User has unsaved edits. Show banner so they decide.
+        setExternalChange({ mtimeMs: data.mtimeMs ?? null })
+      } else {
+        // Clean buffer — reload silently. The existing diff-fetch re-primes
+        // the mtime ref, so subsequent saves won't false-alarm as conflicts.
+        void loadDiff(selectedPath)
+      }
+    })
+
+    void window.api.watchFile(agentId, subId, selectedPath)
+
+    return () => {
+      disposed = true
+      unsubscribe()
+      void window.api.unwatchFile(subId)
+    }
+  }, [agentId, selectedPath, isDirty, loadDiff])
+
+  // ── Hunk navigation ──────────────────────────────────────────────────────
+  const handleJumpHunk = useCallback((direction: 'next' | 'prev') => {
+    const editorInstance = diffEditorRef.current
+    if (!editorInstance) return
+
+    const changes = editorInstance.getLineChanges()
+    if (!changes || changes.length === 0) return
+
+    const modifiedEditor = editorInstance.getModifiedEditor()
+    const currentLine = modifiedEditor.getPosition()?.lineNumber ?? 1
+
+    let target: typeof changes[number] | undefined
+    if (direction === 'next') {
+      target = changes.find((change) => change.modifiedStartLineNumber > currentLine) ?? changes[0]
+    } else {
+      const reversed = [...changes].reverse()
+      target = reversed.find((change) => change.modifiedStartLineNumber < currentLine) ?? changes[changes.length - 1]
+    }
+
+    if (!target) return
+    const line = target.modifiedStartLineNumber || 1
+    modifiedEditor.revealLineInCenter(line)
+    modifiedEditor.setPosition({ lineNumber: line, column: 1 })
+  }, [])
+
+  const handleJumpFile = useCallback((direction: 'next' | 'prev') => {
+    if (files.length === 0) return
+    const currentIndex = selectedPath ? files.findIndex((file) => file.path === selectedPath) : -1
+    const nextIndex = direction === 'next'
+      ? (currentIndex + 1) % files.length
+      : (currentIndex - 1 + files.length) % files.length
+    setSelectedPath(files[nextIndex].path)
+  }, [files, selectedPath])
+
+  // ── Highlight-to-ask wiring ──────────────────────────────────────────────
+  const captureSelection = useCallback(() => {
+    const editorInstance = diffEditorRef.current
+    if (!editorInstance || !selectedPath) return
+
+    // Prefer the modified (right-hand) editor, fall back to original if the
+    // user is selecting from the HEAD side.
+    const modified = editorInstance.getModifiedEditor()
+    const original = editorInstance.getOriginalEditor()
+    const activeEditor = modified.hasTextFocus() ? modified : original.hasTextFocus() ? original : null
+    if (!activeEditor) return
+
+    const selection = activeEditor.getSelection()
+    if (!selection || selection.isEmpty()) return
+
+    const model = activeEditor.getModel()
+    if (!model) return
+
+    const selectedText = model.getValueInRange(selection)
+    if (!selectedText.trim()) return
+
+    // Trim whitespace-only leading/trailing lines but keep inner indentation.
+    const trimmed = selectedText.replace(/^\s*\n+/, '').replace(/\n+\s*$/, '')
+
+    const startLine = selection.startLineNumber
+    const endLine = selection.endLineNumber
+    const lineRange = startLine === endLine ? `${startLine}` : `${startLine}-${endLine}`
+
+    // Anchor the popover just below the selection end, using Monaco's coords.
+    const domNode = activeEditor.getDomNode()
+    if (!domNode) return
+    const rect = domNode.getBoundingClientRect()
+    const lineTop = activeEditor.getTopForLineNumber(endLine) - activeEditor.getScrollTop()
+    const x = rect.left + 80 // offset past line numbers so the popover isn't clipped
+    const y = rect.top + lineTop + 24
+
+    setPopover({
+      anchor: { x, y },
+      selection: {
+        text: trimmed,
+        source: `${selectedPath}:${lineRange}`,
+        language: languageForPath(selectedPath)
+      }
+    })
+  }, [selectedPath])
+
+  const handleDiffMount = useCallback((editorInstance: editor.IStandaloneDiffEditor) => {
+    diffEditorRef.current = editorInstance
+    const modified = editorInstance.getModifiedEditor()
+    const original = editorInstance.getOriginalEditor()
+
+    // Only fire the popover once the selection is *settled*: mouseup ends a
+    // drag, keyup catches shift+arrow selections. Listening to
+    // onDidChangeCursorSelection would fire on every intermediate frame of a
+    // drag, popping the dialog before the user is done highlighting.
+    const onPointerUp = () => requestAnimationFrame(captureSelection)
+    const onKeyUp = (event: KeyboardEvent) => {
+      // Only interesting when the user was extending a selection — plain
+      // arrow movement / typing shouldn't trigger the popover.
+      if (event.shiftKey || event.key === 'Shift') {
+        requestAnimationFrame(captureSelection)
+      }
+    }
+
+    const modifiedDom = modified.getDomNode()
+    const originalDom = original.getDomNode()
+    modifiedDom?.addEventListener('mouseup', onPointerUp)
+    modifiedDom?.addEventListener('keyup', onKeyUp)
+    originalDom?.addEventListener('mouseup', onPointerUp)
+    originalDom?.addEventListener('keyup', onKeyUp)
+
+    // Collapsing the selection (empty click) should dismiss any open popover
+    // so it doesn't strand on a now-empty selection.
+    const onCursorChange = () => {
+      const sel = modified.getSelection() ?? original.getSelection()
+      if (!sel || sel.isEmpty()) {
+        setPopover(null)
+      }
+    }
+    const d1 = modified.onDidChangeCursorPosition(onCursorChange)
+    const d2 = original.onDidChangeCursorPosition(onCursorChange)
+
+    // Content-change: mark dirty whenever the modified-side value drifts
+    // from the last-synced snapshot. Comparing against a ref (not the state)
+    // avoids stale closures after a reload mutates both values under us.
+    const d3 = modified.onDidChangeModelContent(() => {
+      const model = modified.getModel()
+      if (!model) return
+      const value = model.getValue()
+      setIsDirty(value !== lastSyncedContentRef.current)
+    })
+
+    editorInstance.onDidDispose(() => {
+      modifiedDom?.removeEventListener('mouseup', onPointerUp)
+      modifiedDom?.removeEventListener('keyup', onKeyUp)
+      originalDom?.removeEventListener('mouseup', onPointerUp)
+      originalDom?.removeEventListener('keyup', onKeyUp)
+      d1.dispose()
+      d2.dispose()
+      d3.dispose()
+    })
+  }, [captureSelection])
+
+  const handlePopoverSend = useCallback((message: string) => {
+    onSendMessage(message)
+    setPopover(null)
+    onClose()
+  }, [onSendMessage, onClose])
+
+  // ── Keyboard: Esc to close, cmd+up/down for file nav, hunk nav ───────────
+  // Hunk navigation has two bindings because plain n/p would type those
+  // letters when Monaco has focus in edit mode:
+  //   - Outside Monaco: n / p  (fast, mnemonic)
+  //   - Anywhere:       ⌘] / ⌘[  (works inside the editor too)
+  // ⌘↑ / ⌘↓ for file navigation works everywhere since those aren't
+  // standard editor bindings.
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement
+      const inEditable = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA'
+      const inMonaco = target.closest('.monaco-editor') !== null
+      const mod = event.metaKey || event.ctrlKey
+
+      if (event.key === 'Escape' && !inEditable) {
+        // If a popover is open, its own Escape handler runs first (with
+        // stopPropagation), so this branch only fires when there's no popover.
+        event.preventDefault()
+        onClose()
+        return
+      }
+
+      // File navigation: works in and out of Monaco because ⌘↑/⌘↓ aren't
+      // conflicting editor bindings on macOS.
+      if (mod && event.key === 'ArrowDown') {
+        event.preventDefault()
+        handleJumpFile('next')
+        return
+      }
+      if (mod && event.key === 'ArrowUp') {
+        event.preventDefault()
+        handleJumpFile('prev')
+        return
+      }
+
+      // Hunk navigation via ⌘] / ⌘[ works anywhere, including inside the
+      // editor where Monaco would otherwise swallow keys.
+      if (mod && event.key === ']') {
+        event.preventDefault()
+        handleJumpHunk('next')
+        return
+      }
+      if (mod && event.key === '[') {
+        event.preventDefault()
+        handleJumpHunk('prev')
+        return
+      }
+
+      // Bare n/p shortcuts only fire outside the editor and inputs; inside
+      // Monaco those letters need to actually type themselves.
+      if (inEditable || inMonaco) return
+
+      if (event.key === 'n' && !mod) {
+        event.preventDefault()
+        handleJumpHunk('next')
+      } else if (event.key === 'p' && !mod) {
+        event.preventDefault()
+        handleJumpHunk('prev')
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [handleJumpFile, handleJumpHunk, onClose])
+
+  const isAgentBusy = agentStatus === 'running' || agentStatus === 'starting'
+  const language = selectedPath ? languageForPath(selectedPath) : 'plaintext'
+
+  return (
+    <div className="fixed inset-0 bg-neutral-950 text-neutral-100 flex flex-col z-50">
+      {/* Header — drag-region on macOS so the user can still reposition the
+          window; interactive children opt out via no-drag. pl-20 reserves
+          space for the traffic-light cluster. */}
+      <div className="drag-region flex items-center gap-3 h-12 pl-20 pr-3 border-b border-neutral-800 bg-neutral-900 shrink-0">
+        <div className="flex items-center gap-2 text-sm min-w-0">
+          <FolderSimple weight="duotone" className="h-4 w-4 text-neutral-500 shrink-0" />
+          <span className="font-medium truncate">{projectName}</span>
+          <span className="text-neutral-500 shrink-0">/</span>
+          <span className="text-neutral-300 truncate">{agentName}</span>
+          <span className="text-neutral-600 text-xs ml-2 truncate">{branchName}</span>
+        </div>
+        <div className="flex-1" />
+        {isAgentBusy && (
+          <div className="no-drag flex items-center gap-1.5 text-xs text-amber-400 bg-amber-500/10 border border-amber-500/30 px-2 py-1 rounded shrink-0">
+            <Warning weight="fill" className="h-3 w-3" />
+            Agent is working — review only
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={() => void refreshStatus()}
+          className="no-drag flex items-center gap-1.5 text-xs text-neutral-400 hover:text-neutral-200 px-2 py-1 rounded hover:bg-neutral-800"
+          title="Refresh git status"
+        >
+          <ArrowsClockwise className="h-3.5 w-3.5" />
+          Refresh
+        </button>
+        <div className="h-4 w-px bg-neutral-700" />
+        <button
+          type="button"
+          onClick={onClose}
+          className="no-drag flex items-center gap-1.5 text-sm text-neutral-200 hover:text-white bg-neutral-800 hover:bg-neutral-700 px-2.5 py-1 rounded-md"
+          title="Back to fleet (Esc)"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back
+          <kbd className="ml-1 text-[10px] text-neutral-400 font-mono">Esc</kbd>
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 flex min-h-0">
+        {/* File list */}
+        <div className="w-72 border-r border-neutral-800 flex flex-col bg-neutral-900 min-h-0">
+          <div className="shrink-0 px-3 py-1.5 text-[10px] uppercase tracking-wide text-neutral-500 border-b border-neutral-800 flex items-center justify-between">
+            <span>Changed files</span>
+            <span className="text-neutral-600">{files.length}</span>
+          </div>
+          <div className="flex-1 overflow-auto min-h-0">
+            {loadingStatus ? (
+              <div className="flex items-center gap-2 px-3 py-4 text-xs text-neutral-500">
+                <CircleNotch className="h-3.5 w-3.5 animate-spin" />
+                Loading…
+              </div>
+            ) : statusError ? (
+              <div className="px-3 py-3 text-xs text-rose-400">{statusError}</div>
+            ) : files.length === 0 ? (
+              <div className="px-3 py-4 text-xs text-neutral-500">No uncommitted changes.</div>
+            ) : (
+              <ul>
+                {files.map((file) => {
+                  const isSelected = file.path === selectedPath
+                  const basename = file.path.split('/').pop() ?? file.path
+                  const dir = file.path.slice(0, file.path.length - basename.length)
+                  // Only the currently-selected file can be "dirty" — we
+                  // only hold one buffer at a time. Any future multi-buffer
+                  // support would need to track dirty-per-path here.
+                  const rowDirty = isSelected && isDirty
+                  return (
+                    <li key={file.path}>
+                      <button
+                        type="button"
+                        onClick={() => setSelectedPath(file.path)}
+                        className={`w-full text-left px-3 py-1.5 flex items-center gap-2 text-xs ${
+                          isSelected ? 'bg-sky-500/10 text-sky-100' : 'text-neutral-300 hover:bg-neutral-800/50'
+                        }`}
+                      >
+                        <span
+                          className={`w-3 text-center font-mono text-[10px] font-semibold ${STATUS_COLORS[file.status] ?? 'text-neutral-400'}`}
+                          title={file.status}
+                        >
+                          {STATUS_GLYPHS[file.status] ?? '•'}
+                        </span>
+                        <FileText weight="light" className="h-3.5 w-3.5 shrink-0 text-neutral-500" />
+                        <span className="truncate flex-1">
+                          {dir && <span className="text-neutral-500">{dir}</span>}
+                          <span>{basename}</span>
+                        </span>
+                        {rowDirty && (
+                          <span className="text-amber-400 text-[10px]" title="Unsaved changes">●</span>
+                        )}
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </div>
+          <div className="shrink-0 border-t border-neutral-800 px-3 py-2 text-[10px] text-neutral-500 leading-relaxed bg-neutral-900">
+            <div className="flex items-center gap-1 flex-wrap">
+              <kbd className="px-1 py-0.5 bg-neutral-800 rounded font-mono">⌘]</kbd>
+              <span>next hunk</span>
+              <span className="text-neutral-700 mx-0.5">·</span>
+              <kbd className="px-1 py-0.5 bg-neutral-800 rounded font-mono">⌘[</kbd>
+              <span>prev</span>
+              <span className="text-neutral-700 mx-0.5">·</span>
+              <kbd className="px-1 py-0.5 bg-neutral-800 rounded font-mono">⌘↓</kbd>
+              <span>next file</span>
+              <span className="text-neutral-700 mx-0.5">·</span>
+              <kbd className="px-1 py-0.5 bg-neutral-800 rounded font-mono">⌘S</kbd>
+              <span>save</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Diff pane */}
+        <div className="flex-1 flex flex-col min-w-0">
+          {selectedFile ? (
+            <>
+              <div className="flex items-center gap-2 px-3 py-1.5 border-b border-neutral-800 bg-neutral-900/50 text-xs">
+                <span className={`font-mono font-semibold ${STATUS_COLORS[selectedFile.status] ?? 'text-neutral-400'}`}>
+                  {STATUS_GLYPHS[selectedFile.status] ?? '•'}
+                </span>
+                {/* Dirty indicator: bullet that only appears when the buffer
+                    differs from disk. Common editor idiom — saves a word of
+                    UI real estate vs "Unsaved". */}
+                {isDirty && (
+                  <span className="text-amber-400" title="Unsaved changes">
+                    ●
+                  </span>
+                )}
+                <span className="text-neutral-200 truncate">{selectedFile.path}</span>
+                {selectedFile.oldPath && (
+                  <span className="text-neutral-500 text-[10px]">← {selectedFile.oldPath}</span>
+                )}
+                {/* Save state chip. Renders inline so it's visible without
+                    stealing focus or requiring a toast system. */}
+                <SaveStateBadge state={saveState} error={saveError} />
+                <div className="flex-1" />
+                <button
+                  type="button"
+                  onClick={() => handleJumpHunk('prev')}
+                  className="p-1 rounded hover:bg-neutral-800 text-neutral-400 hover:text-neutral-200"
+                  title="Previous hunk (⌘[ or p)"
+                >
+                  <CaretUp className="h-3.5 w-3.5" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleJumpHunk('next')}
+                  className="p-1 rounded hover:bg-neutral-800 text-neutral-400 hover:text-neutral-200"
+                  title="Next hunk (⌘] or n)"
+                >
+                  <CaretDown className="h-3.5 w-3.5" />
+                </button>
+                {canEdit && (
+                  <button
+                    type="button"
+                    onClick={() => void saveFile(false)}
+                    disabled={!isDirty || saveState === 'saving'}
+                    className="flex items-center gap-1 ml-1 px-2 py-0.5 rounded bg-neutral-800 hover:bg-neutral-700 text-neutral-200 text-[10px] font-medium disabled:opacity-40 disabled:cursor-not-allowed"
+                    title={isDirty ? 'Save (⌘S)' : 'No changes to save'}
+                  >
+                    <FloppyDisk className="h-3 w-3" />
+                    Save
+                  </button>
+                )}
+              </div>
+              {/* External-change banner: shown when the watcher detects an
+                  on-disk mutation while the user has unsaved edits. The user
+                  picks: reload (lose their edits) or keep (overwrite agent's
+                  edits on next save). Clean-buffer case reloads silently. */}
+              {externalChange && (
+                <div className="flex items-center gap-3 px-3 py-2 border-b border-amber-500/30 bg-amber-500/10 text-xs text-amber-200">
+                  <Warning weight="fill" className="h-3.5 w-3.5 shrink-0" />
+                  <span className="flex-1">
+                    This file changed on disk. Your unsaved edits are still in the editor.
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setExternalChange(null)
+                      if (selectedPath) void loadDiff(selectedPath)
+                    }}
+                    className="px-2 py-0.5 rounded bg-amber-500/20 hover:bg-amber-500/30 text-amber-100 text-[11px] font-medium"
+                  >
+                    Reload, discard mine
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setExternalChange(null)}
+                    className="px-2 py-0.5 rounded bg-neutral-700 hover:bg-neutral-600 text-neutral-100 text-[11px] font-medium"
+                    title="Keep your edits. Next save will overwrite the external version."
+                  >
+                    Keep mine
+                  </button>
+                </div>
+              )}
+              <div className="flex-1 min-h-0">
+                {loadingDiff ? (
+                  <div className="flex items-center justify-center h-full text-neutral-500 text-sm gap-2">
+                    <CircleNotch className="h-4 w-4 animate-spin" />
+                    Loading diff…
+                  </div>
+                ) : diffError ? (
+                  <div className="p-4 text-sm text-rose-400">{diffError}</div>
+                ) : diffSides ? (
+                  <DiffEditor
+                    original={diffSides.before}
+                    modified={diffSides.after}
+                    language={language}
+                    theme="vs-dark"
+                    onMount={handleDiffMount}
+                    options={{
+                      // Modified (right) side is editable when the file is
+                      // editable on disk; original (left, HEAD) is always
+                      // read-only. Editing historical content doesn't fit
+                      // the review workflow.
+                      readOnly: !canEdit,
+                      originalEditable: false,
+                      renderSideBySide: true,
+                      minimap: { enabled: false },
+                      automaticLayout: true,
+                      fontSize: 12,
+                      lineNumbers: 'on',
+                      scrollBeyondLastLine: false,
+                      renderWhitespace: 'none',
+                      wordWrap: 'off'
+                    }}
+                  />
+                ) : null}
+              </div>
+            </>
+          ) : (
+            <div className="flex items-center justify-center h-full text-neutral-500 text-sm">
+              {files.length === 0 ? 'Nothing to review.' : 'Select a file to see the diff.'}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {popover && (
+        <HighlightAskPopover
+          anchor={popover.anchor}
+          selection={popover.selection}
+          onSend={handlePopoverSend}
+          onClose={() => setPopover(null)}
+        />
+      )}
+
+      {conflictModal && selectedPath && (
+        <ConflictModal
+          filePath={selectedPath}
+          currentMtimeMs={conflictModal.currentMtimeMs}
+          onOverwrite={() => {
+            setConflictModal(null)
+            void saveFile(true)
+          }}
+          onDiscardMine={() => {
+            setConflictModal(null)
+            if (selectedPath) void loadDiff(selectedPath)
+          }}
+          onCancel={() => {
+            setConflictModal(null)
+            // Reset save state so the next keystroke re-arms autosave.
+            setSaveState('idle')
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+/** Small inline indicator for save state. Lives in the file header so it's
+ *  always visible during the autosave cycle. */
+function SaveStateBadge({ state, error }: { state: 'idle' | 'saving' | 'saved' | 'conflict' | 'error'; error: string | null }) {
+  if (state === 'idle') return null
+  if (state === 'saving') {
+    return (
+      <span className="flex items-center gap-1 text-[10px] text-neutral-400">
+        <CircleNotch className="h-3 w-3 animate-spin" />
+        Saving…
+      </span>
+    )
+  }
+  if (state === 'saved') {
+    return (
+      <span className="flex items-center gap-1 text-[10px] text-emerald-400">
+        <CheckCircle weight="fill" className="h-3 w-3" />
+        Saved
+      </span>
+    )
+  }
+  if (state === 'conflict') {
+    return (
+      <span className="flex items-center gap-1 text-[10px] text-amber-400">
+        <Warning weight="fill" className="h-3 w-3" />
+        Conflict
+      </span>
+    )
+  }
+  return (
+    <span className="flex items-center gap-1 text-[10px] text-rose-400" title={error ?? undefined}>
+      <Warning weight="fill" className="h-3 w-3" />
+      Save failed
+    </span>
+  )
+}
+
+/** Modal shown when a save is rejected because the file on disk changed
+ *  since it was read. The user picks between overwriting (clobber disk),
+ *  discarding their edits (reload from disk), or cancelling (leave the
+ *  buffer dirty so they can keep editing and decide later). */
+function ConflictModal({
+  filePath,
+  currentMtimeMs,
+  onOverwrite,
+  onDiscardMine,
+  onCancel
+}: {
+  filePath: string
+  currentMtimeMs: number | null
+  onOverwrite: () => void
+  onDiscardMine: () => void
+  onCancel: () => void
+}) {
+  const diskAge = currentMtimeMs ? Math.max(0, Date.now() - currentMtimeMs) : null
+  const ageLabel = diskAge === null ? 'unknown time' : diskAge < 1000 ? 'just now' : diskAge < 60_000 ? `${Math.floor(diskAge / 1000)}s ago` : `${Math.floor(diskAge / 60_000)}m ago`
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60" onClick={onCancel}>
+      <div
+        className="w-[480px] rounded-lg border border-neutral-700 bg-neutral-900 shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-neutral-800">
+          <Warning weight="fill" className="h-4 w-4 text-amber-400" />
+          <span className="text-sm font-medium">Save conflict</span>
+        </div>
+        <div className="px-4 py-3 space-y-2 text-sm text-neutral-200">
+          <p>
+            <code className="font-mono text-xs bg-neutral-950 px-1 py-0.5 rounded">{filePath}</code> was
+            modified on disk {ageLabel} while you were editing.
+          </p>
+          <p className="text-neutral-400 text-xs">
+            Your edits are still in the buffer. Pick how to reconcile:
+          </p>
+        </div>
+        <div className="flex justify-end gap-2 px-4 py-3 border-t border-neutral-800">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-3 py-1.5 rounded text-xs text-neutral-300 hover:bg-neutral-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onDiscardMine}
+            className="px-3 py-1.5 rounded bg-neutral-800 hover:bg-neutral-700 text-neutral-100 text-xs font-medium"
+            title="Reload from disk, losing your edits"
+          >
+            Discard mine
+          </button>
+          <button
+            type="button"
+            onClick={onOverwrite}
+            className="px-3 py-1.5 rounded bg-amber-500/80 hover:bg-amber-500 text-neutral-900 text-xs font-medium"
+            title="Write your version, overwriting the external changes"
+          >
+            Overwrite disk
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/demoApi.ts
+++ b/src/renderer/src/demoApi.ts
@@ -335,6 +335,13 @@ export function createDemoApi(): OrchestratorApi {
     removeWorktree: noop,
     listWorktrees: () => ok([]),
     getWorktreeStatus: () => ok({ dirty: false, changedFiles: 0 }),
+    getGitStatus: () => ok([]),
+    getGitDiff: () => ok({ before: '', after: '' }),
+    readFile: () => ok({ content: '', mtimeMs: 0, size: 0, encoding: 'utf-8' as const, truncated: false }),
+    writeFile: () => ok({ mtimeMs: 0, size: 0 }),
+    watchFile: () => Promise.resolve({ ok: true } as const),
+    unwatchFile: () => Promise.resolve({ ok: true } as const),
+    onFileChanged: () => () => {},
 
     // ── Database: Projects ──
     listProjects: () => ok([]),

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -591,15 +591,35 @@ function resolveSessionIdForEvent(
   return agent?.sessionId
 }
 
-function trackFileChange(sessionId: string, filePath: string, action: FileChangeRecord['action']): void {
+function trackFileChange(sessionId: string, filePath: string, action: FileChangeRecord['action'], timestamp: number = Date.now()): void {
   const changes = state.fileChanges.get(sessionId) ?? []
   changes.push({
     path: filePath,
     action,
-    timestamp: Date.now()
+    timestamp
   })
   state.fileChanges.set(sessionId, changes)
   fileChangesVersion++
+}
+
+// Tracks agents we've already seeded with git-status-derived file changes, so
+// re-opening the Files Changed tab doesn't clobber real session events that
+// may have arrived since hydration. Cleared when the agent is removed.
+const fileChangesHydrated = new Set<string>()
+
+/** Map a git porcelain status into the three-way action that FileChangeRecord
+ *  uses. Git has richer states (renamed, copied, typechange, unmerged) but the
+ *  UI only distinguishes created/modified/deleted. */
+function gitStatusToFileChangeAction(status: string): FileChangeRecord['action'] {
+  switch (status) {
+    case 'added':
+    case 'untracked':
+      return 'created'
+    case 'deleted':
+      return 'deleted'
+    default:
+      return 'modified'
+  }
 }
 
 function getMessageCreatedAt(info: Record<string, unknown> | HistoricalMessageInfo): number {
@@ -3083,6 +3103,7 @@ export function useAgentStore() {
     if (!window.api) return
 
     removeAgentState(agentId)
+    fileChangesHydrated.delete(agentId)
     emit({ agents: true, messages: true, permissions: true, questions: true })
 
     // Background cleanup (runtime stop, worktree removal) in main process
@@ -3109,6 +3130,53 @@ export function useAgentStore() {
   const getFileChangesForSession = useCallback((sessionId: string): FileChangeRecord[] => {
     return storeState.fileChanges.get(sessionId) ?? []
   }, [fileChangesVersion])
+
+  /**
+   * Seed the Files Changed list for an agent from `git status` in its
+   * worktree. This handles the case where the user opens the drawer on a
+   * restored/dev-reloaded agent that never emitted file-change SSE events
+   * this session — without hydration, the tab would be empty even when
+   * the worktree has real uncommitted changes.
+   *
+   * Hydrated entries use `timestamp: 0` so any future real SSE event wins
+   * on the component's dedup-by-latest-timestamp. We hydrate at most once
+   * per agentId per app lifetime (cleared on agent removal) to avoid
+   * clobbering accumulated session provenance.
+   */
+  const hydrateFileChangesFromGit = useCallback(async (agentId: string): Promise<void> => {
+    if (fileChangesHydrated.has(agentId)) return
+    const agent = state.agents.get(agentId)
+    if (!agent) return
+    fileChangesHydrated.add(agentId)
+
+    try {
+      const result = await window.api.getGitStatus(agentId)
+      if (!result.ok || !result.data) return
+
+      // Stamp hydrated entries with a single "now" so they sort together in
+      // one block, clearly separate from later per-event timestamps. A real
+      // SSE event landing on the same file later will have a larger Date.now()
+      // and win the component's dedup-by-latest-timestamp pass.
+      const hydratedAt = Date.now()
+      for (const file of result.data) {
+        const action = gitStatusToFileChangeAction(file.status)
+        trackFileChange(agent.sessionId, file.path, action, hydratedAt)
+      }
+
+      if (result.data.length > 0) {
+        // fileChangesVersion already bumped by trackFileChange; piggyback
+        // on the agents flag to force a re-render so useCallback deps
+        // in consumers pick up the new file list.
+        emit({ agents: true })
+      }
+    } catch (error) {
+      // Non-fatal: user can still see files as soon as the agent emits events,
+      // or can open the Workspace view (⌘E) for the git-backed diff.
+      console.warn('[useAgentStore] Failed to hydrate file changes from git:', error)
+      // Leave the "hydrated" flag set so we don't retry in a tight loop if
+      // the call fails repeatedly (e.g. non-git worktree).
+    }
+  }, [])
 
   const getEventsForSession = useCallback((sessionId: string): EventLogEntry[] => {
     return storeState.eventLog.get(sessionId) ?? []
@@ -3270,7 +3338,8 @@ export function useAgentStore() {
     getMessagesForSession,
     getFileChangesForSession,
     getEventsForSession,
-    getToolCallsForSession
+    getToolCallsForSession,
+    hydrateFileChangesFromGit
   }), [
     agents, permissions, questions, storeState.healthy, storeState.initializing,
     launchAgent, sendMessage, listCommands, listAgentConfigs,
@@ -3280,6 +3349,7 @@ export function useAgentStore() {
     toggleLabel, clearLabels, setPrUrl,
     dismissAgentError, compactSession, selectDirectory,
     getMessagesForSession, getFileChangesForSession,
-    getEventsForSession, getToolCallsForSession
+    getEventsForSession, getToolCallsForSession,
+    hydrateFileChangesFromGit
   ])
 }

--- a/src/renderer/src/lib/language.ts
+++ b/src/renderer/src/lib/language.ts
@@ -1,0 +1,58 @@
+/**
+ * Map a filename to a Monaco language ID. Monaco will fall back to plain
+ * text for unknown extensions, which is fine for lockfiles and configs.
+ */
+const EXTENSION_MAP: Record<string, string> = {
+  ts: 'typescript',
+  tsx: 'typescript',
+  js: 'javascript',
+  jsx: 'javascript',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  json: 'json',
+  md: 'markdown',
+  mdx: 'markdown',
+  py: 'python',
+  go: 'go',
+  rs: 'rust',
+  java: 'java',
+  kt: 'kotlin',
+  rb: 'ruby',
+  php: 'php',
+  c: 'c',
+  h: 'c',
+  cpp: 'cpp',
+  cc: 'cpp',
+  hpp: 'cpp',
+  cs: 'csharp',
+  swift: 'swift',
+  scala: 'scala',
+  sh: 'shell',
+  bash: 'shell',
+  zsh: 'shell',
+  yaml: 'yaml',
+  yml: 'yaml',
+  toml: 'toml',
+  xml: 'xml',
+  html: 'html',
+  htm: 'html',
+  css: 'css',
+  scss: 'scss',
+  less: 'less',
+  sql: 'sql',
+  graphql: 'graphql',
+  gql: 'graphql',
+  dockerfile: 'dockerfile',
+  proto: 'protobuf',
+  tf: 'hcl',
+  hcl: 'hcl'
+}
+
+export function languageForPath(filePath: string): string {
+  const base = filePath.split('/').pop() ?? filePath
+  if (base.toLowerCase() === 'dockerfile') return 'dockerfile'
+  const dot = base.lastIndexOf('.')
+  if (dot === -1) return 'plaintext'
+  const ext = base.slice(dot + 1).toLowerCase()
+  return EXTENSION_MAP[ext] ?? 'plaintext'
+}

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -63,6 +63,13 @@ export interface OrchestratorApi {
   removeWorktree: (options: { repoRoot: string; worktreePath: string }) => Promise<IpcResult>
   listWorktrees: (repoRoot: string) => Promise<IpcResult<WorktreeListEntry[]>>
   getWorktreeStatus: (worktreePath: string) => Promise<IpcResult<WorktreeStatus>>
+  getGitStatus: (agentId: string) => Promise<IpcResult<GitStatusFile[]>>
+  getGitDiff: (agentId: string, relativePath: string) => Promise<IpcResult<{ before: string; after: string }>>
+  readFile: (agentId: string, relativePath: string) => Promise<IpcResult<FileReadPayload>>
+  writeFile: (agentId: string, relativePath: string, content: string, expectedMtimeMs: number | null) => Promise<IpcResult<FileWritePayload>>
+  watchFile: (agentId: string, subscriptionId: string, relativePath: string) => Promise<IpcResult>
+  unwatchFile: (subscriptionId: string) => Promise<IpcResult>
+  onFileChanged: (callback: (data: FileChangedPayload) => void) => () => void
 
   // ── Database: Projects ──
   listProjects: () => Promise<IpcResult<Project[]>>
@@ -135,6 +142,39 @@ export interface ProjectSessionEntry {
 export interface WorktreeStatus {
   dirty: boolean
   changedFiles: number
+}
+
+export interface GitStatusFile {
+  path: string
+  oldPath?: string
+  status: 'added' | 'modified' | 'deleted' | 'renamed' | 'copied' | 'untracked' | 'unmerged' | 'typechange'
+  staged: boolean
+  unstaged: boolean
+}
+
+export interface FileReadPayload {
+  content: string
+  mtimeMs: number
+  size: number
+  encoding: 'utf-8' | 'binary'
+  truncated: boolean
+}
+
+export interface FileWritePayload {
+  mtimeMs: number
+  size: number
+  /** Present on CONFLICT errors — the mtime observed on disk at the time the
+   *  write was rejected. Lets the UI show a precise "agent edited N seconds
+   *  ago" message in the conflict modal. */
+  currentMtimeMs?: number | null
+}
+
+export interface FileChangedPayload {
+  subscriptionId: string
+  event: 'changed' | 'renamed' | 'deleted' | 'error'
+  absPath?: string
+  mtimeMs?: number
+  error?: string
 }
 
 export interface Project {


### PR DESCRIPTION
## Summary

Full-window workspace surface for reviewing and lightly editing an agent's uncommitted work without leaving the app.

- Git-status-backed file list + Monaco diff viewer (HEAD vs working tree)
- Modified side editable with 1s autosave + `⌘S`; HEAD side stays read-only
- Select text in the diff or in the Messages tab → popover that quotes `path:line` + fenced code and sends through the normal chat pipeline
- Narrow `fs.watch` on the open file: silent reload when buffer clean, `[Reload, discard mine] [Keep mine]` banner when dirty
- Save-mtime mismatch raises a conflict modal with overwrite / discard / cancel

Also fixes two pre-existing UX issues:
- Files Changed tab hydrates from `git status` on drawer open so restored / dev-reloaded agents aren't blank
- Files Changed tab badge dedupes by path (was counting every event)

## How to try it

1. Select an agent → `⌘E` (or **Open In → Review changes**)
2. Click a changed file in the left pane → diff loads with syntax highlighting
3. Edit on the right side → autosave after 1s, or `⌘S`
4. `⌘]` / `⌘[` for next/prev hunk; `⌘↑` / `⌘↓` for next/prev file; `Esc` to exit
5. Select any text → "Ask about selection" popover

## Scope notes

- Monaco (`@monaco-editor/react` + `monaco-editor`) and no other runtime deps added. No chokidar — `fs.watch` on a single file is enough here.
- Path-traversal guard: renderer passes `{agentId, relativePath}`; main realpath-resolves the worktree root and asserts containment. Rejects symlink escapes.
- Atomic writes via temp-file + rename so a crash mid-save leaves the original intact.
- Not in this PR: multi-buffer dirty tracking, three-way merge UI, stage/revert hunks, pause-agent-before-edit. Per discussion, autosave fires even while the agent is running; the conflict UI handles the race.

## Checks

- `npm run typecheck` ✅
- `npm test` ✅ (212 passed)
- `npm run build` ✅
- Lint: 0 errors