### PR TITLE
Log error-shaped events from EventBridge to main-process stdout

### DIFF
--- a/src/main/services/event-bridge.ts
+++ b/src/main/services/event-bridge.ts
@@ -204,12 +204,46 @@ export class EventBridge {
       runtimeManager.touchRuntimeActivity(this.runtimeId)
     }
 
+    // Surface error-shaped events in main-process logs so issues like
+    // ProviderAuthError ("Unauthorized: ... opencode auth login ...") are
+    // visible without digging through the renderer's DevTools console.
+    if (event.type.endsWith('.error') || event.type.endsWith('.failed')) {
+      console.error(
+        `[EventBridge:${this.runtimeId}] ${event.type}:`,
+        this.summarizeErrorEvent(event.properties)
+      )
+    }
+
     // Forward all events to the renderer, tagged with the runtime ID
     this.broadcastToRenderer('opencode:event', {
       runtimeId: this.runtimeId,
       directory: this.directory,
       event
     })
+  }
+
+  /**
+   * Extract the most useful fields from an error-shaped event payload.
+   * Matches the SDK shape for session.error (properties.error.{name,data.message})
+   * and falls back to the raw payload for unknown shapes.
+   */
+  private summarizeErrorEvent(properties: unknown): unknown {
+    if (!properties || typeof properties !== 'object') return properties
+
+    const props = properties as Record<string, unknown>
+    const err = props.error
+    if (err && typeof err === 'object') {
+      const e = err as Record<string, unknown>
+      const data = (e.data as Record<string, unknown> | undefined) ?? {}
+      return {
+        sessionID: props.sessionID,
+        name: e.name,
+        providerID: data.providerID,
+        message: data.message,
+        statusCode: data.statusCode
+      }
+    }
+    return properties
   }
 
   private broadcastToRenderer(channel: string, data: unknown): void {


### PR DESCRIPTION
## Summary

`EventBridge.forwardEvent` previously only logged event types (and only the first 5 / every 50th event), so `session.error` payloads — including `ProviderAuthError` messages telling the user to run `opencode auth login` — were forwarded straight to the renderer without ever being logged in the main process.

When the upstream provider rejects auth, the local opencode server's event loop also stalls long enough that `RuntimeManager`'s 5s `/health` probe times out, so the only visible symptom in stdout was a stream of `Health check failed` warnings with no hint at the real cause.

## Change

Surface any event whose `type` ends in `.error` or `.failed` via `console.error` with the most useful fields extracted (`name`, `providerID`, `message`, `statusCode`, `sessionID`). Falls back to the raw payload for unknown shapes.

Next time auth fails the main-process log will now show something like:

\`\`\`
[EventBridge:runtime-1] session.error: {
  sessionID: 'ses_abc',
  name: 'ProviderAuthError',
  providerID: 'anthropic',
  message: 'Unauthorized: request was blocked by a gateway or proxy...'
}
\`\`\`

Also catches \`workspace.failed\` and any future \`*.error\` / \`*.failed\` events.