### PR TITLE
Move 'return to transcript' toggle inside the ask-about-selection popover

### DIFF
--- a/src/renderer/src/components/HighlightAskPopover.tsx
+++ b/src/renderer/src/components/HighlightAskPopover.tsx
@@ -29,6 +29,13 @@ interface HighlightAskPopoverProps {
   selectionRect: SelectionRect
   /** What the user highlighted — shown in a preview strip at the top of the popover. */
   selection: HighlightSelection
+  /** Whether sending should return the user to the chat transcript. The
+   *  popover renders a small inline toggle so the user can change this
+   *  per-question without leaving the popover. */
+  returnToTranscript: boolean
+  /** Called when the toggle changes. The host owns persistence (e.g. saving
+   *  to the preferences store) — the popover only reflects + emits. */
+  onChangeReturnToTranscript: (next: boolean) => void
   /** Called when the user sends. Receives the full composed message (citation + question). */
   onSend: (message: string) => void
   /** Dismiss without sending. */
@@ -60,7 +67,14 @@ const ANCHOR_GAP = 8
  * header — useful when the auto-placement still lands somewhere awkward
  * (e.g. selection spans most of the viewport).
  */
-export function HighlightAskPopover({ selectionRect, selection, onSend, onClose }: HighlightAskPopoverProps) {
+export function HighlightAskPopover({
+  selectionRect,
+  selection,
+  returnToTranscript,
+  onChangeReturnToTranscript,
+  onSend,
+  onClose
+}: HighlightAskPopoverProps) {
   const [question, setQuestion] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -213,6 +227,19 @@ export function HighlightAskPopover({ selectionRect, selection, onSend, onClose 
           rows={3}
           className="w-full resize-none bg-neutral-950 border border-neutral-800 rounded px-2 py-1.5 text-sm text-neutral-100 placeholder:text-neutral-600 focus:outline-none focus:ring-1 focus:ring-sky-500/50 focus:border-sky-500/50"
         />
+        {/* "Return to transcript" toggle. Lives next to the Send button so
+            the user can flip it per-question without leaving the popover. */}
+        <label className="flex items-center gap-2 mt-2 cursor-pointer select-none group">
+          <input
+            type="checkbox"
+            checked={returnToTranscript}
+            onChange={(event) => onChangeReturnToTranscript(event.target.checked)}
+            className="h-3 w-3 rounded border-neutral-700 bg-neutral-950 text-sky-500 focus:ring-sky-500/50 focus:ring-offset-0"
+          />
+          <span className="text-[11px] text-neutral-400 group-hover:text-neutral-300">
+            Return to transcript after sending
+          </span>
+        </label>
         <div className="flex items-center justify-between mt-2">
           <span className="text-[10px] text-neutral-500">Enter to send · Shift+Enter for newline</span>
           <button

--- a/src/renderer/src/components/WorkspaceView.tsx
+++ b/src/renderer/src/components/WorkspaceView.tsx
@@ -594,12 +594,9 @@ export function WorkspaceView({
     return () => { cancelled = true }
   }, [])
 
-  const toggleReturnToTranscript = useCallback(() => {
-    setReturnToTranscriptAfterSend((current) => {
-      const next = !current
-      void window.api.setPreference(WORKSPACE_RETURN_PREF_KEY, String(next))
-      return next
-    })
+  const setReturnToTranscriptPersisted = useCallback((next: boolean) => {
+    setReturnToTranscriptAfterSend(next)
+    void window.api.setPreference(WORKSPACE_RETURN_PREF_KEY, String(next))
   }, [])
 
   // ── Keyboard: Esc to close, cmd+up/down for file nav, hunk nav ───────────
@@ -689,26 +686,6 @@ export function WorkspaceView({
             Agent is working — review only
           </div>
         )}
-        {/* "After send" toggle: when on, sending a question pops the user
-            back to the chat transcript; when off (default), the workspace
-            stays open. Persisted via the preferences store. */}
-        <button
-          type="button"
-          onClick={toggleReturnToTranscript}
-          className={`no-drag flex items-center gap-1.5 text-xs px-2 py-1 rounded transition-colors ${
-            returnToTranscriptAfterSend
-              ? 'text-sky-300 bg-sky-500/15 hover:bg-sky-500/25'
-              : 'text-neutral-400 hover:text-neutral-200 hover:bg-neutral-800'
-          }`}
-          title={
-            returnToTranscriptAfterSend
-              ? 'After send: return to transcript. Click to stay in workspace instead.'
-              : 'After send: stay in workspace. Click to return to transcript instead.'
-          }
-        >
-          <span className={`h-1.5 w-1.5 rounded-full ${returnToTranscriptAfterSend ? 'bg-sky-400' : 'bg-neutral-600'}`} />
-          {returnToTranscriptAfterSend ? 'Return on send' : 'Stay on send'}
-        </button>
         <button
           type="button"
           onClick={() => void refreshStatus()}
@@ -942,6 +919,8 @@ export function WorkspaceView({
         <HighlightAskPopover
           selectionRect={popover.selectionRect}
           selection={popover.selection}
+          returnToTranscript={returnToTranscriptAfterSend}
+          onChangeReturnToTranscript={setReturnToTranscriptPersisted}
           onSend={handlePopoverSend}
           onClose={() => setPopover(null)}
         />


### PR DESCRIPTION
## Summary

The toggle in the workspace header was the wrong place. "Return to transcript on send" is a per-question choice, not a workspace-wide mode — and it competed for header space with Refresh / agent-busy / Back.

Move the toggle into the popover itself, sitting right above Send. The user can flip it for the question they're about to send without leaving the dialog.

The popover stays a controlled component:
- `WorkspaceView` still owns the state and persists it via the preferences store under `workspace.returnToTranscriptAfterSend`
- New `returnToTranscript` + `onChangeReturnToTranscript` props on the popover — it reflects the current value and emits changes
- Send still uses the live state at click time, so toggling and immediately sending takes effect

Removed:
- The "Stay on send / Return on send" pill from the workspace header
- The `toggleReturnToTranscript` callback (replaced with `setReturnToTranscriptPersisted` that takes the new value directly)

## Checks

- `npm run typecheck` ✅
- `npm test` ✅ (212 passed)

Follow-up to #167.