### PR TITLE
Remove highlight-to-ask popover from message transcript

### DIFF
--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -41,7 +41,7 @@ import { Markdown } from './Markdown'
 import { FilesChanged } from './FilesChanged'
 import { ToolsUsage } from './ToolsUsage'
 import { EventLog } from './EventLog'
-import { HighlightAskPopover, type HighlightSelection } from './HighlightAskPopover'
+
 import type { FileChange } from './FilesChanged'
 import type { ToolCall } from './ToolsUsage'
 import type { EventEntry } from './EventLog'
@@ -222,9 +222,6 @@ export const DetailDrawer = memo(function DetailDrawer({
   const [cursorPos, setCursorPos] = useState(0)
   const [visibleMessageCount, setVisibleMessageCount] = useState(VISIBLE_MESSAGE_WINDOW)
   const [showPrLinkModal, setShowPrLinkModal] = useState(false)
-  // Highlight-to-ask popover state. Anchored near the selection end; nulled
-  // out on send/close/selection-cleared.
-  const [highlightPopover, setHighlightPopover] = useState<{ anchor: { x: number; y: number }; selection: HighlightSelection } | null>(null)
 
   // Input history cycling: -1 = not browsing, 0+ = offset from most recent
   const historyIndexRef = useRef(-1)
@@ -399,80 +396,6 @@ export const DetailDrawer = memo(function DetailDrawer({
   useEffect(() => {
     textareaRef.current?.focus()
   }, [agent.id])
-
-  // ── Highlight-to-ask in the transcript ────────────────────────────────
-  // Track text selections made inside the transcript content region. When a
-  // non-empty selection settles (mouseup / keyup), anchor the popover near
-  // its end and let the user compose a question quoting the selected text.
-  //
-  // Why this shape and not `selectionchange`: fires too aggressively during
-  // a drag, and we only want the popover once the user is done highlighting.
-  // We still reset on selection clear so switching focus to the composer
-  // doesn't leave a stale popover floating.
-  useEffect(() => {
-    if (activeTab !== 'transcript') {
-      setHighlightPopover(null)
-      return
-    }
-    const content = transcriptContentRef.current
-    if (!content) return
-
-    const captureSelection = () => {
-      const selection = window.getSelection()
-      if (!selection || selection.isCollapsed || selection.rangeCount === 0) return
-
-      const range = selection.getRangeAt(0)
-      if (!content.contains(range.commonAncestorContainer)) return
-
-      const text = selection.toString().trim()
-      if (!text) return
-
-      const rect = range.getBoundingClientRect()
-      if (rect.width === 0 && rect.height === 0) return
-
-      setHighlightPopover({
-        anchor: { x: rect.left, y: rect.bottom + 6 },
-        selection: {
-          text,
-          source: 'message transcript'
-        }
-      })
-    }
-
-    const onMouseUp = () => {
-      // Defer by a frame so the browser finalizes the selection first.
-      requestAnimationFrame(captureSelection)
-    }
-    const onKeyUp = (event: KeyboardEvent) => {
-      if (event.shiftKey || event.key.startsWith('Arrow')) {
-        requestAnimationFrame(captureSelection)
-      }
-    }
-
-    content.addEventListener('mouseup', onMouseUp)
-    content.addEventListener('keyup', onKeyUp)
-    return () => {
-      content.removeEventListener('mouseup', onMouseUp)
-      content.removeEventListener('keyup', onKeyUp)
-    }
-  }, [activeTab])
-
-  const handleHighlightSend = useCallback((message: string) => {
-    if (onSendMessage) {
-      onSendMessage(message)
-    }
-    setHighlightPopover(null)
-    // Clear the selection so the popover doesn't immediately re-trigger.
-    window.getSelection()?.removeAllRanges()
-    // Re-engage follow-to-bottom so the user watches the agent's reply land
-    // even if they'd scrolled up to inspect the quoted passage.
-    followBottomRef.current = true
-    setShowJumpToLatest(false)
-    requestAnimationFrame(() => {
-      const container = transcriptScrollRef.current
-      if (container) container.scrollTop = container.scrollHeight
-    })
-  }, [onSendMessage])
 
   const scrollToBottom = (el: HTMLDivElement) => { el.scrollTop = el.scrollHeight }
 
@@ -1291,14 +1214,7 @@ export const DetailDrawer = memo(function DetailDrawer({
           onClose={() => setShowPrLinkModal(false)}
         />
       )}
-      {highlightPopover && onSendMessage && (
-        <HighlightAskPopover
-          anchor={highlightPopover.anchor}
-          selection={highlightPopover.selection}
-          onSend={handleHighlightSend}
-          onClose={() => setHighlightPopover(null)}
-        />
-      )}
+
     </div>
   )
 })


### PR DESCRIPTION
## Summary

The popover that appeared on selecting text in the Messages tab made plain copy painful: selecting text to copy would pop the dialog and steal focus, so ⌘C didn't land cleanly.

Removes the transcript-side wiring entirely. The Workspace view's editor still has highlight-to-ask, which is where the citation shape (`path:line` + fenced code) actually pays off.

## Checks

- `npm run typecheck` ✅
- `npm test` ✅ (212 passed)
- Lint: 0 errors

Follow-up to #163.