### PR TITLE
Dismiss slash command popup once a command is inserted

### DIFF
--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -345,11 +345,15 @@ export const DetailDrawer = memo(function DetailDrawer({
 
   const trimmedInput = inputText.trim().toLowerCase()
 
+  // Only suggest commands while the user is still typing a single-token command
+  // (no space or newline yet). Once they add a space, they've committed to that
+  // command and are typing arguments — or the next Enter should submit.
+  const isTypingCommand = inputText.startsWith('/') && !inputText.includes(' ') && !inputText.includes('\n')
   const matchingCommands = useMemo(
-    () => inputText.startsWith('/')
+    () => isTypingCommand
       ? commands.filter(({ command }) => command.startsWith(trimmedInput))
       : [],
-    [inputText, trimmedInput, commands]
+    [isTypingCommand, trimmedInput, commands]
   )
 
   const showCommandAutocomplete = matchingCommands.length > 0 && trimmedInput.length > 0

--- a/src/renderer/src/components/LaunchModal.tsx
+++ b/src/renderer/src/components/LaunchModal.tsx
@@ -150,11 +150,15 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
 
   const trimmedPrompt = prompt.trim().toLowerCase()
 
+  // Only suggest commands while the user is still typing a single-token command
+  // (no space or newline yet). Once they add a space, they've committed to that
+  // command and are typing arguments — or the next Enter should submit.
+  const isTypingCommand = prompt.startsWith('/') && !prompt.includes(' ') && !prompt.includes('\n')
   const matchingCommands = useMemo(
-    () => prompt.startsWith('/')
+    () => isTypingCommand
       ? commands.filter(({ command }) => command.startsWith(trimmedPrompt))
       : [],
-    [prompt, trimmedPrompt, commands]
+    [isTypingCommand, trimmedPrompt, commands]
   )
 
   const showCommandAutocomplete = matchingCommands.length > 0 && trimmedPrompt.length > 0


### PR DESCRIPTION
## Summary

Follow-up to #174.

After #174 kept the autocomplete popup visible at exact match, the Enter keystroke that inserts the chosen command (which writes the value back with a trailing space) left the popup re-matching against the trimmed text. The popup never dismissed and a second Enter could not fall through to submit.

Guard `matchingCommands` behind a new `isTypingCommand` boolean — true only while the input starts with `/` and contains no space or newline — in `DetailDrawer` and `LaunchModal`. This matches the pattern `SettingsModal` already uses.

Restores the expected two-Enter flow: first inserts the command and hides the popup, second submits.