### PR TITLE
Expose a localhost HTTP API for external session launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,98 @@ Electron + React + TypeScript. SQLite for local persistence. Communicates with O
 - **Main process** — runtime management, agent controller, event bridge, database
 - **Renderer** — React 19 with TailwindCSS 4, central state via `useSyncExternalStore`
 
+## External HTTP API
+
+OCO exposes a localhost HTTP API for external tools to launch and control agents. The intended use case is bridging external triggers (voice prompts, hotkeys, scripts) into OCO's fleet, with the option to attach the OpenCode TUI to the same session OCO created. Both clients then see the same SSE event stream.
+
+The server binds to `127.0.0.1` only and is gated by a per-launch random token (see Discovery below). Don't expose the port off the loopback interface — the auth model is "anyone with read access to your home directory can drive OCO," not "anyone on the machine."
+
+### Discovery
+
+On startup, OCO writes the listening port and a per-run auth token to a JSON file inside Electron's `userData` directory. The exact path depends on how OCO is running:
+
+- macOS: `~/Library/Application Support/oc-orchestrator/api.json`
+- Linux: `~/.config/oc-orchestrator/api.json`
+- Windows: `%APPDATA%\oc-orchestrator\api.json`
+
+```json
+{
+  "port": 54321,
+  "pid": 12345,
+  "startedAt": 1731112233000,
+  "version": "1.2.3",
+  "token": "a1b2c3..."
+}
+```
+
+Always check `pid` is alive before using `port` — the file isn't cleaned up on hard crash. The `token` is regenerated each launch and required for every mutating request via `Authorization: Bearer <token>`.
+
+### Endpoints
+
+Every request except `GET /health` requires `Authorization: Bearer <token>` where the token comes from the discovery file. The public contract is keyed on `sessionId`, not OCO's internal `agentId`, so the same identifier flows directly into `opencode attach --session <id>` without translation.
+
+| Method | Path | Body | Returns |
+|--------|------|------|---------|
+| `GET` | `/health` | — | `{ ok, version, pid }` |
+| `POST` | `/sessions` | `{ dir, prompt?, model?, title?, resume? }` | `{ agentId, sessionId, runtimeUrl, directory, leaseId, leaseExpiresAt }` |
+| `POST` | `/sessions/:sessionId/prompt` | `{ text, model? }` | `{ ok }` |
+| `POST` | `/sessions/:sessionId/abort` | — | `{ ok }` |
+| `POST` | `/leases/:leaseId/refresh` | — | `{ ok, expiresAt }` |
+| `DELETE` | `/leases/:leaseId` | — | `{ ok }` |
+
+`POST /sessions` requires `dir` to be a git repository — non-git paths are rejected with `400 not_a_git_repo`. The directory is normalized to its canonical repo root before any agent or project work happens, and that canonical root is what gets returned in the response (and is what you should pass to `opencode attach --dir`).
+
+`resume` is mutually exclusive with `prompt` and `model`; combining them returns `400 bad_request`. To resume and then send a message, call `POST /sessions { dir, resume }` followed by `POST /sessions/:sessionId/prompt { text }`.
+
+### Source attribution
+
+Send `X-OCO-Source: <label>` to identify the calling tool. The label appears in the desktop notification ("Voice prompt attached → my-project") and in the row flash on the FleetTable. Falls back to "External" if absent. The notification can be toggled in **Settings → Notify When → External Session Attached**.
+
+### Lease model
+
+`POST /sessions` returns a `leaseId` with a 30-minute TTL. While the lease is active, OCO's idle reaper won't reap the runtime even if there's no other activity. Refresh every ~5 minutes via `POST /leases/:leaseId/refresh`. Release with `DELETE /leases/:leaseId` when done. Expired leases are pruned lazily.
+
+Refreshing a lease whose underlying session has been removed from OCO returns `410 session_gone` and drops the lease — that prevents a forgotten refresher from pinning a runtime alive after its session has gone away.
+
+### Example: voice-prompt → OCO + TUI
+
+```bash
+#!/usr/bin/env bash
+DISCOVERY="$HOME/Library/Application Support/oc-orchestrator/api.json"
+
+PORT=$(jq -r .port "$DISCOVERY")
+TOKEN=$(jq -r .token "$DISCOVERY")
+PID=$(jq -r .pid "$DISCOVERY")
+kill -0 "$PID" 2>/dev/null || { echo "OCO is not running"; exit 1; }
+
+AUTH=(-H "Authorization: Bearer $TOKEN")
+
+# Create the session in OCO.  resume + prompt are mutually exclusive — to
+# pick up an existing session and then send a message, do two requests.
+RESP=$(curl -fs -X POST "http://127.0.0.1:$PORT/sessions" \
+  "${AUTH[@]}" \
+  -H "Content-Type: application/json" \
+  -H "X-OCO-Source: voice-prompt" \
+  -d "$(jq -n --arg dir "$WORKDIR" --arg prompt "$PROMPT" '{dir:$dir,prompt:$prompt}')")
+
+RUNTIME_URL=$(echo "$RESP" | jq -r .runtimeUrl)
+SESSION_ID=$(echo "$RESP" | jq -r .sessionId)
+LEASE_ID=$(echo "$RESP"   | jq -r .leaseId)
+
+# Refresh the lease in the background, release on exit.
+( while sleep 300; do
+    curl -fs -X POST "${AUTH[@]}" "http://127.0.0.1:$PORT/leases/$LEASE_ID/refresh" >/dev/null || break
+  done ) &
+REFRESHER=$!
+trap "kill $REFRESHER 2>/dev/null; \
+      curl -fs -X DELETE \"${AUTH[@]}\" \"http://127.0.0.1:$PORT/leases/$LEASE_ID\" >/dev/null" EXIT
+
+# Attach the OpenCode TUI to OCO's runtime, on the just-created session.
+# Both clients now share SSE events: typing in the TUI shows in OCO,
+# approving permissions in OCO unblocks prompts the TUI sent.
+exec opencode attach "$RUNTIME_URL" --session "$SESSION_ID" --dir "$WORKDIR"
+```
+
 ## License
 
 MIT

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,7 @@ import { agentController } from './services/agent-controller'
 import { database } from './services/database'
 import { runtimeManager } from './services/runtime-manager'
 import { startUpdateChecker, stopUpdateChecker } from './services/update-checker'
