### PR TITLE
Keep slash command hint visible when full command is typed

### DIFF
--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -352,10 +352,7 @@ export const DetailDrawer = memo(function DetailDrawer({
     [inputText, trimmedInput, commands]
   )
 
-  const showCommandAutocomplete = useMemo(() => {
-    if (matchingCommands.length === 0 || trimmedInput.length === 0) return false
-    return !commands.some(({ command }) => command === trimmedInput)
-  }, [matchingCommands, trimmedInput, commands])
+  const showCommandAutocomplete = matchingCommands.length > 0 && trimmedInput.length > 0
 
   // ── @ Agent mention detection ──
   // Find the @mention being typed at or before the cursor position.

--- a/src/renderer/src/components/LaunchModal.tsx
+++ b/src/renderer/src/components/LaunchModal.tsx
@@ -157,10 +157,7 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
     [prompt, trimmedPrompt, commands]
   )
 
-  const showCommandAutocomplete = useMemo(() => {
-    if (matchingCommands.length === 0 || trimmedPrompt.length === 0) return false
-    return !commands.some(({ command }) => command === trimmedPrompt)
-  }, [matchingCommands, trimmedPrompt, commands])
+  const showCommandAutocomplete = matchingCommands.length > 0 && trimmedPrompt.length > 0
 
   const agentMentionResult = useMemo(() => {
     if (agentConfigs.length === 0) return null

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -707,7 +707,7 @@ function PromptTextarea({
   const matchingCommands = isTypingCommand
     ? commands.filter((c) => c.command.startsWith(trimmed))
     : []
-  const shouldShow = showAutocomplete && matchingCommands.length > 0 && !commands.some((c) => c.command === trimmed)
+  const shouldShow = showAutocomplete && matchingCommands.length > 0
 
   const insertCommand = (command: string) => {
     onChange(`${command} `)


### PR DESCRIPTION
## Summary

- The slash-command autocomplete popup hid itself the moment the typed text exactly matched a known command, so typing `/close` made the hint vanish on the final keystroke.
- Drop the exact-match suppression in all three prompt inputs (`DetailDrawer`, `LaunchModal`, `SettingsModal`) so the hint stays visible until the user adds a space or newline (i.e. transitions from typing a command to writing arguments).
- Collapsed two redundant `useMemo` blocks down to plain boolean expressions while in the same code.