### PR TITLE
Scope drawer composer to Transcript tab and tighten workspace UX

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1073,15 +1073,15 @@ Then give me a brief summary of what the previous session was working on and whe
   /** Send a message to the agent whose Workspace view is currently open. Used
    *  by the highlight-to-ask popover so quoted citations flow through the
    *  normal send pipeline (history, /commands, @mentions). After sending we
-   *  pop back to the transcript and scroll to the bottom so the user can
-   *  watch the reply stream in, which is the whole point of asking. */
+   *  pop back to the transcript and snap to the very bottom — 'bottom' (vs
+   *  'last-user-message') matters because the citation has a long quoted
+   *  block, and landing at the *top* of that message would push the agent's
+   *  incoming reply offscreen. Re-engaging follow-mode also keeps the
+   *  streaming reply auto-scrolled into view. */
   const handleWorkspaceSendMessage = useCallback(async (text: string) => {
     if (!workspaceAgentId) return
     await storeSendMessage(workspaceAgentId, text)
-    // Open the drawer for this agent and jump the transcript to the latest
-    // user message (our citation). setSelectedAgentId with a scroll target
-    // signals the drawer to switch to the transcript tab and scroll.
-    setSelectedAgentId(workspaceAgentId, 'last-user-message')
+    setSelectedAgentId(workspaceAgentId, 'bottom')
   }, [workspaceAgentId, storeSendMessage, setSelectedAgentId])
 
   const workspaceAgent = useMemo(() => {

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -130,7 +130,7 @@ interface DetailDrawerProps {
    * each request so repeated clicks retrigger the scroll even when the target
    * is unchanged.
    */
-  scrollRequest?: { target: 'last-user-message'; seq: number } | null
+  scrollRequest?: { target: 'last-user-message' | 'bottom'; seq: number } | null
   onClose: () => void
   onSendMessage?: (text: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>) => void
   onApprove?: () => void
@@ -476,12 +476,29 @@ export const DetailDrawer = memo(function DetailDrawer({
   }, [activeTab])
 
   // Scroll-to-target: react to scrollRequest.seq changes. Triggered when the
-  // user clicks the "Last Message" cell in the fleet table.
+  // user clicks the "Last Message" cell in the fleet table or sends from the
+  // workspace popover.
   const lastHandledScrollSeqRef = useRef<number>(-1)
   useEffect(() => {
     if (!scrollRequest) return
     if (scrollRequest.seq === lastHandledScrollSeqRef.current) return
     lastHandledScrollSeqRef.current = scrollRequest.seq
+
+    if (activeTab !== 'transcript') setActiveTab('transcript')
+
+    if (scrollRequest.target === 'bottom') {
+      // Snap to the very bottom and re-engage follow-mode so the streaming
+      // reply auto-scrolls into view as it arrives. This is what we want
+      // after sending from the workspace popover — the user just sent a
+      // message and wants to watch the agent answer.
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        followBottomRef.current = true
+        setShowJumpToLatest(false)
+        const container = transcriptScrollRef.current
+        if (container) container.scrollTop = container.scrollHeight
+      }))
+      return
+    }
 
     if (scrollRequest.target !== 'last-user-message') return
 
@@ -494,8 +511,6 @@ export const DetailDrawer = memo(function DetailDrawer({
     }
     if (targetIndex < 0) return
     const targetId = messages[targetIndex].id
-
-    if (activeTab !== 'transcript') setActiveTab('transcript')
 
     // Expand the visible window if the target is outside it so the node renders.
     const neededCount = messages.length - targetIndex
@@ -902,6 +917,12 @@ export const DetailDrawer = memo(function DetailDrawer({
         </div>
 
         {/* Vertical resize handle */}
+        {/* Resize handle + bottom pane (chat input + action rail) only show
+            on the Transcript tab. The other tabs (Files Changed, Tools,
+            Events) are pure read-only views — keeping the composer there
+            offered nothing and stole space from the content above. */}
+        {activeTab === 'transcript' && (
+        <>
         <div
           onMouseDown={handleVerticalResizeStart}
           className="h-1.5 shrink-0 cursor-row-resize group flex items-center justify-center border-t border-kumo-line"
@@ -1198,6 +1219,8 @@ export const DetailDrawer = memo(function DetailDrawer({
           </div>
         </div>
         </div>{/* end bottom pane */}
+        </>
+        )}
       </div>
 
       {showPrLinkModal && onSetPrUrl && (

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -61,7 +61,15 @@ const quickActionIconMap: Record<QuickActionIcon, typeof Lightning> = {
   'wrench': Wrench,
 }
 
-export type DrawerScrollTarget = 'last-user-message'
+/**
+ * Where to land in the transcript when opening the drawer.
+ *  - 'last-user-message': scroll the last user message to the top of the
+ *    viewport. Used when jumping back from a notification or quick-action.
+ *  - 'bottom': scroll all the way to the bottom and re-engage follow-mode
+ *    so the next streaming reply auto-scrolls into view. Used after sending
+ *    from the workspace's highlight-to-ask popover.
+ */
+export type DrawerScrollTarget = 'last-user-message' | 'bottom'
 
 interface FleetTableProps {
   agents: AgentRuntime[]

--- a/src/renderer/src/components/WorkspaceView.tsx
+++ b/src/renderer/src/components/WorkspaceView.tsx
@@ -839,6 +839,12 @@ export function WorkspaceView({
                       readOnly: !canEdit,
                       originalEditable: false,
                       renderSideBySide: true,
+                      // Hide Monaco's inline per-hunk revert arrows. They
+                      // silently overwrite edits on a single click with no
+                      // confirmation, which is hostile here. Users still
+                      // have ⌘Z for fine-grained undo and the "Reload,
+                      // discard mine" banner for whole-file revert.
+                      renderMarginRevertIcon: false,
                       minimap: { enabled: false },
                       automaticLayout: true,
                       fontSize: 12,


### PR DESCRIPTION
## Summary

Three follow-ups to the workspace view from #163.

### Hide composer on non-Transcript tabs
The chat input + action rail rendered on Files Changed / Tools / Events even though they're read-only views. It offered nothing and stole vertical space from the content above. Now the composer + resize handle only show when `activeTab === 'transcript'`.

### Snap to bottom after popover send
Sending from the workspace's highlight-to-ask popover routed through the existing `'last-user-message'` scroll target, which lands at the *top* of the citation. Since the citation has a long quoted code block, the agent's incoming reply was pushed offscreen. Added a `'bottom'` variant that scrolls to `scrollHeight` and re-engages follow-mode so the streaming reply auto-scrolls into view.

### Disable Monaco inline revert arrows
Monaco renders small chevron arrows in the diff gutter that revert a hunk on a single click — no tooltip, no confirmation. Easy to misclick and silently destroy edits. Set `renderMarginRevertIcon: false`.

Users still have:
- `⌘Z` for fine-grained undo (works mid-edit)
- The "Reload, discard mine" banner for whole-file revert

The simpler alternative (DOM-intercept the click + show a confirmation modal) was on the table but adds fragile coupling to Monaco's internal class names. Disabling is honest and ships.

## Checks

- `npm run typecheck` ✅
- `npm test` ✅ (212 passed)
- Lint: 0 errors

Follow-up to #163, #164.