+import { startExternalApi, stopExternalApi } from './services/external-api'
 
 // Pin userData path before setName — otherwise it shifts to ~/Library/Application Support/Orchestrator/
 const userDataPath = app.getPath('userData')
@@ -172,6 +173,12 @@ app.whenReady().then(async () => {
   agentController.startIdleRuntimeChecks()
   startUpdateChecker()
 
+  // External HTTP API for tools like voice-prompt.  Starts after DB init so
+  // POST /sessions can persist projects, but doesn't block window creation.
+  startExternalApi().catch((error) => {
+    console.error('[Main] Failed to start external API:', error)
+  })
+
   // Restore agents after the renderer has loaded so the window appears
   // with the loading indicator before we start spawning runtimes.
   // If did-finish-load already fired while awaiting DB init, start immediately.
@@ -205,6 +212,7 @@ app.on('window-all-closed', () => {
 
 app.on('before-quit', () => {
   console.log('[Main] Shutting down all agents and runtimes...')
+  stopExternalApi()
   stopUpdateChecker()
   agentController.stopAll()
 

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -5,6 +5,7 @@ import { EventBridge } from './event-bridge'
 import { notificationService, type NotifiableEventType } from './notification-service'
 import { database } from './database'
 import { workspaceManager } from './workspace-manager'
+import { leaseRegistry } from './lease-registry'
 
 interface Attachment {
   id?: string
@@ -51,7 +52,7 @@ function buildMessageParts(text: string, attachments?: Attachment[]): Array<Text
 }
 
 // Bare model IDs (no slash) get an empty providerID so the server resolves the provider.
-function parseModelString(model: string): { providerID: string; modelID: string } {
+export function parseModelString(model: string): { providerID: string; modelID: string } {
   const slashIdx = model.indexOf('/')
   if (slashIdx > 0) {
     return { providerID: model.slice(0, slashIdx), modelID: model.slice(slashIdx + 1) }
@@ -1342,7 +1343,18 @@ class AgentController {
       const now = Date.now()
       const idleRuntimes = runtimeManager
         .getAllRuntimes()
-        .filter((runtime) => now - runtime.lastActivityAt >= idleTimeoutMs)
+        .filter((runtime) => {
+          if (now - runtime.lastActivityAt < idleTimeoutMs) return false
+          // Skip runtimes whose directory has an active lease — an external
+          // tool (e.g. an attached opencode TUI) is keeping them alive.
+          if (leaseRegistry.hasActiveLeaseForDirectory(runtime.directory)) {
+            console.log(
+              `[AgentController] Keeping runtime ${runtime.id} alive: active lease on ${runtime.directory}`
+            )
+            return false
+          }
+          return true
+        })
 
       await Promise.all(
         idleRuntimes.map(async (runtime) => {

--- a/src/main/services/external-api.ts
+++ b/src/main/services/external-api.ts
@@ -1,0 +1,333 @@
+import { app } from 'electron'
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import { writeFileSync, unlinkSync, existsSync, chmodSync } from 'node:fs'
+import { join } from 'node:path'
+import { randomBytes, timingSafeEqual } from 'node:crypto'
+import { agentController, parseModelString } from './agent-controller'
+import { runtimeManager } from './runtime-manager'
+import { workspaceManager } from './workspace-manager'
+import { database } from './database'
+import { leaseRegistry } from './lease-registry'
+import { notificationService } from './notification-service'
+import { getAppVersion } from '../version'
+
+/**
+ * Localhost HTTP API for external tools (e.g. voice-prompt) to launch and
+ * control OCO agents.  Bound to 127.0.0.1 only.
+ *
+ * Auth: every request needs `Authorization: Bearer <token>` where the token
+ * is regenerated on each app start and written to the discovery file
+ * (mode 0600 on POSIX so other users on the box can't read it).  This isn't
+ * defense against a privileged local attacker, but it stops every
+ * unprivileged process on the machine from hijacking OCO via a port scan.
+ *
+ * Identity: the public contract is keyed on `sessionId`, not OCO's internal
+ * `agentId`.  This lets the same identifier flow into `opencode attach
+ * --session <id>` without translation.
+ *
+ * Source attribution: clients send `X-OCO-Source` (e.g. "voice-prompt") and
+ * the desktop notification surfaces it as "Voice prompt attached → my-project".
+ * Falls back to "External" if absent.
+ */
+
+interface LaunchBody {
+  dir?: string
+  prompt?: string
+  model?: string
+  title?: string
+  resume?: string
+  [k: string]: unknown
+}
+
+interface PromptBody {
+  text?: string
+  model?: string
+  [k: string]: unknown
+}
+
+const DISCOVERY_FILENAME = 'api.json'
+
+let server: Server | null = null
+let actualPort = 0
+let authToken = ''
+
+export async function startExternalApi(): Promise<void> {
+  if (server) return
+
+  authToken = randomBytes(32).toString('hex')
+  server = createServer(handleRequest)
+
+  await new Promise<void>((resolve, reject) => {
+    server!.once('error', reject)
+    server!.listen(0, '127.0.0.1', () => {
+      const address = server!.address()
+      if (!address || typeof address === 'string') {
+        reject(new Error('Failed to bind external API'))
+        return
+      }
+      actualPort = address.port
+      writeDiscoveryFile()
+      console.log(`[ExternalAPI] Listening on http://127.0.0.1:${actualPort}`)
+      resolve()
+    })
+  })
+}
+
+export function stopExternalApi(): void {
+  if (!server) return
+  removeDiscoveryFile()
+  server.close()
+  server = null
+  actualPort = 0
+  authToken = ''
+}
+
+function discoveryFilePath(): string {
+  return join(app.getPath('userData'), DISCOVERY_FILENAME)
+}
+
+function writeDiscoveryFile(): void {
+  const path = discoveryFilePath()
+  const payload = {
+    port: actualPort,
+    pid: process.pid,
+    startedAt: Date.now(),
+    version: getAppVersion(),
+    token: authToken
+  }
+  try {
+    writeFileSync(path, JSON.stringify(payload, null, 2), 'utf-8')
+    // Restrict to owner-read/write only — the file contains an auth token.
+    // chmod is a no-op on Windows but harmless.
+    if (process.platform !== 'win32') {
+      try { chmodSync(path, 0o600) } catch { /* best-effort */ }
+    }
+  } catch (error) {
+    console.error('[ExternalAPI] Failed to write discovery file:', error)
+  }
+}
+
+function removeDiscoveryFile(): void {
+  const path = discoveryFilePath()
+  if (!existsSync(path)) return
+  try {
+    unlinkSync(path)
+  } catch (error) {
+    console.error('[ExternalAPI] Failed to remove discovery file:', error)
+  }
+}
+
+async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  try {
+    await routeRequest(req, res)
+  } catch (error) {
+    console.error('[ExternalAPI] Unhandled error:', error)
+    if (!res.headersSent) sendJson(res, 500, { error: 'internal_error', message: String(error) })
+  }
+}
+
+async function routeRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const url = req.url ?? '/'
+  const method = req.method ?? 'GET'
+
+  // /health is public so callers can probe liveness without holding the
+  // token (e.g. checking that OCO came back up after a restart).
+  if (method === 'GET' && url === '/health') {
+    return sendJson(res, 200, { ok: true, version: getAppVersion(), pid: process.pid })
+  }
+
+  // Every other endpoint is mutating or reveals session state — require
+  // the discovery-file token.
+  if (!isAuthorized(req)) return sendJson(res, 401, { error: 'unauthorized' })
+
+  if (method === 'POST' && url === '/sessions') {
+    const body = await readJsonBody<LaunchBody>(req)
+    return handleLaunch(req, res, body)
+  }
+
+  const sessionMatch = url.match(/^\/sessions\/([^/]+)\/(prompt|abort)$/)
+  if (method === 'POST' && sessionMatch) {
+    const [, sessionId, action] = sessionMatch
+    if (action === 'prompt') {
+      const body = await readJsonBody<PromptBody>(req)
+      return handleSessionPrompt(res, sessionId, body)
+    }
+    return handleSessionAbort(res, sessionId)
+  }
+
+  const leaseMatch = url.match(/^\/leases\/([^/]+)(?:\/(refresh))?$/)
+  if (leaseMatch) {
+    const [, leaseId, action] = leaseMatch
+    if (method === 'POST' && action === 'refresh') return handleLeaseRefresh(res, leaseId)
+    if (method === 'DELETE' && !action) return handleLeaseRelease(res, leaseId)
+  }
+
+  sendJson(res, 404, { error: 'not_found' })
+}
+
+function isAuthorized(req: IncomingMessage): boolean {
+  const header = req.headers.authorization
+  if (typeof header !== 'string') return false
+  const match = header.match(/^Bearer\s+(.+)$/i)
+  if (!match) return false
+  // Constant-time comparison so we don't leak the token byte-by-byte over
+  // request timing.  Length-equalize first since timingSafeEqual throws on
+  // mismatched lengths.
+  const provided = Buffer.from(match[1])
+  const expected = Buffer.from(authToken)
+  if (provided.length !== expected.length) return false
+  return timingSafeEqual(provided, expected)
+}
+
+async function handleLaunch(
+  req: IncomingMessage,
+  res: ServerResponse,
+  body: LaunchBody
+): Promise<void> {
+  const dir = (body.dir ?? '').trim()
+  if (!dir) return sendJson(res, 400, { error: 'bad_request', message: 'dir is required' })
+
+  // resume + prompt would be ambiguous: do we resume the conversation or
+  // send a fresh first message?  Reject explicitly so callers don't think
+  // both happened.  Send the prompt in a follow-up POST /sessions/:id/prompt.
+  if (body.resume && (body.prompt ?? '').trim()) {
+    return sendJson(res, 400, {
+      error: 'bad_request',
+      message: 'resume and prompt are mutually exclusive — POST /sessions/:sessionId/prompt after resuming'
+    })
+  }
+  if (body.resume && body.model) {
+    return sendJson(res, 400, {
+      error: 'bad_request',
+      message: 'resume and model are mutually exclusive — change models with POST /sessions/:sessionId/prompt'
+    })
+  }
+
+  if (!workspaceManager.isGitRepo(dir)) {
+    return sendJson(res, 400, {
+      error: 'not_a_git_repo',
+      message: `${dir} is not a git repository`
+    })
+  }
+
+  // Normalize to the canonical repo root for both project persistence AND
+  // the agent's directory.  Mirrors `LaunchModal.persistProjectSettings`
+  // and matches what the README documents.
+  const canonicalRoot = workspaceManager.getRepoRoot(dir)
+  const name = canonicalRoot.split('/').filter(Boolean).pop() ?? canonicalRoot
+  database.ensureProject(name, canonicalRoot)
+
+  const source = readSourceHeader(req)
+
+  const handle = body.resume
+    ? await agentController.resumeAgent({
+        directory: canonicalRoot,
+        sessionId: body.resume,
+        title: body.title
+      })
+    : await agentController.launchAgent({
+        directory: canonicalRoot,
+        prompt: body.prompt,
+        title: body.title,
+        model: body.model
+      })
+
+  const runtime = runtimeManager.getRuntime(handle.runtimeId)
+  if (!runtime) {
+    return sendJson(res, 500, { error: 'runtime_unavailable' })
+  }
+
+  const { id: agentId, sessionId, projectName } = handle
+  const lease = leaseRegistry.acquire(canonicalRoot, sessionId, source)
+  notificationService.notifyExternalAttached({ source, projectName, sessionId, agentId })
+
+  sendJson(res, 200, {
+    agentId,
+    sessionId,
+    runtimeUrl: runtime.serverUrl,
+    directory: canonicalRoot,
+    leaseId: lease.id,
+    leaseExpiresAt: lease.expiresAt
+  })
+}
+
+async function handleSessionPrompt(
+  res: ServerResponse,
+  sessionId: string,
+  body: PromptBody
+): Promise<void> {
+  const text = (body.text ?? '').trim()
+  if (!text) return sendJson(res, 400, { error: 'bad_request', message: 'text is required' })
+
+  const agent = findAgentBySession(sessionId)
+  if (!agent) return sendJson(res, 404, { error: 'session_not_found' })
+
+  if (body.model) {
+    const { providerID, modelID } = parseModelString(body.model)
+    await agentController.sendMessageWithModel(agent.id, text, providerID, modelID)
+  } else {
+    await agentController.sendMessage(agent.id, text)
+  }
+  sendJson(res, 200, { ok: true })
+}
+
+async function handleSessionAbort(res: ServerResponse, sessionId: string): Promise<void> {
+  const agent = findAgentBySession(sessionId)
+  if (!agent) return sendJson(res, 404, { error: 'session_not_found' })
+  await agentController.abortAgent(agent.id)
+  sendJson(res, 200, { ok: true })
+}
+
+function handleLeaseRefresh(res: ServerResponse, leaseId: string): void {
+  const lease = leaseRegistry.get(leaseId)
+  if (!lease) return sendJson(res, 404, { error: 'lease_not_found_or_expired' })
+
+  // Refuse to refresh leases whose underlying session no longer exists in
+  // OCO (e.g. the agent was removed from the fleet).  Otherwise a stale
+  // refresher could keep a future runtime for the same directory pinned
+  // forever.
+  if (!findAgentBySession(lease.sessionId)) {
+    leaseRegistry.release(leaseId)
+    return sendJson(res, 410, { error: 'session_gone' })
+  }
+
+  // We already validated the lease exists above, so refresh() can only fail
+  // on a microsecond-level race with concurrent expiry.  Treat that as a
+  // refresh-no-op rather than splitting the response with a second 404.
+  const refreshed = leaseRegistry.refresh(leaseId) ?? lease
+  sendJson(res, 200, { ok: true, expiresAt: refreshed.expiresAt })
+}
+
+function handleLeaseRelease(res: ServerResponse, leaseId: string): void {
+  const removed = leaseRegistry.release(leaseId)
+  sendJson(res, 200, { ok: removed })
+}
+
+function findAgentBySession(sessionId: string): { id: string } | undefined {
+  return agentController.getAllAgents().find((handle) => handle.sessionId === sessionId)
+}
+
+function readSourceHeader(req: IncomingMessage): string {
+  const raw = req.headers['x-oco-source']
+  if (typeof raw === 'string' && raw.trim()) return raw.trim().slice(0, 64)
+  return 'External'
+}
+
+async function readJsonBody<T>(req: IncomingMessage): Promise<T> {
+  const chunks: Buffer[] = []
+  let total = 0
+  const limit = 1 << 20 // 1 MB cap — these payloads are tiny
+  for await (const chunk of req) {
+    const buf = chunk as Buffer
+    total += buf.length
+    if (total > limit) throw new Error('Request body too large')
+    chunks.push(buf)
+  }
+  if (total === 0) return {} as T
+  return JSON.parse(Buffer.concat(chunks).toString('utf-8')) as T
+}
+
+function sendJson(res: ServerResponse, status: number, payload: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify(payload))
+}

--- a/src/main/services/lease-registry.ts
+++ b/src/main/services/lease-registry.ts
@@ -1,0 +1,87 @@
+import { randomUUID } from 'node:crypto'
+
+/**
+ * Lease registry for external attachments to OCO sessions.
+ *
+ * When an external client (e.g. a voice-prompt wrapper script attaching the
+ * opencode TUI) wants to keep an agent's runtime alive while it's connected,
+ * it acquires a lease via the HTTP API.  RuntimeManager.stopIdleRuntimes
+ * checks the registry before reaping a runtime — any runtime whose directory
+ * has an active lease is skipped.
+ *
+ * Leases have a TTL.  Clients refresh before expiry; expired leases are
+ * pruned lazily on the next lookup.  This avoids leaking a lease forever if
+ * the external client crashes without releasing.
+ */
+
+interface Lease {
+  id: string
+  directory: string
+  sessionId: string
+  source: string
+  expiresAt: number
+}
+
+const DEFAULT_TTL_MS = 30 * 60 * 1000
+
+class LeaseRegistry {
+  private leases = new Map<string, Lease>()
+  private ttlMs = DEFAULT_TTL_MS
+
+  acquire(directory: string, sessionId: string, source: string): Lease {
+    const lease: Lease = {
+      id: randomUUID(),
+      directory,
+      sessionId,
+      source,
+      expiresAt: Date.now() + this.ttlMs
+    }
+    this.leases.set(lease.id, lease)
+    return lease
+  }
+
+  refresh(leaseId: string): Lease | undefined {
+    const lease = this.get(leaseId)
+    if (!lease) return undefined
+    lease.expiresAt = Date.now() + this.ttlMs
+    return lease
+  }
+
+  release(leaseId: string): boolean {
+    return this.leases.delete(leaseId)
+  }
+
+  /**
+   * Returns true if the directory has at least one non-expired lease.
+   * Prunes expired leases as a side effect.
+   */
+  hasActiveLeaseForDirectory(directory: string): boolean {
+    const now = Date.now()
+    let found = false
+    for (const [id, lease] of this.leases) {
+      if (now >= lease.expiresAt) {
+        this.leases.delete(id)
+        continue
+      }
+      if (lease.directory === directory) found = true
+    }
+    return found
+  }
+
+  get(leaseId: string): Lease | undefined {
+    const lease = this.leases.get(leaseId)
+    if (!lease) return undefined
+    if (Date.now() >= lease.expiresAt) {
+      this.leases.delete(leaseId)
+      return undefined
+    }
+    return lease
+  }
+
+  /** Test/debug helper. */
+  size(): number {
+    return this.leases.size
+  }
+}
+
+export const leaseRegistry = new LeaseRegistry()

--- a/src/main/services/notification-service.ts
+++ b/src/main/services/notification-service.ts
@@ -6,6 +6,7 @@ export type NotifiableEventType =
   | 'errored'
   | 'completed'
   | 'disconnected'
+  | 'external_attached'
 
 export interface NotificationPreferences {
   needs_approval: boolean
@@ -13,6 +14,7 @@ export interface NotificationPreferences {
   errored: boolean
   completed: boolean
   disconnected: boolean
+  external_attached: boolean
 }
 
 interface SentNotificationKey {
@@ -27,7 +29,10 @@ const NOTIFICATION_TITLES: Record<NotifiableEventType, (agentName: string) => st
   needs_input: (agentName) => `Agent ${agentName} needs your input`,
   errored: (agentName) => `Agent ${agentName} encountered an error`,
   completed: (agentName) => `Agent ${agentName} completed its task`,
-  disconnected: (agentName) => `Runtime disconnected from agent ${agentName}`
+  disconnected: (agentName) => `Runtime disconnected from agent ${agentName}`,
+  // For external_attached the agentName slot carries the source label
+  // (e.g. "Voice prompt"), not a real agent name.
+  external_attached: (source) => `${source} attached`
 }
 
 const NOTIFICATION_BODIES: Record<NotifiableEventType, (projectName?: string) => string> = {
@@ -35,7 +40,8 @@ const NOTIFICATION_BODIES: Record<NotifiableEventType, (projectName?: string) =>
   needs_input: (projectName) => projectName ? `Project: ${projectName}` : 'Waiting for your input',
   errored: (projectName) => projectName ? `Project: ${projectName}` : 'Check the agent for details',
   completed: (projectName) => projectName ? `Project: ${projectName}` : 'Task finished successfully',
-  disconnected: (projectName) => projectName ? `Project: ${projectName}` : 'Connection lost'
+  disconnected: (projectName) => projectName ? `Project: ${projectName}` : 'Connection lost',
+  external_attached: (projectName) => projectName ? `New session in ${projectName}` : 'New external session'
 }
 
 class NotificationService {
@@ -44,7 +50,8 @@ class NotificationService {
     needs_input: true,
     errored: true,
     completed: false,
-    disconnected: true
+    disconnected: true,
+    external_attached: true
   }
 
   private soundEnabled = true
@@ -81,6 +88,68 @@ class NotificationService {
     }
   }
 
+  /**
+   * Surface an external attachment (e.g. voice-prompt creating a session via
+   * the HTTP API).
+   *
+   * The renderer broadcast is unconditional — it drives the FleetTable row
+   * flash and is independent of whether the user wants OS notifications.
+   * Only the OS Notification respects `preferences.external_attached`.
+   *
+   * Dedup short-circuits OS notifications fired within DEDUP_WINDOW_MS for
+   * the same (source, sessionId), so a client that retries POST /sessions
+   * after a transient error doesn't spam the user.
+   */
+  notifyExternalAttached(args: { source: string; projectName?: string; sessionId?: string; agentId?: string }): void {
+    // Renderer broadcast: always send so the FleetTable flashes regardless
+    // of OS notification preference.
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed() && !win.webContents.isDestroyed()) {
+        win.webContents.send('external:attached', {
+          source: args.source,
+          projectName: args.projectName,
+          sessionId: args.sessionId,
+          agentId: args.agentId
+        })
+      }
+    }
+
+    if (!this.preferences.external_attached) return
+    if (!Notification.isSupported()) return
+
+    // Dedup so a retried POST /sessions doesn't double-toast.  Keyed on
+    // (source, sessionId) — same source + same session = same intent.
+    // Falls back to source alone when no sessionId is provided.
+    const dedupKey = `external_attached:${args.source}:${args.sessionId ?? ''}`
+    if (this.isDuplicateKey(dedupKey)) return
+    this.recordKey(dedupKey)
+
+    const title = NOTIFICATION_TITLES.external_attached(args.source)
+    const body = NOTIFICATION_BODIES.external_attached(args.projectName)
+
+    const notification = new Notification({
+      title,
+      body,
+      silent: !this.soundEnabled
+    })
+
+    this.activeNotifications.add(notification)
+
+    if (args.agentId) {
+      const agentId = args.agentId
+      notification.on('click', () => {
+        this.handleNotificationClick(agentId)
+        this.activeNotifications.delete(notification)
+      })
+    }
+
+    notification.on('close', () => {
+      setTimeout(() => this.activeNotifications.delete(notification), 5 * 60 * 1000)
+    })
+
+    notification.show()
+  }
+
   checkAndNotify(
     agentId: string,
     status: NotifiableEventType,
@@ -101,21 +170,26 @@ class NotificationService {
   }
 
   private isDuplicate(agentId: string, eventType: NotifiableEventType): boolean {
-    const key = this.buildKey(agentId, eventType)
-    const lastSent = this.sentNotifications.get(key)
-
-    if (lastSent === undefined) {
-      return false
-    }
-
-    return Date.now() - lastSent < DEDUP_WINDOW_MS
+    return this.isDuplicateKey(this.buildKey(agentId, eventType))
   }
 
   private recordNotification(agentId: string, eventType: NotifiableEventType): void {
-    const key = this.buildKey(agentId, eventType)
-    this.sentNotifications.set(key, Date.now())
+    this.recordKey(this.buildKey(agentId, eventType))
+  }
 
-    // Clean up old entries periodically
+  /**
+   * Lower-level dedup helpers that take an arbitrary key.  Used by callers
+   * that don't fit the (agentId, NotifiableEventType) shape — e.g. external
+   * attachments keyed on (source, sessionId).
+   */
+  private isDuplicateKey(key: string): boolean {
+    const lastSent = this.sentNotifications.get(key)
+    if (lastSent === undefined) return false
+    return Date.now() - lastSent < DEDUP_WINDOW_MS
+  }
+
+  private recordKey(key: string): void {
+    this.sentNotifications.set(key, Date.now())
     if (this.sentNotifications.size > 100) {
       this.pruneOldEntries()
     }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -285,6 +285,12 @@ const api = {
     return () => ipcRenderer.removeListener('agent:launched', handler)
   },
 
+  onExternalAttached: (callback: (data: { source: string; projectName?: string; sessionId?: string; agentId?: string }) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: unknown) => callback(data as never)
+    ipcRenderer.on('external:attached', handler)
+    return () => ipcRenderer.removeListener('external:attached', handler)
+  },
+
   onRuntimeStarted: (callback: (data: { id: string; directory: string; serverUrl: string }) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, data: unknown) => callback(data as never)
     ipcRenderer.on('runtime:started', handler)

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -20,6 +20,7 @@ import {
 } from '@phosphor-icons/react'
 import type { AgentRuntime, LabelDefinition, LabelColorKey, ColumnKey, ColumnWidths, SortDirection } from '../types'
 import { formatBranchLabel, isUrgent, labelSortKey, compareStatusPriority, ALL_COLUMNS } from '../types'
+import { isRecentlyAttached } from '../hooks/useAgentStore'
 import { StatusBadge } from './StatusBadge'
 import { LabelDropdown } from './LabelDropdown'
 import { TextInputModal } from './TextInputModal'
@@ -766,6 +767,7 @@ function AgentRow({
 }) {
   const urgent = isUrgent(agent)
   const isStale = !!agent.blockedSince
+  const flashing = isRecentlyAttached(agent.id)
   const [inlineValue, setInlineValue] = useState(agent.name)
   const inlineInputRef = useRef<HTMLInputElement>(null)
   const inlineSubmittedRef = useRef(false)
@@ -814,7 +816,7 @@ function AgentRow({
           : urgent
             ? 'bg-kumo-danger/[0.04] hover:bg-kumo-danger/[0.08]'
             : 'hover:bg-kumo-control'
-      }`}
+      } ${flashing ? 'ring-2 ring-inset ring-kumo-brand/60 bg-kumo-brand/[0.06]' : ''}`}
     >
       {show('agent') && (
         <td className="px-3 py-2 overflow-hidden">

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -245,6 +245,7 @@ export function SettingsModal({ onClose, initialTab = 'general', commands = [] }
                       { key: 'needs_input', label: 'Needs Input' },
                       { key: 'errored', label: 'Errored' },
                       { key: 'completed', label: 'Completed' },
+                      { key: 'external_attached', label: 'External Session Attached' },
                     ] as const
                   ).map((pref) => (
                     <label key={pref.key} className="flex items-center gap-2.5 cursor-pointer group">

--- a/src/renderer/src/data/settings.ts
+++ b/src/renderer/src/data/settings.ts
@@ -3,6 +3,7 @@ export interface NotificationPrefs {
   needs_input: boolean
   errored: boolean
   completed: boolean
+  external_attached: boolean
 }
 
 export type QuickActionIcon =
@@ -75,6 +76,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
     needs_input: true,
     errored: true,
     completed: false,
+    external_attached: true,
   },
   verboseMode: false,
   soundEnabled: true,

--- a/src/renderer/src/demoApi.ts
+++ b/src/renderer/src/demoApi.ts
@@ -366,7 +366,8 @@ export function createDemoApi(): OrchestratorApi {
       needs_input: true,
       errored: true,
       completed: true,
-      disconnected: false
+      disconnected: false,
+      external_attached: true
     }),
     setNotificationPreference: noop,
     getSoundEnabled: () => ok(true),
@@ -387,6 +388,7 @@ export function createDemoApi(): OrchestratorApi {
     // ── Event Listeners ──
     onEvent: noopListener,
     onAgentLaunched: noopListener,
+    onExternalAttached: noopListener,
     onSessionReset: noopListener,
     onRuntimeStarted: noopListener,
     onRuntimeStopped: noopListener,

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -246,6 +246,16 @@ let eventLogVersion = 0
 // Cleared when a server-generated session title arrives (which is a better summary).
 const taskSummaryLocked = new Set<string>()
 
+// Agents that were just created via an external attachment (e.g. voice-prompt
+// hitting POST /sessions).  FleetTable reads this to apply a brief flash
+// animation on the row.  Entries clear after RECENTLY_ATTACHED_TTL_MS.
+const recentlyAttachedAgents = new Set<string>()
+const RECENTLY_ATTACHED_TTL_MS = 4_000
+
+export function isRecentlyAttached(agentId: string): boolean {
+  return recentlyAttachedAgents.has(agentId)
+}
+
 // Tracks agents that should have PR URL extraction enabled.  We only extract
 // PR URLs when the user explicitly triggered the "Create PR" flow so that
 // URLs the user pastes in their own messages don't get picked up.
@@ -2694,6 +2704,16 @@ export function useAgentStore() {
       window.api.onEvent(processEvent),
       window.api.onAgentLaunched(handleAgentLaunched),
       window.api.onSessionReset(handleSessionReset),
+      window.api.onExternalAttached((data) => {
+        const { agentId } = data
+        if (!agentId) return
+        recentlyAttachedAgents.add(agentId)
+        emit({ agents: true })
+        setTimeout(() => {
+          recentlyAttachedAgents.delete(agentId)
+          emit({ agents: true })
+        }, RECENTLY_ATTACHED_TTL_MS)
+      }),
       window.api.onEventError((data) => {
         console.error(`[EventError] Runtime ${data.runtimeId}: ${data.error}`)
         state.healthy = false

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -108,6 +108,7 @@ export interface OrchestratorApi {
 
   onEvent: (callback: (data: OpenCodeEventPayload) => void) => () => void
   onAgentLaunched: (callback: (data: AgentLaunchedPayload) => void) => () => void
+  onExternalAttached: (callback: (data: ExternalAttachedPayload) => void) => () => void
   onSessionReset: (callback: (data: SessionResetPayload) => void) => () => void
   onRuntimeStarted: (callback: (data: RuntimeStartedPayload) => void) => () => void
   onRuntimeStopped: (callback: (data: { id: string }) => void) => () => void
@@ -193,6 +194,7 @@ export type NotifiableEventType =
   | 'errored'
   | 'completed'
   | 'disconnected'
+  | 'external_attached'
 
 export interface NotificationPreferences {
   needs_approval: boolean
@@ -200,6 +202,7 @@ export interface NotificationPreferences {
   errored: boolean
   completed: boolean
   disconnected: boolean
+  external_attached: boolean
 }
 
 export interface OpenCodeEventPayload {
@@ -245,6 +248,13 @@ export interface SessionResetPayload {
   branchName: string
   prompt: string
   title: string
+}
+
+export interface ExternalAttachedPayload {
+  source: string
+  projectName?: string
+  sessionId?: string
+  agentId?: string
 }
 
 export type ListAgentsPayload = AgentLaunchedPayload[]


### PR DESCRIPTION
External tools that want to drive OCO have had no way in. Scripts like a voice-prompt hotkey can spawn the opencode TUI but the resulting session lives in a server OCO knows nothing about. The fleet table stays empty, notifications don't fire, the work happens in a vacuum.

This adds a localhost HTTP server bound to 127.0.0.1 that callers use to create or resume sessions in OCO. The response carries the runtime URL and session ID, so the caller can immediately run `opencode attach <runtime> --session <id>` and end up on the same opencode server OCO is talking to. SSE events fan out to both clients, so typing in the TUI shows in OCO and approving a permission in OCO unblocks the TUI's prompt. That last bit is the whole point: it gives you OCO's supervision UI for an interactive TUI session you started somewhere else.

The public contract uses sessionId, not OCO's internal agentId, because sessionId is what `opencode attach` wants. Auth is a per-launch random bearer token written to a 0600 discovery file under userData. Callers hold a refreshable lease so OCO's idle reaper doesn't kill the runtime under an attached TUI; leases drop on release, on expiry, or when the underlying session disappears. New sessions arriving through the API flash their fleet table row and (optionally, configurable in Settings) fire a desktop notification tagged with whatever the caller passed in `X-OCO-Source`, so voice prompts read as "Voice prompt" rather than a generic "External" label.

The README documents the endpoints and includes a working voice-prompt wrapper script that does the launch, the lease refresh loop, and the attach.

Verified end to end against a dev build: auth gating, all four 400 validation paths, real launches with a follow-up prompt the agent actually executed, lease refresh/release/410-on-session-gone, and a live `opencode attach` showing the shared conversation history.