### PR TITLE
Smarten the ask-about-selection popover and add stay-on-send toggle

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1072,16 +1072,20 @@ Then give me a brief summary of what the previous session was working on and whe
 
   /** Send a message to the agent whose Workspace view is currently open. Used
    *  by the highlight-to-ask popover so quoted citations flow through the
-   *  normal send pipeline (history, /commands, @mentions). After sending we
-   *  pop back to the transcript and snap to the very bottom — 'bottom' (vs
-   *  'last-user-message') matters because the citation has a long quoted
-   *  block, and landing at the *top* of that message would push the agent's
-   *  incoming reply offscreen. Re-engaging follow-mode also keeps the
-   *  streaming reply auto-scrolled into view. */
-  const handleWorkspaceSendMessage = useCallback(async (text: string) => {
+   *  normal send pipeline (history, /commands, @mentions).
+   *
+   *  When `returnToTranscript` is true we pop the drawer to the transcript
+   *  scrolled all the way to the bottom — 'bottom' (vs 'last-user-message')
+   *  matters because the citation has a long quoted block and landing at
+   *  the *top* of that message would push the agent's incoming reply
+   *  offscreen. When false, the workspace stays open and the user can keep
+   *  reviewing while the reply streams in the (hidden) drawer behind. */
+  const handleWorkspaceSendMessage = useCallback(async (text: string, options: { returnToTranscript: boolean }) => {
     if (!workspaceAgentId) return
     await storeSendMessage(workspaceAgentId, text)
-    setSelectedAgentId(workspaceAgentId, 'bottom')
+    if (options.returnToTranscript) {
+      setSelectedAgentId(workspaceAgentId, 'bottom')
+    }
   }, [workspaceAgentId, storeSendMessage, setSelectedAgentId])
 
   const workspaceAgent = useMemo(() => {

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -1155,12 +1155,19 @@ export const DetailDrawer = memo(function DetailDrawer({
                   }
                 ]}
               />
+              {onOpenWorkspace && (
+                <ActionButton
+                  icon={<Code size={12} />}
+                  label="Review"
+                  onClick={() => onOpenWorkspace()}
+                  className="w-full"
+                />
+              )}
               <ActionDropdownButton
                 icon={<ArrowSquareOut size={12} />}
                 label="Open In"
                 className="w-full"
                 items={[
-                  ...(onOpenWorkspace ? [{ icon: <Code size={12} />, label: 'Review changes (⌘E)', onClick: () => onOpenWorkspace() }] : []),
                   { icon: <Terminal size={12} />, label: 'Terminal', onClick: onOpenTerminal },
                   { icon: <ArrowSquareOut size={12} />, label: 'Editor', onClick: onOpenInEditor }
                 ]}

--- a/src/renderer/src/components/HighlightAskPopover.tsx
+++ b/src/renderer/src/components/HighlightAskPopover.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState, useCallback } from 'react'
-import { ChatCircleDots, PaperPlaneTilt, X } from '@phosphor-icons/react'
+import { useEffect, useLayoutEffect, useRef, useState, useCallback } from 'react'
+import { ChatCircleDots, DotsSixVertical, PaperPlaneTilt, X } from '@phosphor-icons/react'
 
 /** The selection being quoted into the agent message. */
 export interface HighlightSelection {
@@ -12,9 +12,21 @@ export interface HighlightSelection {
   language?: string
 }
 
+/** Viewport rectangle of the user's text selection. The popover uses this to
+ *  pick a side (above/below) with more room rather than always anchoring
+ *  beneath the selection end. */
+export interface SelectionRect {
+  top: number
+  bottom: number
+  left: number
+  right: number
+}
+
 interface HighlightAskPopoverProps {
-  /** Absolute viewport position where the popover anchors (typically near the selection end). */
-  anchor: { x: number; y: number }
+  /** The selection's bounding rect in viewport coordinates. The popover
+   *  picks above-vs-below based on which side has more room and clamps
+   *  horizontally to fit. */
+  selectionRect: SelectionRect
   /** What the user highlighted — shown in a preview strip at the top of the popover. */
   selection: HighlightSelection
   /** Called when the user sends. Receives the full composed message (citation + question). */
@@ -27,31 +39,41 @@ const MAX_PREVIEW_CHARS = 160
 /** Popover width in px. Mirrors the `w-[400px]` class below; kept in sync
  *  manually so the off-screen clamp math can reason about dimensions. */
 const POPOVER_WIDTH = 400
-/** Conservative height estimate used only for clamping — real height varies
+/** Conservative height estimate used only for placement \u2014 real height varies
  *  with preview size. Slightly oversized so the popover never touches the
- *  window edge. */
-const POPOVER_MAX_HEIGHT = 220
+ *  window edge when there's room to fit. */
+const POPOVER_MAX_HEIGHT = 320
 /** Minimum distance from viewport edges so the popover doesn't butt against
  *  the screen corner. */
-const VIEWPORT_MARGIN = 8
+const VIEWPORT_MARGIN = 12
+/** Vertical gap between the selection and the popover so they don't touch. */
+const ANCHOR_GAP = 8
 
 /**
- * Floating composer that shows a preview of a code/text selection and lets the
- * user ask a quick question about it. Composes the final message as a
- * markdown-quoted citation followed by the user's question, so the agent sees
- * the snippet with full context when replying.
+ * Floating composer that shows a preview of a code/text selection and lets
+ * the user ask a quick question about it. Composes the final message as a
+ * markdown-quoted citation followed by the user's question, so the agent
+ * sees the snippet with full context when replying.
  *
- * Used from two entry points:
- *   - Monaco editor/diff selection in the Workspace view
- *   - Text selection inside the DetailDrawer Messages tab
+ * Placement: prefers below the selection, but if there's not enough room
+ * below it flips above. The user can drag the popover anywhere by the
+ * header — useful when the auto-placement still lands somewhere awkward
+ * (e.g. selection spans most of the viewport).
  */
-export function HighlightAskPopover({ anchor, selection, onSend, onClose }: HighlightAskPopoverProps) {
+export function HighlightAskPopover({ selectionRect, selection, onSend, onClose }: HighlightAskPopoverProps) {
   const [question, setQuestion] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  // Autofocus the textarea on open. Using requestAnimationFrame avoids
-  // losing focus to the selection-change event that triggered the popover.
+  // Position is null until first layout. We compute the smart default in
+  // useLayoutEffect so we have the actual popover height available; before
+  // then we render off-screen to avoid a flicker at (0, 0).
+  const [position, setPosition] = useState<{ x: number; y: number } | null>(null)
+  // Once the user drags, stop re-applying the smart default on resize.
+  const [userPositioned, setUserPositioned] = useState(false)
+
+  // Autofocus the textarea on open. requestAnimationFrame avoids losing
+  // focus to the selection-change event that triggered the popover.
   useEffect(() => {
     const frame = requestAnimationFrame(() => textareaRef.current?.focus())
     return () => cancelAnimationFrame(frame)
@@ -79,6 +101,14 @@ export function HighlightAskPopover({ anchor, selection, onSend, onClose }: High
     }
   }, [onClose])
 
+  // Smart default placement. Runs once after first paint so we know the
+  // popover's actual height (we use the rendered DOM rect, not the constant
+  // estimate). Picks above-vs-below by which side has more room.
+  useLayoutEffect(() => {
+    if (userPositioned) return
+    setPosition(computeSmartPosition(selectionRect, containerRef.current?.offsetHeight ?? POPOVER_MAX_HEIGHT))
+  }, [selectionRect, userPositioned])
+
   const handleSend = useCallback(() => {
     const trimmed = question.trim()
     if (!trimmed) return
@@ -94,31 +124,65 @@ export function HighlightAskPopover({ anchor, selection, onSend, onClose }: High
     }
   }
 
-  // Clamp so the popover never slides off-screen. The caller picks the
-  // anchor near the selection end, and we just ensure it fits.
-  const clampedX = Math.max(
-    VIEWPORT_MARGIN,
-    Math.min(anchor.x, window.innerWidth - POPOVER_WIDTH - VIEWPORT_MARGIN)
-  )
-  const clampedY = Math.max(
-    VIEWPORT_MARGIN,
-    Math.min(anchor.y, window.innerHeight - POPOVER_MAX_HEIGHT - VIEWPORT_MARGIN)
-  )
+  // ── Drag handling ────────────────────────────────────────────────────────
+  // Header acts as a drag handle. We track an offset from the pointer to the
+  // popover origin at mousedown, then update absolute position on each
+  // mousemove. Pointer capture isn't strictly necessary — listening on
+  // window during the drag handles fast moves where the cursor leaves the
+  // header.
+  const dragStateRef = useRef<{ offsetX: number; offsetY: number } | null>(null)
+
+  const handleDragStart = (event: React.PointerEvent) => {
+    if (!position || !containerRef.current) return
+    // Don't initiate a drag from the close button (it has its own click).
+    if ((event.target as HTMLElement).closest('button')) return
+    event.preventDefault()
+    dragStateRef.current = {
+      offsetX: event.clientX - position.x,
+      offsetY: event.clientY - position.y
+    }
+    setUserPositioned(true)
+
+    const handleMove = (moveEvent: PointerEvent) => {
+      const drag = dragStateRef.current
+      if (!drag) return
+      const x = clampX(moveEvent.clientX - drag.offsetX)
+      const y = clampY(moveEvent.clientY - drag.offsetY, containerRef.current?.offsetHeight ?? POPOVER_MAX_HEIGHT)
+      setPosition({ x, y })
+    }
+    const handleUp = () => {
+      dragStateRef.current = null
+      window.removeEventListener('pointermove', handleMove)
+      window.removeEventListener('pointerup', handleUp)
+    }
+    window.addEventListener('pointermove', handleMove)
+    window.addEventListener('pointerup', handleUp)
+  }
 
   const previewText = selection.text.length > MAX_PREVIEW_CHARS
     ? selection.text.slice(0, MAX_PREVIEW_CHARS) + '…'
     : selection.text
 
+  // Render off-screen on first paint so we can measure before the user sees
+  // it. Without this the popover briefly flashes at (0, 0).
+  const style = position
+    ? { left: position.x, top: position.y }
+    : { left: -9999, top: -9999, visibility: 'hidden' as const }
+
   return (
     <div
       ref={containerRef}
-      style={{ left: clampedX, top: clampedY }}
+      style={style}
       className="fixed z-[9999] w-[400px] rounded-lg border border-neutral-700 bg-neutral-900 shadow-2xl shadow-black/60"
       role="dialog"
       aria-label="Ask about highlighted text"
     >
-      <div className="flex items-center justify-between px-3 py-2 border-b border-neutral-800">
+      <div
+        onPointerDown={handleDragStart}
+        className="flex items-center justify-between px-3 py-2 border-b border-neutral-800 cursor-grab active:cursor-grabbing select-none"
+      >
         <div className="flex items-center gap-1.5 text-xs text-neutral-400">
+          <DotsSixVertical weight="bold" className="h-3.5 w-3.5 text-neutral-600" />
           <ChatCircleDots weight="duotone" className="h-3.5 w-3.5" />
           <span className="font-medium">Ask about selection</span>
         </div>
@@ -178,4 +242,40 @@ export function composeCitationMessage(selection: HighlightSelection, question: 
     '',
     question
   ].join('\n')
+}
+
+/** Pick a position that fits the popover relative to the selection, preferring
+ *  whichever side (above or below) has more room. Falls back to clamping if
+ *  neither side has enough room. */
+function computeSmartPosition(rect: SelectionRect, popoverHeight: number): { x: number; y: number } {
+  const viewportHeight = window.innerHeight
+  const roomAbove = rect.top - VIEWPORT_MARGIN
+  const roomBelow = viewportHeight - rect.bottom - VIEWPORT_MARGIN
+
+  let y: number
+  if (roomBelow >= popoverHeight + ANCHOR_GAP) {
+    // Default: below the selection.
+    y = rect.bottom + ANCHOR_GAP
+  } else if (roomAbove >= popoverHeight + ANCHOR_GAP) {
+    // Flip above when there's room there but not below.
+    y = rect.top - popoverHeight - ANCHOR_GAP
+  } else {
+    // Neither side fits cleanly; pick the side with more room and clamp.
+    y = roomBelow >= roomAbove
+      ? Math.max(VIEWPORT_MARGIN, viewportHeight - popoverHeight - VIEWPORT_MARGIN)
+      : VIEWPORT_MARGIN
+  }
+
+  return {
+    x: clampX(rect.left),
+    y: clampY(y, popoverHeight)
+  }
+}
+
+function clampX(x: number): number {
+  return Math.max(VIEWPORT_MARGIN, Math.min(x, window.innerWidth - POPOVER_WIDTH - VIEWPORT_MARGIN))
+}
+
+function clampY(y: number, popoverHeight: number): number {
+  return Math.max(VIEWPORT_MARGIN, Math.min(y, window.innerHeight - popoverHeight - VIEWPORT_MARGIN))
 }

--- a/src/renderer/src/components/WorkspaceView.tsx
+++ b/src/renderer/src/components/WorkspaceView.tsx
@@ -14,7 +14,7 @@ import {
   FolderSimple,
   Warning
 } from '@phosphor-icons/react'
-import { HighlightAskPopover, type HighlightSelection } from './HighlightAskPopover'
+import { HighlightAskPopover, type HighlightSelection, type SelectionRect } from './HighlightAskPopover'
 import { languageForPath } from '../lib/language'
 
 // Wire the Monaco loader to the bundled copy so it doesn't try to fetch from a
@@ -38,8 +38,11 @@ interface WorkspaceViewProps {
   onClose: () => void
   /** Hands a composed message (from the highlight-to-ask popover) back to the
    *  main send path, so it uses the same history/attachments/command pipeline
-   *  as the chat input. */
-  onSendMessage: (text: string) => void
+   *  as the chat input. The `returnToTranscript` flag tells the host whether
+   *  to pop the user back to the chat transcript (true) or leave them in the
+   *  workspace to keep reviewing (false). The host honours it via a
+   *  scrollRequest signal; the workspace itself only decides the policy. */
+  onSendMessage: (text: string, options: { returnToTranscript: boolean }) => void
 }
 
 interface GitStatusFile {
@@ -81,6 +84,11 @@ const STATUS_GLYPHS: Record<string, string> = {
  *  paste or rapid typing, short enough that you don't lose work if the app
  *  crashes. */
 const AUTOSAVE_DEBOUNCE_MS = 1000
+
+/** Preference key for the "return to transcript after send" toggle in the
+ *  workspace header. Stringly-typed because the preference store is
+ *  string-valued; we encode booleans as 'true'/'false'. */
+const WORKSPACE_RETURN_PREF_KEY = 'workspace.returnToTranscriptAfterSend'
 
 /** Stable subscription id for the file watcher — we reuse it on file switch
  *  so the main process just rebinds the single watch rather than accumulating
@@ -153,7 +161,15 @@ export function WorkspaceView({
   // Overwrite / Discard mine / Cancel without losing their edits.
   const [conflictModal, setConflictModal] = useState<{ currentMtimeMs: number | null } | null>(null)
 
-  const [popover, setPopover] = useState<{ anchor: { x: number; y: number }; selection: HighlightSelection } | null>(null)
+  const [popover, setPopover] = useState<{ selectionRect: SelectionRect; selection: HighlightSelection } | null>(null)
+
+  // After-send behaviour: when true, sending from the highlight-to-ask popover
+  // pops the user back to the chat transcript; when false, the workspace
+  // stays open so they can keep reviewing while the reply streams behind.
+  // Default false (stay in workspace) — better fits the "review code, ask
+  // multiple questions" workflow. Persisted via the preferences store so the
+  // user's choice survives reloads.
+  const [returnToTranscriptAfterSend, setReturnToTranscriptAfterSend] = useState(false)
 
   const diffEditorRef = useRef<editor.IStandaloneDiffEditor | null>(null)
   const autosaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -468,16 +484,24 @@ export function WorkspaceView({
     const endLine = selection.endLineNumber
     const lineRange = startLine === endLine ? `${startLine}` : `${startLine}-${endLine}`
 
-    // Anchor the popover just below the selection end, using Monaco's coords.
+    // Build a viewport-coordinate rect for the selection so the popover can
+    // pick a side (above vs below) with more room. Monaco's
+    // getTopForLineNumber returns content-area-relative pixels; combined
+    // with the editor DOM rect and scroll offset we get viewport coords.
     const domNode = activeEditor.getDomNode()
     if (!domNode) return
-    const rect = domNode.getBoundingClientRect()
-    const lineTop = activeEditor.getTopForLineNumber(endLine) - activeEditor.getScrollTop()
-    const x = rect.left + 80 // offset past line numbers so the popover isn't clipped
-    const y = rect.top + lineTop + 24
+    const editorRect = domNode.getBoundingClientRect()
+    const scrollTop = activeEditor.getScrollTop()
+    const lineHeight = activeEditor.getOption(monacoNs.editor.EditorOption.lineHeight)
+    const top = editorRect.top + activeEditor.getTopForLineNumber(startLine) - scrollTop
+    const bottom = editorRect.top + activeEditor.getTopForLineNumber(endLine) - scrollTop + lineHeight
+    // Offset left past the line-number gutter so the popover doesn't sit
+    // on top of the gutter when above-placement is chosen.
+    const left = editorRect.left + 80
+    const right = editorRect.right
 
     setPopover({
-      anchor: { x, y },
+      selectionRect: { top, bottom, left, right },
       selection: {
         text: trimmed,
         source: `${selectedPath}:${lineRange}`,
@@ -544,10 +568,39 @@ export function WorkspaceView({
   }, [captureSelection])
 
   const handlePopoverSend = useCallback((message: string) => {
-    onSendMessage(message)
+    onSendMessage(message, { returnToTranscript: returnToTranscriptAfterSend })
     setPopover(null)
-    onClose()
-  }, [onSendMessage, onClose])
+    if (returnToTranscriptAfterSend) {
+      onClose()
+    }
+  }, [onSendMessage, onClose, returnToTranscriptAfterSend])
+
+  // ── Load + persist 'return to transcript' preference ────────────────────
+  // Single string-valued preference for now; if other workspace prefs
+  // accumulate we can switch to a JSON-encoded settings blob.
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const result = await window.api.getPreference(WORKSPACE_RETURN_PREF_KEY)
+        if (cancelled) return
+        if (result.ok && typeof result.data === 'string') {
+          setReturnToTranscriptAfterSend(result.data === 'true')
+        }
+      } catch {
+        // Non-fatal: fall back to the default (false).
+      }
+    })()
+    return () => { cancelled = true }
+  }, [])
+
+  const toggleReturnToTranscript = useCallback(() => {
+    setReturnToTranscriptAfterSend((current) => {
+      const next = !current
+      void window.api.setPreference(WORKSPACE_RETURN_PREF_KEY, String(next))
+      return next
+    })
+  }, [])
 
   // ── Keyboard: Esc to close, cmd+up/down for file nav, hunk nav ───────────
   // Hunk navigation has two bindings because plain n/p would type those
@@ -636,6 +689,26 @@ export function WorkspaceView({
             Agent is working — review only
           </div>
         )}
+        {/* "After send" toggle: when on, sending a question pops the user
+            back to the chat transcript; when off (default), the workspace
+            stays open. Persisted via the preferences store. */}
+        <button
+          type="button"
+          onClick={toggleReturnToTranscript}
+          className={`no-drag flex items-center gap-1.5 text-xs px-2 py-1 rounded transition-colors ${
+            returnToTranscriptAfterSend
+              ? 'text-sky-300 bg-sky-500/15 hover:bg-sky-500/25'
+              : 'text-neutral-400 hover:text-neutral-200 hover:bg-neutral-800'
+          }`}
+          title={
+            returnToTranscriptAfterSend
+              ? 'After send: return to transcript. Click to stay in workspace instead.'
+              : 'After send: stay in workspace. Click to return to transcript instead.'
+          }
+        >
+          <span className={`h-1.5 w-1.5 rounded-full ${returnToTranscriptAfterSend ? 'bg-sky-400' : 'bg-neutral-600'}`} />
+          {returnToTranscriptAfterSend ? 'Return on send' : 'Stay on send'}
+        </button>
         <button
           type="button"
           onClick={() => void refreshStatus()}
@@ -867,7 +940,7 @@ export function WorkspaceView({
 
       {popover && (
         <HighlightAskPopover
-          anchor={popover.anchor}
+          selectionRect={popover.selectionRect}
           selection={popover.selection}
           onSend={handlePopoverSend}
           onClose={() => setPopover(null)}


### PR DESCRIPTION
## Summary

Three workspace-view fixes.

### Smarter popover placement + drag handle
Anchoring at the selection end routinely dropped the popover below the viewport when reviewing code near the bottom of the diff. Replaced the single-anchor API (`{x, y}`) with a `SelectionRect` (`top, bottom, left, right`); `computeSmartPosition` now picks above-vs-below based on which side has more room and only falls back to clamping when neither side fits.

The header is also a drag handle now (`DotsSixVertical` glyph, `cursor-grab`). Once the user drags, smart-placement stops re-applying. Useful when the auto-placement still lands somewhere awkward.

`useLayoutEffect` measures the rendered popover height before placing — no flash at (0, 0).

### "Stay on send" / "Return on send" toggle
The popover always popped the user back to the transcript on send. Wrong for the "review code, ask three questions in a row" workflow.

New toggle in the workspace header switches between:
- **Stay on send** (default): workspace stays open, reply streams into the hidden transcript
- **Return on send**: snap to transcript scrolled to bottom (the previous behavior)

Persisted via the existing preferences store under `workspace.returnToTranscriptAfterSend`. Loaded on mount, saved on toggle. The `onSendMessage` callback now takes `{ returnToTranscript: boolean }` so the host honours the policy without the workspace having to know about routing.

### Promote "Review" to its own button
`Open In → Review changes` was high-traffic but two clicks deep. Lifted it to a dedicated `ActionButton` in the right column (above `Open In`). `⌘E` shortcut still works.

## Checks

- `npm run typecheck` ✅
- `npm test` ✅ (212 passed)
- Lint: 0 errors

Follow-up to #163, #165.