### PR TITLE
Flip portaled menus on viewport overflow and route ad-hoc dropdowns through them

### DIFF
--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -1032,58 +1032,72 @@ export const DetailDrawer = memo(function DetailDrawer({
           <div className={`relative flex flex-col flex-1 min-h-0 rounded-lg border bg-kumo-control transition-colors ${
             isDragOver ? 'border-kumo-brand' : 'border-kumo-line focus-within:border-kumo-ring'
           }`}>
-            {/* Autocomplete popups */}
-            {showCommandAutocomplete && (
-              <div className="absolute bottom-full left-0 right-0 z-20 mb-2 rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl">
-                {matchingCommands.map((item, index) => (
-                  <button
-                    key={item.command}
-                    type="button"
-                    onMouseDown={(event) => {
-                      event.preventDefault()
-                      setInputText(`${item.command} `)
-                    }}
-                    className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
-                      index === commandPickerIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
-                    }`}
-                  >
-                    <span className="font-mono text-[11px] text-kumo-default">{item.command}</span>
-                    <span className="text-[11px] text-kumo-subtle">{item.description}</span>
-                  </button>
-                ))}
-                <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
-                  Tab/Enter to select · Arrow keys to navigate · Esc to dismiss
-                </div>
+            {/* Autocomplete popups — portal'd above the textarea so they
+                escape the input container's overflow/border, with viewport
+                flipping handled by PortaledMenu. */}
+            <PortaledMenu
+              open={showCommandAutocomplete}
+              triggerRef={textareaRef}
+              placement="top-left"
+              matchTriggerWidth
+              gap={8}
+              onDismiss={() => {}}
+              className="rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl"
+            >
+              {matchingCommands.map((item, index) => (
+                <button
+                  key={item.command}
+                  type="button"
+                  onMouseDown={(event) => {
+                    event.preventDefault()
+                    setInputText(`${item.command} `)
+                  }}
+                  className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
+                    index === commandPickerIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
+                  }`}
+                >
+                  <span className="font-mono text-[11px] text-kumo-default">{item.command}</span>
+                  <span className="text-[11px] text-kumo-subtle">{item.description}</span>
+                </button>
+              ))}
+              <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
+                Tab/Enter to select · Arrow keys to navigate · Esc to dismiss
               </div>
-            )}
-            {showAgentPicker && (
-              <div className="absolute bottom-full left-0 right-0 z-20 mb-2 rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl">
-                <div className="px-2.5 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wide">
-                  Agents
-                </div>
-                {matchingAgents.map((cfg, index) => (
-                  <button
-                    key={cfg.name}
-                    type="button"
-                    onMouseDown={(event) => {
-                      event.preventDefault()
-                      insertAgentMention(cfg.name)
-                    }}
-                    className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
-                      index === agentPickerIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
-                    }`}
-                  >
-                    <span className="font-mono text-[11px] text-kumo-brand">@{cfg.name}</span>
-                    {cfg.description && (
-                      <span className="text-[11px] text-kumo-subtle truncate">{cfg.description}</span>
-                    )}
-                  </button>
-                ))}
-                <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
-                  Tab/Enter to select · Arrow keys to navigate · Esc to dismiss
-                </div>
+            </PortaledMenu>
+            <PortaledMenu
+              open={showAgentPicker}
+              triggerRef={textareaRef}
+              placement="top-left"
+              matchTriggerWidth
+              gap={8}
+              onDismiss={() => setAgentPickerDismissed(true)}
+              className="rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl"
+            >
+              <div className="px-2.5 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wide">
+                Agents
               </div>
-            )}
+              {matchingAgents.map((cfg, index) => (
+                <button
+                  key={cfg.name}
+                  type="button"
+                  onMouseDown={(event) => {
+                    event.preventDefault()
+                    insertAgentMention(cfg.name)
+                  }}
+                  className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
+                    index === agentPickerIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
+                  }`}
+                >
+                  <span className="font-mono text-[11px] text-kumo-brand">@{cfg.name}</span>
+                  {cfg.description && (
+                    <span className="text-[11px] text-kumo-subtle truncate">{cfg.description}</span>
+                  )}
+                </button>
+              ))}
+              <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
+                Tab/Enter to select · Arrow keys to navigate · Esc to dismiss
+              </div>
+            </PortaledMenu>
 
             {/* Attachment thumbnails inside the container */}
             {attachments.length > 0 && (

--- a/src/renderer/src/components/EventLog.tsx
+++ b/src/renderer/src/components/EventLog.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useEffect, useRef, memo } from 'react'
 import { ListBullets, CaretDown, CaretRight, Funnel } from '@phosphor-icons/react'
+import { PortaledMenu } from './PortaledMenu'
 
 export interface EventEntry {
   id: string
@@ -48,6 +49,7 @@ export const EventLog = memo(function EventLog({ events, verbose = false }: Even
   )
   const [typeFilter, setTypeFilter] = useState<string>('all')
   const [showFilterMenu, setShowFilterMenu] = useState(false)
+  const filterButtonRef = useRef<HTMLButtonElement>(null)
   // Track items the user explicitly collapsed so we don't re-expand them
   const manuallyCollapsedRef = useRef<Set<string>>(new Set())
 
@@ -116,8 +118,9 @@ export const EventLog = memo(function EventLog({ events, verbose = false }: Even
 
         <div className="flex-1" />
 
-        <div className="relative">
+        <>
           <button
+            ref={filterButtonRef}
             onClick={() => setShowFilterMenu(!showFilterMenu)}
             className={`flex items-center gap-1 px-2 py-1 rounded-md text-[11px] border transition-colors cursor-pointer ${
               typeFilter !== 'all'
@@ -130,30 +133,34 @@ export const EventLog = memo(function EventLog({ events, verbose = false }: Even
             <CaretDown size={10} />
           </button>
 
-          {showFilterMenu && (
-            <div className="absolute right-0 top-full mt-1 bg-kumo-elevated border border-kumo-line rounded-md shadow-lg z-10 min-w-[140px] py-1">
+          <PortaledMenu
+            open={showFilterMenu}
+            triggerRef={filterButtonRef}
+            placement="bottom-right"
+            onDismiss={() => setShowFilterMenu(false)}
+            className="bg-kumo-elevated border border-kumo-line rounded-md shadow-lg min-w-[140px] py-1"
+          >
+            <button
+              onClick={() => { setTypeFilter('all'); setShowFilterMenu(false) }}
+              className={`w-full text-left px-3 py-1.5 text-[11px] transition-colors cursor-pointer ${
+                typeFilter === 'all' ? 'text-kumo-link bg-kumo-interact/8' : 'text-kumo-default hover:bg-kumo-fill'
+              }`}
+            >
+              All types
+            </button>
+            {eventTypes.map((eventType) => (
               <button
-                onClick={() => { setTypeFilter('all'); setShowFilterMenu(false) }}
+                key={eventType}
+                onClick={() => { setTypeFilter(eventType); setShowFilterMenu(false) }}
                 className={`w-full text-left px-3 py-1.5 text-[11px] transition-colors cursor-pointer ${
-                  typeFilter === 'all' ? 'text-kumo-link bg-kumo-interact/8' : 'text-kumo-default hover:bg-kumo-fill'
+                  typeFilter === eventType ? 'text-kumo-link bg-kumo-interact/8' : 'text-kumo-default hover:bg-kumo-fill'
                 }`}
               >
-                All types
+                {eventType}
               </button>
-              {eventTypes.map((eventType) => (
-                <button
-                  key={eventType}
-                  onClick={() => { setTypeFilter(eventType); setShowFilterMenu(false) }}
-                  className={`w-full text-left px-3 py-1.5 text-[11px] transition-colors cursor-pointer ${
-                    typeFilter === eventType ? 'text-kumo-link bg-kumo-interact/8' : 'text-kumo-default hover:bg-kumo-fill'
-                  }`}
-                >
-                  {eventType}
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
+            ))}
+          </PortaledMenu>
+        </>
       </div>
 
       {/* Event list */}

--- a/src/renderer/src/components/FilterBar.tsx
+++ b/src/renderer/src/components/FilterBar.tsx
@@ -1,7 +1,9 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef } from 'react'
 import { MagnifyingGlass, Columns, Check } from '@phosphor-icons/react'
 import type { AgentStatus, LabelDefinition, ColumnKey } from '../types'
 import { LABEL_COLORS, ALL_COLUMNS } from '../types'
+import { PortaledMenu } from './PortaledMenu'
+
 
 export type StatusFilter = 'blocked' | 'running' | 'idle' | 'errored' | 'completed'
 export type LabelFilter = string
@@ -281,29 +283,12 @@ function ColumnToggle({
   onToggle: (key: ColumnKey) => void
 }) {
   const [open, setOpen] = useState(false)
-  const containerRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!open) return
-    const handleClickOutside = (event: MouseEvent): void => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        setOpen(false)
-      }
-    }
-    const handleEscape = (event: KeyboardEvent): void => {
-      if (event.key === 'Escape') setOpen(false)
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    document.addEventListener('keydown', handleEscape)
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
-      document.removeEventListener('keydown', handleEscape)
-    }
-  }, [open])
+  const buttonRef = useRef<HTMLButtonElement>(null)
 
   return (
-    <div ref={containerRef} className="relative">
+    <>
       <button
+        ref={buttonRef}
         onClick={() => setOpen((prev) => !prev)}
         title="Toggle columns"
         className={`flex items-center gap-1 px-2 py-1 rounded text-[11px] border transition-colors cursor-pointer ${
@@ -316,26 +301,30 @@ function ColumnToggle({
         <span>Columns</span>
       </button>
 
-      {open && (
-        <div className="absolute right-0 top-full mt-1 z-[100] min-w-[160px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl">
-          {ALL_COLUMNS.map((col) => {
-            const isVisible = visibleColumns.has(col.key)
-            return (
-              <button
-                key={col.key}
-                onClick={() => onToggle(col.key)}
-                className="flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] text-kumo-default rounded hover:bg-kumo-fill transition-colors text-left cursor-pointer"
-              >
-                <span className={`w-3.5 h-3.5 flex items-center justify-center rounded border ${isVisible ? 'bg-kumo-interact/20 border-kumo-interact/40 text-kumo-link' : 'border-kumo-line text-transparent'}`}>
-                  {isVisible && <Check size={10} weight="bold" />}
-                </span>
-                {col.label}
-              </button>
-            )
-          })}
-        </div>
-      )}
-    </div>
+      <PortaledMenu
+        open={open}
+        triggerRef={buttonRef}
+        placement="bottom-right"
+        onDismiss={() => setOpen(false)}
+        className="min-w-[160px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl"
+      >
+        {ALL_COLUMNS.map((col) => {
+          const isVisible = visibleColumns.has(col.key)
+          return (
+            <button
+              key={col.key}
+              onClick={() => onToggle(col.key)}
+              className="flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] text-kumo-default rounded hover:bg-kumo-fill transition-colors text-left cursor-pointer"
+            >
+              <span className={`w-3.5 h-3.5 flex items-center justify-center rounded border ${isVisible ? 'bg-kumo-interact/20 border-kumo-interact/40 text-kumo-link' : 'border-kumo-line text-transparent'}`}>
+                {isVisible && <Check size={10} weight="bold" />}
+              </span>
+              {col.label}
+            </button>
+          )
+        })}
+      </PortaledMenu>
+    </>
   )
 }
 

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -23,6 +23,7 @@ import { formatBranchLabel, isUrgent, labelSortKey, compareStatusPriority, ALL_C
 import { isRecentlyAttached } from '../hooks/useAgentStore'
 import { StatusBadge } from './StatusBadge'
 import { LabelDropdown } from './LabelDropdown'
+import { PortaledMenu } from './PortaledMenu'
 import { TextInputModal } from './TextInputModal'
 import { Tooltip } from './Tooltip'
 import { PrTooltipContent } from './PrTooltip'
@@ -971,13 +972,14 @@ function AgentRow({
         <div className="w-full flex items-center justify-center py-2 text-kumo-subtle group-hover:text-kumo-default">
           <ArrowRight size={14} weight="bold" />
         </div>
-        {arrowMenu.open && (
-          <ArrowMenuPopover
-            onOpen={() => { arrowMenu.close(); onOpen?.() }}
-            onOpenTerminal={() => { arrowMenu.close(); onOpenTerminal?.() }}
-            onOpenInEditor={() => { arrowMenu.close(); onOpenInEditor?.() }}
-          />
-        )}
+        <ArrowMenuPopover
+          open={arrowMenu.open}
+          triggerRef={arrowMenu.containerRef}
+          onDismiss={arrowMenu.close}
+          onOpen={() => { arrowMenu.close(); onOpen?.() }}
+          onOpenTerminal={() => { arrowMenu.close(); onOpenTerminal?.() }}
+          onOpenInEditor={() => { arrowMenu.close(); onOpenInEditor?.() }}
+        />
       </td>
     </tr>
   )
@@ -1056,16 +1058,28 @@ function ScrollArrow({ direction, onClick }: { direction: 'left' | 'right'; onCl
 const arrowMenuItemClass = 'flex items-center gap-2 w-full px-2.5 py-1.5 text-[11px] text-kumo-default rounded hover:bg-kumo-fill transition-colors text-left'
 
 function ArrowMenuPopover({
+  open,
+  triggerRef,
+  onDismiss,
   onOpen,
   onOpenTerminal,
   onOpenInEditor
 }: {
+  open: boolean
+  triggerRef: React.RefObject<HTMLTableCellElement | null>
+  onDismiss: () => void
   onOpen: () => void
   onOpenTerminal: () => void
   onOpenInEditor: () => void
 }) {
   return (
-    <div className="absolute right-0 top-full mt-1 z-[100] min-w-[160px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl">
+    <PortaledMenu
+      open={open}
+      triggerRef={triggerRef}
+      placement="bottom-right"
+      onDismiss={onDismiss}
+      className="min-w-[160px] rounded-lg border border-kumo-line bg-kumo-elevated p-1 shadow-xl"
+    >
       <button
         className={arrowMenuItemClass}
         onClick={(event) => { event.stopPropagation(); onOpen() }}
@@ -1084,6 +1098,6 @@ function ArrowMenuPopover({
       >
         <ArrowSquareOut size={13} /> Editor
       </button>
-    </div>
+    </PortaledMenu>
   )
 }

--- a/src/renderer/src/components/LaunchModal.tsx
+++ b/src/renderer/src/components/LaunchModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { X, FolderOpen, CaretDown, Warning, Trash, Paperclip, ClockCounterClockwise, CircleNotch, ChatCircleDots, Play } from '@phosphor-icons/react'
 import { SelectField } from './SelectField'
 import { LabelDropdown } from './LabelDropdown'
+import { PortaledMenu } from './PortaledMenu'
 import { useModelOptions } from '../hooks/useModelOptions'
 import { useImageAttachments } from '../hooks/useImageAttachments'
 import { loadSettings } from '../data/settings'
@@ -128,7 +129,8 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
     removeAttachment, clearAttachments,
     handlePaste, handleDragOver, handleDragEnter, handleDragLeave, handleDrop, handleFileInputChange
   } = useImageAttachments()
-  const dropdownRef = useRef<HTMLDivElement>(null)
+  const dropdownButtonRef = useRef<HTMLButtonElement>(null)
+  const sessionDropdownButtonRef = useRef<HTMLButtonElement>(null)
   const promptRef = useRef<HTMLTextAreaElement>(null)
   const [cursorPos, setCursorPos] = useState(0)
   const [agentPickerDismissed, setAgentPickerDismissed] = useState(false)
@@ -144,7 +146,7 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
   const [importName, setImportName] = useState('')
   const [importPrompt, setImportPrompt] = useState('')
   const [showSessionDropdown, setShowSessionDropdown] = useState(false)
-  const sessionDropdownRef = useRef<HTMLDivElement>(null)
+
 
   const trimmedPrompt = prompt.trim().toLowerCase()
 
@@ -406,17 +408,7 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
     if (activeTab !== 'import') { setSelectedSession(null); setImportSearch(''); setImportName(''); setImportPrompt('') }
   }, [activeTab])
 
-  // Close session dropdown on outside click
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (sessionDropdownRef.current && !sessionDropdownRef.current.contains(event.target as Node)) {
-        setShowSessionDropdown(false)
-        setImportSearch('')
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [])
+  // Session dropdown outside-click handling is delegated to PortaledMenu.
 
   const filteredImportSessions = useMemo(() => {
     if (!importSearch.trim()) return importSessions
@@ -434,17 +426,7 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
     )
   }, [savedProjects, projectSearch])
 
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setShowDropdown(false)
-        setProjectSearch('')
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [])
+  // Project dropdown outside-click handling is delegated to PortaledMenu.
 
   const persistProjectSettings = async (dir: string) => {
     try {
@@ -522,7 +504,7 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
     'flex w-full items-center justify-between gap-3 rounded-md border border-kumo-line bg-kumo-control px-3 py-2 text-sm text-kumo-default outline-none transition-colors hover:bg-kumo-fill focus:border-kumo-ring'
 
   const selectMenuClasses =
-    'absolute left-0 right-0 top-full z-20 mt-1 overflow-hidden rounded-md border border-kumo-line bg-kumo-overlay shadow-xl'
+    'overflow-hidden rounded-md border border-kumo-line bg-kumo-overlay shadow-xl'
 
   const selectedProject = savedProjects.find((p) => p.repo_root === directory)
   const hasDirectory = directory.trim().length > 0
@@ -589,9 +571,10 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
             <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
               Project Directory
             </label>
-            <div className="relative flex gap-2" ref={dropdownRef}>
-              <div className="flex-1 min-w-0 relative">
+            <div className="flex gap-2">
+              <div className="flex-1 min-w-0">
                 <button
+                  ref={dropdownButtonRef}
                   type="button"
                   onClick={() => setShowDropdown(!showDropdown)}
                   className={`w-full flex items-center gap-2 px-3 py-2 bg-kumo-control border rounded-md text-sm outline-none transition-colors hover:bg-kumo-fill focus:border-kumo-ring ${
@@ -615,65 +598,66 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
                   <CaretDown size={14} className="text-kumo-subtle shrink-0" />
                 </button>
 
-                {showDropdown && (
-                  <div className="fixed mt-1 bg-kumo-control border border-kumo-fill-hover rounded-md shadow-2xl z-[210] max-h-[320px] flex flex-col overflow-hidden" style={{
-                    width: dropdownRef.current?.querySelector('button')?.getBoundingClientRect().width,
-                    left: dropdownRef.current?.querySelector('button')?.getBoundingClientRect().left,
-                    top: (dropdownRef.current?.querySelector('button')?.getBoundingClientRect().bottom ?? 0) + 4
-                  }}>
-                    {savedProjects.length > 0 && (
-                      <div className="px-2 pt-2 pb-1 shrink-0">
-                        <input
-                          type="text"
-                          value={projectSearch}
-                          onChange={(e) => setProjectSearch(e.target.value)}
-                          placeholder="Search projects..."
-                          className="w-full rounded border border-kumo-line bg-kumo-elevated px-2 py-1 text-xs text-kumo-default placeholder:text-kumo-subtle outline-none focus:border-kumo-ring"
-                          autoFocus
-                        />
-                      </div>
-                    )}
-                    <div className="overflow-y-auto flex-1">
-                      {filteredProjects.length > 0 && (
-                        <>
-                          <div className="px-3 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wider">
-                            Saved Projects
-                          </div>
-                          {filteredProjects.map((project) => (
-                            <div
-                              key={project.id}
-                              className="group flex items-center px-3 py-1.5 hover:bg-kumo-fill-hover transition-colors cursor-pointer"
-                              onMouseDown={() => handleSelectProject(project.repo_root)}
-                            >
-                              <div className="min-w-0 flex-1">
-                                <div className="text-xs text-kumo-default font-medium truncate">{project.name}</div>
-                                <div className="text-[11px] text-kumo-subtle font-mono truncate">{project.repo_root}</div>
-                              </div>
-                              <button
-                                onMouseDown={(e) => void removeProject(project.id, e)}
-                                className="ml-2 p-1 rounded text-kumo-subtle/0 group-hover:text-kumo-subtle hover:!text-kumo-danger hover:bg-kumo-fill-hover transition-colors shrink-0"
-                                title="Remove from saved projects"
-                              >
-                                <Trash size={12} />
-                              </button>
-                            </div>
-                          ))}
-                          <div className="border-t border-kumo-fill-hover" />
-                        </>
-                      )}
-                      {filteredProjects.length === 0 && savedProjects.length > 0 && (
-                        <div className="px-3 py-4 text-xs text-kumo-subtle text-center">No matching projects</div>
-                      )}
-                      <button
-                        onMouseDown={() => void handleBrowse()}
-                        className="w-full px-3 py-2 text-left text-xs text-kumo-default hover:bg-kumo-fill-hover transition-colors flex items-center gap-2"
-                      >
-                        <FolderOpen size={14} className="text-kumo-subtle" />
-                        Browse for directory...
-                      </button>
+                <PortaledMenu
+                  open={showDropdown}
+                  triggerRef={dropdownButtonRef}
+                  placement="bottom-left"
+                  matchTriggerWidth
+                  onDismiss={() => { setShowDropdown(false); setProjectSearch('') }}
+                  className="bg-kumo-control border border-kumo-fill-hover rounded-md shadow-2xl max-h-[320px] flex flex-col overflow-hidden"
+                >
+                  {savedProjects.length > 0 && (
+                    <div className="px-2 pt-2 pb-1 shrink-0">
+                      <input
+                        type="text"
+                        value={projectSearch}
+                        onChange={(e) => setProjectSearch(e.target.value)}
+                        placeholder="Search projects..."
+                        className="w-full rounded border border-kumo-line bg-kumo-elevated px-2 py-1 text-xs text-kumo-default placeholder:text-kumo-subtle outline-none focus:border-kumo-ring"
+                        autoFocus
+                      />
                     </div>
+                  )}
+                  <div className="overflow-y-auto flex-1">
+                    {filteredProjects.length > 0 && (
+                      <>
+                        <div className="px-3 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wider">
+                          Saved Projects
+                        </div>
+                        {filteredProjects.map((project) => (
+                          <div
+                            key={project.id}
+                            className="group flex items-center px-3 py-1.5 hover:bg-kumo-fill-hover transition-colors cursor-pointer"
+                            onMouseDown={() => handleSelectProject(project.repo_root)}
+                          >
+                            <div className="min-w-0 flex-1">
+                              <div className="text-xs text-kumo-default font-medium truncate">{project.name}</div>
+                              <div className="text-[11px] text-kumo-subtle font-mono truncate">{project.repo_root}</div>
+                            </div>
+                            <button
+                              onMouseDown={(e) => void removeProject(project.id, e)}
+                              className="ml-2 p-1 rounded text-kumo-subtle/0 group-hover:text-kumo-subtle hover:!text-kumo-danger hover:bg-kumo-fill-hover transition-colors shrink-0"
+                              title="Remove from saved projects"
+                            >
+                              <Trash size={12} />
+                            </button>
+                          </div>
+                        ))}
+                        <div className="border-t border-kumo-fill-hover" />
+                      </>
+                    )}
+                    {filteredProjects.length === 0 && savedProjects.length > 0 && (
+                      <div className="px-3 py-4 text-xs text-kumo-subtle text-center">No matching projects</div>
+                    )}
+                    <button
+                      onMouseDown={() => void handleBrowse()}
+                      className="w-full px-3 py-2 text-left text-xs text-kumo-default hover:bg-kumo-fill-hover transition-colors flex items-center gap-2"
+                    >
+                      <FolderOpen size={14} className="text-kumo-subtle" />
+                      Browse for directory...
+                    </button>
                   </div>
-                )}
+                </PortaledMenu>
               </div>
               <button
                 onClick={handleBrowse}
@@ -833,48 +817,63 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
                     </div>
                   )}
 
-                  {showCommandAutocomplete && (
-                    <div className="absolute bottom-full left-0 right-0 z-20 mb-2 rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl">
-                      {matchingCommands.map((item, index) => (
-                        <button
-                          key={item.command}
-                          type="button"
-                          onMouseDown={(event) => { event.preventDefault(); setPrompt(`${item.command} `) }}
-                          className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
-                            index === commandPickerIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
-                          }`}
-                        >
-                          <span className="font-mono text-[11px] text-kumo-default">{item.command}</span>
-                          <span className="text-[11px] text-kumo-subtle">{item.description}</span>
-                        </button>
-                      ))}
-                      <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
-                        Tab/Enter to select · Arrow keys to navigate · Esc to dismiss
-                      </div>
+                  {/* Popup visibility is driven by prompt content. onDismiss is
+                      a no-op so clicks outside the textarea don't permanently
+                      hide a popup that would re-derive itself. */}
+                  <PortaledMenu
+                    open={showCommandAutocomplete}
+                    triggerRef={promptRef}
+                    placement="top-left"
+                    matchTriggerWidth
+                    gap={8}
+                    onDismiss={() => {}}
+                    className="rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl"
+                  >
+                    {matchingCommands.map((item, index) => (
+                      <button
+                        key={item.command}
+                        type="button"
+                        onMouseDown={(event) => { event.preventDefault(); setPrompt(`${item.command} `) }}
+                        className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
+                          index === commandPickerIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
+                        }`}
+                      >
+                        <span className="font-mono text-[11px] text-kumo-default">{item.command}</span>
+                        <span className="text-[11px] text-kumo-subtle">{item.description}</span>
+                      </button>
+                    ))}
+                    <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
+                      Tab/Enter to select · Arrow keys to navigate · Esc to dismiss
                     </div>
-                  )}
+                  </PortaledMenu>
 
-                  {showAgentPicker && (
-                    <div className="absolute bottom-full left-0 right-0 z-20 mb-2 rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl">
-                      <div className="px-2.5 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wide">Agents</div>
-                      {matchingAgents.map((cfg, index) => (
-                        <button
-                          key={cfg.name}
-                          type="button"
-                          onMouseDown={(event) => { event.preventDefault(); insertAgentMention(cfg.name) }}
-                          className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
-                            index === agentPickerIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
-                          }`}
-                        >
-                          <span className="font-mono text-[11px] text-kumo-brand">@{cfg.name}</span>
-                          {cfg.description && <span className="text-[11px] text-kumo-subtle truncate">{cfg.description}</span>}
-                        </button>
-                      ))}
-                      <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
-                        Tab/Enter to select · Arrow keys to navigate · Esc to dismiss
-                      </div>
+                  <PortaledMenu
+                    open={showAgentPicker}
+                    triggerRef={promptRef}
+                    placement="top-left"
+                    matchTriggerWidth
+                    gap={8}
+                    onDismiss={() => setAgentPickerDismissed(true)}
+                    className="rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl"
+                  >
+                    <div className="px-2.5 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wide">Agents</div>
+                    {matchingAgents.map((cfg, index) => (
+                      <button
+                        key={cfg.name}
+                        type="button"
+                        onMouseDown={(event) => { event.preventDefault(); insertAgentMention(cfg.name) }}
+                        className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
+                          index === agentPickerIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
+                        }`}
+                      >
+                        <span className="font-mono text-[11px] text-kumo-brand">@{cfg.name}</span>
+                        {cfg.description && <span className="text-[11px] text-kumo-subtle truncate">{cfg.description}</span>}
+                      </button>
+                    ))}
+                    <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
+                      Tab/Enter to select · Arrow keys to navigate · Esc to dismiss
                     </div>
-                  )}
+                  </PortaledMenu>
 
                   <textarea
                     ref={promptRef}
@@ -923,8 +922,9 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
                     <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
                       Session
                     </label>
-                    <div className="relative" ref={sessionDropdownRef}>
+                    <div>
                       <button
+                        ref={sessionDropdownButtonRef}
                         type="button"
                         onClick={() => { if (!importLoading && !importError) setShowSessionDropdown(!showSessionDropdown) }}
                         disabled={importLoading}
@@ -954,63 +954,64 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
                         {!importLoading && <CaretDown size={14} className="text-kumo-subtle shrink-0" />}
                       </button>
 
-                      {showSessionDropdown && !importLoading && importSessions.length > 0 && (
-                        <div className="fixed mt-1 bg-kumo-control border border-kumo-fill-hover rounded-md shadow-2xl z-[210] max-h-[320px] flex flex-col overflow-hidden" style={{
-                          width: sessionDropdownRef.current?.getBoundingClientRect().width,
-                          left: sessionDropdownRef.current?.getBoundingClientRect().left,
-                          top: (sessionDropdownRef.current?.getBoundingClientRect().bottom ?? 0) + 4
-                        }}>
-                          <div className="px-2 pt-2 pb-1 shrink-0">
-                            <input
-                              type="text"
-                              value={importSearch}
-                              onChange={(e) => setImportSearch(e.target.value)}
-                              placeholder="Search sessions..."
-                              className="w-full rounded border border-kumo-line bg-kumo-elevated px-2 py-1 text-xs text-kumo-default placeholder:text-kumo-subtle outline-none focus:border-kumo-ring"
-                              autoFocus
-                            />
-                          </div>
-                          <div className="overflow-y-auto flex-1">
-                            {filteredImportSessions.map((session) => {
-                              const isSelected = selectedSession?.id === session.id
-                              const wtLabel = worktreeLabel(session.directory, directory.trim())
-                              return (
-                                <div
-                                  key={session.id}
-                                  onMouseDown={() => {
-                                    setSelectedSession(session)
-                                    setImportName(deriveForkedName(session.title))
-                                    setShowSessionDropdown(false)
-                                    setImportSearch('')
-                                  }}
-                                  className={`flex items-center gap-2.5 px-3 py-2 cursor-pointer transition-colors ${
-                                    isSelected ? 'bg-kumo-brand/10' : 'hover:bg-kumo-fill-hover'
-                                  }`}
-                                >
-                                  <div className="flex-1 min-w-0">
-                                    <div className="text-xs text-kumo-default font-medium truncate">{session.title}</div>
-                                    <div className="flex items-center gap-1.5 text-[10px] text-kumo-subtle mt-0.5">
-                                      <span>{formatTimestamp(session.updatedAt)}</span>
-                                      {wtLabel && (
-                                        <>
-                                          <span className="text-kumo-line">|</span>
-                                          <span className="font-mono truncate">{wtLabel}</span>
-                                        </>
-                                      )}
-                                    </div>
-                                  </div>
-                                  {isSelected && (
-                                    <span className="shrink-0 text-[10px] font-medium text-kumo-brand">&#10003;</span>
-                                  )}
-                                </div>
-                              )
-                            })}
-                            {filteredImportSessions.length === 0 && (
-                              <div className="px-3 py-4 text-xs text-kumo-subtle text-center">No matching sessions</div>
-                            )}
-                          </div>
+                      <PortaledMenu
+                        open={showSessionDropdown && !importLoading && importSessions.length > 0}
+                        triggerRef={sessionDropdownButtonRef}
+                        placement="bottom-left"
+                        matchTriggerWidth
+                        onDismiss={() => { setShowSessionDropdown(false); setImportSearch('') }}
+                        className="bg-kumo-control border border-kumo-fill-hover rounded-md shadow-2xl max-h-[320px] flex flex-col overflow-hidden"
+                      >
+                        <div className="px-2 pt-2 pb-1 shrink-0">
+                          <input
+                            type="text"
+                            value={importSearch}
+                            onChange={(e) => setImportSearch(e.target.value)}
+                            placeholder="Search sessions..."
+                            className="w-full rounded border border-kumo-line bg-kumo-elevated px-2 py-1 text-xs text-kumo-default placeholder:text-kumo-subtle outline-none focus:border-kumo-ring"
+                            autoFocus
+                          />
                         </div>
-                      )}
+                        <div className="overflow-y-auto flex-1">
+                          {filteredImportSessions.map((session) => {
+                            const isSelected = selectedSession?.id === session.id
+                            const wtLabel = worktreeLabel(session.directory, directory.trim())
+                            return (
+                              <div
+                                key={session.id}
+                                onMouseDown={() => {
+                                  setSelectedSession(session)
+                                  setImportName(deriveForkedName(session.title))
+                                  setShowSessionDropdown(false)
+                                  setImportSearch('')
+                                }}
+                                className={`flex items-center gap-2.5 px-3 py-2 cursor-pointer transition-colors ${
+                                  isSelected ? 'bg-kumo-brand/10' : 'hover:bg-kumo-fill-hover'
+                                }`}
+                              >
+                                <div className="flex-1 min-w-0">
+                                  <div className="text-xs text-kumo-default font-medium truncate">{session.title}</div>
+                                  <div className="flex items-center gap-1.5 text-[10px] text-kumo-subtle mt-0.5">
+                                    <span>{formatTimestamp(session.updatedAt)}</span>
+                                    {wtLabel && (
+                                      <>
+                                        <span className="text-kumo-line">|</span>
+                                        <span className="font-mono truncate">{wtLabel}</span>
+                                      </>
+                                    )}
+                                  </div>
+                                </div>
+                                {isSelected && (
+                                  <span className="shrink-0 text-[10px] font-medium text-kumo-brand">&#10003;</span>
+                                )}
+                              </div>
+                            )
+                          })}
+                          {filteredImportSessions.length === 0 && (
+                            <div className="px-3 py-4 text-xs text-kumo-subtle text-center">No matching sessions</div>
+                          )}
+                        </div>
+                      </PortaledMenu>
                     </div>
                     <p className="text-[11px] text-kumo-subtle -mt-0.5">
                       Creates a new worktree and copies the session history into it.

--- a/src/renderer/src/components/PortaledMenu.tsx
+++ b/src/renderer/src/components/PortaledMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 /** Where to anchor the menu relative to the trigger button. */
@@ -17,21 +17,120 @@ interface MenuCoords {
   bottom?: number
   left?: number
   right?: number
+  width?: number
 }
 
-function computeCoords(rect: DOMRect, placement: MenuPlacement, gap: number): MenuCoords {
-  // Use viewport-relative coords so `position: fixed` in the portaled menu
-  // sits exactly where the trigger would have placed an absolute child, but
-  // without any overflow-clipping from the trigger's ancestors.
-  switch (placement) {
+interface MenuSize {
+  width: number
+  height: number
+}
+
+/** Minimum gap between the menu and the viewport edge when flipping/clamping. */
+const VIEWPORT_PADDING = 4
+
+function isLeftPlacement(placement: MenuPlacement): boolean {
+  return placement === 'top-left' || placement === 'bottom-left'
+}
+
+function isTopPlacement(placement: MenuPlacement): boolean {
+  return placement === 'top-left' || placement === 'top-right'
+}
+
+function sameCoords(a: MenuCoords | null, b: MenuCoords): boolean {
+  if (!a) return false
+  return (
+    a.top === b.top &&
+    a.bottom === b.bottom &&
+    a.left === b.left &&
+    a.right === b.right &&
+    a.width === b.width
+  )
+}
+
+/**
+ * Pick the placement that keeps the menu on screen.
+ *
+ * Horizontal flip: 'left'-anchored menus extend rightward from rect.left;
+ * 'right'-anchored menus extend leftward from rect.right. Skipped when the
+ * menu's width is locked to the trigger (the menu is always on-screen
+ * horizontally as long as the trigger is).
+ *
+ * Vertical flip: 'top'-anchored menus extend upward from rect.top;
+ * 'bottom'-anchored menus extend downward from rect.bottom.
+ */
+function resolvePlacement(
+  rect: DOMRect,
+  placement: MenuPlacement,
+  menuSize: MenuSize,
+  matchTriggerWidth: boolean
+): MenuPlacement {
+  let effective = placement
+
+  if (!matchTriggerWidth) {
+    const overflowsRight = rect.left + menuSize.width > window.innerWidth - VIEWPORT_PADDING
+    const overflowsLeft = rect.right - menuSize.width < VIEWPORT_PADDING
+    if (isLeftPlacement(effective) && overflowsRight) {
+      effective = effective === 'top-left' ? 'top-right' : 'bottom-right'
+    } else if (!isLeftPlacement(effective) && overflowsLeft) {
+      effective = effective === 'top-right' ? 'top-left' : 'bottom-left'
+    }
+  }
+
+  const overflowsTop = rect.top - menuSize.height < VIEWPORT_PADDING
+  const overflowsBottom = rect.bottom + menuSize.height > window.innerHeight - VIEWPORT_PADDING
+  const leftAnchored = isLeftPlacement(effective)
+  if (isTopPlacement(effective) && overflowsTop) {
+    effective = leftAnchored ? 'bottom-left' : 'bottom-right'
+  } else if (!isTopPlacement(effective) && overflowsBottom) {
+    effective = leftAnchored ? 'top-left' : 'top-right'
+  }
+
+  return effective
+}
+
+/**
+ * Compute the viewport-relative coords for the portaled menu. Position is
+ * `position: fixed`, so coords are measured from the viewport edges. When the
+ * menu has been rendered once we also flip placement on overflow.
+ */
+function computeCoords(
+  rect: DOMRect,
+  placement: MenuPlacement,
+  gap: number,
+  menuSize: MenuSize | undefined,
+  matchTriggerWidth: boolean
+): MenuCoords {
+  const effective = menuSize
+    ? resolvePlacement(rect, placement, menuSize, matchTriggerWidth)
+    : placement
+
+  const width = matchTriggerWidth ? rect.width : undefined
+
+  switch (effective) {
     case 'top-right':
-      return { bottom: window.innerHeight - rect.top + gap, right: window.innerWidth - rect.right }
+      return {
+        bottom: window.innerHeight - rect.top + gap,
+        right: window.innerWidth - rect.right,
+        width
+      }
     case 'top-left':
-      return { bottom: window.innerHeight - rect.top + gap, left: rect.left }
+      return {
+        bottom: window.innerHeight - rect.top + gap,
+        left: rect.left,
+        width
+      }
     case 'bottom-right':
-      return { top: rect.bottom + gap, right: window.innerWidth - rect.right }
+      return {
+        top: rect.bottom + gap,
+        right: window.innerWidth - rect.right,
+        width
+      }
     case 'bottom-left':
-      return { top: rect.bottom + gap, left: rect.left }
+      return {
+        top: rect.bottom + gap,
+        left: rect.left,
+        width
+      }
   }
 }
 
@@ -42,16 +141,17 @@ interface PortaledMenuProps {
   onDismiss: () => void
   /** Gap in px between trigger and menu (default 4). */
   gap?: number
-  /** Anything clicked inside this ref is treated as "inside" and does not
-   *  dismiss. Use for nested popovers or input fields that live within the
-   *  menu body. */
+  /** When true, the menu's width is forced to match the trigger's width.
+   *  Useful for select-style dropdowns and autocomplete popovers anchored
+   *  to a textarea or input. Defaults to false. */
+  matchTriggerWidth?: boolean
   children: React.ReactNode
   className?: string
 }
 
 /**
  * Renders its children at document.body, positioned relative to a trigger
- * element. Handles click-outside and Escape-to-close. Reposition on scroll
+ * element. Handles click-outside and Escape-to-close. Repositions on scroll
  * and window resize so the menu tracks its trigger.
  */
 export function PortaledMenu({
@@ -60,40 +160,48 @@ export function PortaledMenu({
   placement,
   onDismiss,
   gap = 4,
+  matchTriggerWidth = false,
   children,
   className
 }: PortaledMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null)
   const [coords, setCoords] = useState<MenuCoords | null>(null)
 
-  // Compute position synchronously after the browser lays out the trigger,
-  // so the menu appears in the right place on the first paint after open.
+  // Position the menu in two passes. First pass renders at the requested
+  // placement (menuSize unknown). Second pass measures the rendered menu and
+  // flips to the opposite side if it would overflow the viewport. The flip
+  // runs synchronously in a layout effect so users never see the off-screen
+  // frame. We coalesce equal coords to avoid an infinite update loop.
+  const reposition = useCallback(() => {
+    const rect = triggerRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const menuRect = menuRef.current?.getBoundingClientRect()
+    const menuSize = menuRect ? { width: menuRect.width, height: menuRect.height } : undefined
+    const next = computeCoords(rect, placement, gap, menuSize, matchTriggerWidth)
+    setCoords((prev) => (sameCoords(prev, next) ? prev : next))
+  }, [triggerRef, placement, gap, matchTriggerWidth])
+
   useLayoutEffect(() => {
     if (!open) {
       setCoords(null)
       return
     }
-    const rect = triggerRef.current?.getBoundingClientRect()
-    if (rect) setCoords(computeCoords(rect, placement, gap))
-  }, [open, placement, gap, triggerRef])
+    reposition()
+  })
 
   // Keep the menu pinned to its trigger when the user scrolls or resizes.
   useEffect(() => {
     if (!open) return
-    const reposition = () => {
-      const rect = triggerRef.current?.getBoundingClientRect()
-      if (rect) setCoords(computeCoords(rect, placement, gap))
-    }
     window.addEventListener('resize', reposition)
     window.addEventListener('scroll', reposition, true)
     return () => {
       window.removeEventListener('resize', reposition)
       window.removeEventListener('scroll', reposition, true)
     }
-  }, [open, placement, gap, triggerRef])
+  }, [open, reposition])
 
-  // Click-outside + Escape dismissal. Check both the trigger and the portaled
-  // menu — clicks inside either count as "inside".
+  // Click-outside + Escape dismissal. Clicks on the trigger or inside the
+  // portaled menu count as "inside" and don't dismiss.
   useEffect(() => {
     if (!open) return
     const onClick = (event: MouseEvent) => {

--- a/src/renderer/src/components/SelectField.tsx
+++ b/src/renderer/src/components/SelectField.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { CaretDown, Check, MagnifyingGlass } from '@phosphor-icons/react'
+import { PortaledMenu } from './PortaledMenu'
 
 interface SelectOption {
   value: string
@@ -13,6 +14,11 @@ interface SelectFieldProps {
   searchable?: boolean
   searchPlaceholder?: string
   buttonClassName?: string
+  /**
+   * Style-only classes for the dropdown menu (background, border, etc.).
+   * Position is handled by PortaledMenu — strip any `absolute`/`top-*`/
+   * `bottom-*`/`left-*`/`right-*`/`mt-*` classes from this string.
+   */
   menuClassName?: string
 }
 
@@ -27,7 +33,7 @@ export function SelectField({
 }: SelectFieldProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [search, setSearch] = useState('')
-  const containerRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
 
   const selectedOption = useMemo(() => {
@@ -43,30 +49,6 @@ export function SelectField({
     )
   }, [options, searchable, search])
 
-  useEffect(() => {
-    if (!isOpen) return
-
-    const handlePointerDown = (event: MouseEvent) => {
-      if (!containerRef.current?.contains(event.target as Node)) {
-        setIsOpen(false)
-      }
-    }
-
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setIsOpen(false)
-      }
-    }
-
-    window.addEventListener('mousedown', handlePointerDown)
-    window.addEventListener('keydown', handleEscape)
-
-    return () => {
-      window.removeEventListener('mousedown', handlePointerDown)
-      window.removeEventListener('keydown', handleEscape)
-    }
-  }, [isOpen])
-
   // Reset search and auto-focus when dropdown opens
   useEffect(() => {
     if (isOpen && searchable) {
@@ -76,8 +58,9 @@ export function SelectField({
   }, [isOpen, searchable])
 
   return (
-    <div ref={containerRef} className="relative">
+    <>
       <button
+        ref={buttonRef}
         type="button"
         aria-haspopup="listbox"
         aria-expanded={isOpen}
@@ -88,11 +71,15 @@ export function SelectField({
         <CaretDown size={14} className={`shrink-0 text-kumo-subtle transition-transform ${isOpen ? 'rotate-180' : ''}`} />
       </button>
 
-      {isOpen && (
-        <div
-          role="listbox"
-          className={menuClassName}
-        >
+      <PortaledMenu
+        open={isOpen}
+        triggerRef={buttonRef}
+        placement="bottom-left"
+        matchTriggerWidth
+        onDismiss={() => setIsOpen(false)}
+        className={menuClassName}
+      >
+        <div role="listbox">
           {searchable && (
             <div className="px-2 pt-2 pb-1">
               <div className="relative">
@@ -137,7 +124,7 @@ export function SelectField({
             })
           )}
         </div>
-      )}
-    </div>
+      </PortaledMenu>
+    </>
   )
 }

--- a/src/renderer/src/components/SessionBrowser.tsx
+++ b/src/renderer/src/components/SessionBrowser.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { X, FolderOpen, CaretDown, Trash, ClockCounterClockwise, CircleNotch, ChatCircleDots } from '@phosphor-icons/react'
 import type { Project } from '../types/api'
+import { PortaledMenu } from './PortaledMenu'
 
 interface SessionInfo {
   id: string
@@ -61,7 +62,7 @@ export function SessionBrowser({
   const [projectSearch, setProjectSearch] = useState('')
   const [validating, setValidating] = useState(false)
   const [dirError, setDirError] = useState<string | null>(null)
-  const dropdownRef = useRef<HTMLDivElement>(null)
+  const dropdownButtonRef = useRef<HTMLButtonElement>(null)
 
   // Load saved projects
   useEffect(() => {
@@ -195,17 +196,7 @@ export function SessionBrowser({
     )
   }, [savedProjects, projectSearch])
 
-  // Close dropdown on outside click
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setShowDropdown(false)
-        setProjectSearch('')
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [])
+  // Outside-click handling is delegated to PortaledMenu's onDismiss.
 
   const handleBrowse = async () => {
     const selected = await onSelectDirectory()
@@ -281,9 +272,10 @@ export function SessionBrowser({
             <p className="text-[11px] text-kumo-subtle -mt-0.5">
               Select the original project directory (not a worktree) to browse its sessions.
             </p>
-            <div className="relative flex gap-2" ref={dropdownRef}>
-              <div className="flex-1 min-w-0 relative">
+            <div className="flex gap-2">
+              <div className="flex-1 min-w-0">
                 <button
+                  ref={dropdownButtonRef}
                   type="button"
                   onClick={() => setShowDropdown(!showDropdown)}
                   className={`w-full flex items-center gap-2 px-3 py-2 bg-kumo-control border rounded-md text-sm outline-none transition-colors hover:bg-kumo-fill focus:border-kumo-ring ${
@@ -307,65 +299,70 @@ export function SessionBrowser({
                   <CaretDown size={14} className="text-kumo-subtle shrink-0" />
                 </button>
 
-                {showDropdown && (
-                  <div className="absolute top-full left-0 right-0 mt-1 bg-kumo-control border border-kumo-fill-hover rounded-md shadow-2xl z-10 max-h-[240px] flex flex-col overflow-hidden">
-                    {savedProjects.length > 0 && (
-                      <div className="px-2 pt-2 pb-1 shrink-0">
-                        <input
-                          type="text"
-                          value={projectSearch}
-                          onChange={(e) => setProjectSearch(e.target.value)}
-                          placeholder="Search projects..."
-                          className="w-full rounded border border-kumo-line bg-kumo-elevated px-2 py-1 text-xs text-kumo-default placeholder:text-kumo-subtle outline-none focus:border-kumo-ring"
-                          autoFocus
-                        />
-                      </div>
-                    )}
-                    <div className="overflow-y-auto flex-1">
-                      {filteredProjects.length > 0 && (
-                        <>
-                          <div className="px-3 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wider">
-                            Saved Projects
-                          </div>
-                          {filteredProjects.map((project) => (
-                            <div
-                              key={project.id}
-                              className="group flex items-center px-3 py-1.5 hover:bg-kumo-fill-hover transition-colors cursor-pointer"
-                              onMouseDown={() => handleSelectProject(project.repo_root)}
-                            >
-                              <div className="min-w-0 flex-1">
-                                <div className="text-xs text-kumo-default font-medium truncate">
-                                  {project.name}
-                                </div>
-                                <div className="text-[11px] text-kumo-subtle font-mono truncate">
-                                  {project.repo_root}
-                                </div>
-                              </div>
-                              <button
-                                onMouseDown={(e) => void removeProject(project.id, e)}
-                                className="ml-2 p-1 rounded text-kumo-subtle/0 group-hover:text-kumo-subtle hover:!text-kumo-danger hover:bg-kumo-fill-hover transition-colors shrink-0"
-                                title="Remove from saved projects"
-                              >
-                                <Trash size={12} />
-                              </button>
-                            </div>
-                          ))}
-                          <div className="border-t border-kumo-fill-hover" />
-                        </>
-                      )}
-                      {filteredProjects.length === 0 && savedProjects.length > 0 && (
-                        <div className="px-3 py-4 text-xs text-kumo-subtle text-center">No matching projects</div>
-                      )}
-                      <button
-                        onMouseDown={() => void handleBrowse()}
-                        className="w-full px-3 py-2 text-left text-xs text-kumo-default hover:bg-kumo-fill-hover transition-colors flex items-center gap-2"
-                      >
-                        <FolderOpen size={14} className="text-kumo-subtle" />
-                        Browse for directory...
-                      </button>
+                <PortaledMenu
+                  open={showDropdown}
+                  triggerRef={dropdownButtonRef}
+                  placement="bottom-left"
+                  matchTriggerWidth
+                  onDismiss={() => { setShowDropdown(false); setProjectSearch('') }}
+                  className="bg-kumo-control border border-kumo-fill-hover rounded-md shadow-2xl max-h-[240px] flex flex-col overflow-hidden"
+                >
+                  {savedProjects.length > 0 && (
+                    <div className="px-2 pt-2 pb-1 shrink-0">
+                      <input
+                        type="text"
+                        value={projectSearch}
+                        onChange={(e) => setProjectSearch(e.target.value)}
+                        placeholder="Search projects..."
+                        className="w-full rounded border border-kumo-line bg-kumo-elevated px-2 py-1 text-xs text-kumo-default placeholder:text-kumo-subtle outline-none focus:border-kumo-ring"
+                        autoFocus
+                      />
                     </div>
+                  )}
+                  <div className="overflow-y-auto flex-1">
+                    {filteredProjects.length > 0 && (
+                      <>
+                        <div className="px-3 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wider">
+                          Saved Projects
+                        </div>
+                        {filteredProjects.map((project) => (
+                          <div
+                            key={project.id}
+                            className="group flex items-center px-3 py-1.5 hover:bg-kumo-fill-hover transition-colors cursor-pointer"
+                            onMouseDown={() => handleSelectProject(project.repo_root)}
+                          >
+                            <div className="min-w-0 flex-1">
+                              <div className="text-xs text-kumo-default font-medium truncate">
+                                {project.name}
+                              </div>
+                              <div className="text-[11px] text-kumo-subtle font-mono truncate">
+                                {project.repo_root}
+                              </div>
+                            </div>
+                            <button
+                              onMouseDown={(e) => void removeProject(project.id, e)}
+                              className="ml-2 p-1 rounded text-kumo-subtle/0 group-hover:text-kumo-subtle hover:!text-kumo-danger hover:bg-kumo-fill-hover transition-colors shrink-0"
+                              title="Remove from saved projects"
+                            >
+                              <Trash size={12} />
+                            </button>
+                          </div>
+                        ))}
+                        <div className="border-t border-kumo-fill-hover" />
+                      </>
+                    )}
+                    {filteredProjects.length === 0 && savedProjects.length > 0 && (
+                      <div className="px-3 py-4 text-xs text-kumo-subtle text-center">No matching projects</div>
+                    )}
+                    <button
+                      onMouseDown={() => void handleBrowse()}
+                      className="w-full px-3 py-2 text-left text-xs text-kumo-default hover:bg-kumo-fill-hover transition-colors flex items-center gap-2"
+                    >
+                      <FolderOpen size={14} className="text-kumo-subtle" />
+                      Browse for directory...
+                    </button>
                   </div>
-                )}
+                </PortaledMenu>
               </div>
               <button
                 onClick={handleBrowse}

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -18,6 +18,7 @@ import {
   DotsSixVertical,
 } from '@phosphor-icons/react'
 import { SelectField } from './SelectField'
+import { PortaledMenu } from './PortaledMenu'
 import {
   DEFAULT_CREATE_PR_PROMPT,
   MAX_QUICK_ACTIONS,
@@ -124,7 +125,7 @@ export function SettingsModal({ onClose, initialTab = 'general', commands = [] }
     'flex w-full items-center justify-between gap-3 rounded-md border border-kumo-line bg-kumo-control px-3 py-2 text-sm text-kumo-default outline-none transition-colors hover:bg-kumo-fill focus:border-kumo-ring'
 
   const selectMenuClasses =
-    'absolute left-0 right-0 top-full z-20 mt-1 overflow-hidden rounded-md border border-kumo-line bg-kumo-overlay shadow-xl'
+    'overflow-hidden rounded-md border border-kumo-line bg-kumo-overlay shadow-xl'
 
   const inputClasses =
     'w-full px-3 py-2 bg-kumo-control border border-kumo-line rounded-md text-sm text-kumo-default outline-none focus:border-kumo-ring placeholder:text-kumo-subtle'
@@ -746,29 +747,6 @@ function PromptTextarea({
         Prompt
       </label>
       <div className="relative">
-        {shouldShow && (
-          <div className="absolute bottom-full left-0 right-0 z-20 mb-1 rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl max-h-40 overflow-y-auto">
-            {matchingCommands.map((cmd, index) => (
-              <button
-                key={cmd.command}
-                type="button"
-                onMouseDown={(e) => {
-                  e.preventDefault()
-                  insertCommand(cmd.command)
-                }}
-                className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
-                  index === selectedIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
-                }`}
-              >
-                <span className="font-mono text-[11px] text-kumo-default">{cmd.command}</span>
-                <span className="text-[11px] text-kumo-subtle truncate">{cmd.description}</span>
-              </button>
-            ))}
-            <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
-              Tab/Enter to select · Arrow keys to navigate
-            </div>
-          </div>
-        )}
         <textarea
           ref={textareaRef}
           value={value}
@@ -784,6 +762,34 @@ function PromptTextarea({
           rows={6}
           className={`${inputClasses} min-h-24 resize-y leading-6`}
         />
+        <PortaledMenu
+          open={shouldShow}
+          triggerRef={textareaRef}
+          placement="top-left"
+          matchTriggerWidth
+          onDismiss={() => setShowAutocomplete(false)}
+          className="rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl max-h-40 overflow-y-auto"
+        >
+          {matchingCommands.map((cmd, index) => (
+            <button
+              key={cmd.command}
+              type="button"
+              onMouseDown={(e) => {
+                e.preventDefault()
+                insertCommand(cmd.command)
+              }}
+              className={`flex w-full items-start gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
+                index === selectedIndex ? 'bg-kumo-fill' : 'hover:bg-kumo-fill'
+              }`}
+            >
+              <span className="font-mono text-[11px] text-kumo-default">{cmd.command}</span>
+              <span className="text-[11px] text-kumo-subtle truncate">{cmd.description}</span>
+            </button>
+          ))}
+          <div className="px-2.5 py-1 text-[10px] text-kumo-subtle border-t border-kumo-line mt-1 pt-1">
+            Tab/Enter to select · Arrow keys to navigate
+          </div>
+        </PortaledMenu>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

The label dropdown in the transcript drawer was clipped because it anchored its left edge to a trigger sitting right against the viewport edge. Rather than patch one placement, teach `PortaledMenu` to measure the rendered menu and flip horizontally or vertically when it would overflow, with a `matchTriggerWidth` option for select-style menus that need to track their input's width.

Then migrate every ad-hoc absolute-positioned dropdown through `PortaledMenu` so the same fix benefits everything: the column toggle, event filter, scroll-arrow menu, `SelectField`, project and session pickers, and the slash-command and agent-mention autocompletes. Cursor-anchored menus (the row context menu) and the existing modal/tooltip components keep their own positioning.

## What changed

- `PortaledMenu` now measures the rendered menu and flips placement when either axis would overflow the viewport. Split positioning into `resolvePlacement` (which side) and `computeCoords` (turn it into coords).
- New `matchTriggerWidth` prop locks the menu width to the trigger — used by select-style dropdowns and textarea autocompletes.
- Migrated `FilterBar` columns toggle, `EventLog` filter, `FleetTable` scroll-arrow menu, `SelectField`, `SessionBrowser` project picker, `LaunchModal` project + session pickers + autocompletes, `SettingsModal` slash-command autocomplete, and `DetailDrawer` autocompletes to `PortaledMenu`.

## Testing

- Typecheck clean (both node and web targets)
- Lint: 0 errors (warnings pre-existing)
- 212/212 unit tests pass
- Production build succeeds