### PR TITLE
Show configured editor name in Open In menus

### DIFF
--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -32,6 +32,7 @@ import { formatBranchLabel } from '../types'
 import type { LivePermission, LiveQuestion } from '../hooks/useAgentStore'
 import { loadSettings, SETTINGS_CHANGED_EVENT, MAX_QUICK_ACTIONS, isQuickActionValid, type QuickAction, type QuickActionIcon } from '../data/settings'
 import { useImageAttachments } from '../hooks/useImageAttachments'
+import { useEditorLabel } from '../hooks/useEditorLabel'
 import { StatusBadge } from './StatusBadge'
 import { LabelDropdown } from './LabelDropdown'
 import { ContextUsageIndicator } from './ContextUsageIndicator'
@@ -253,6 +254,7 @@ export const DetailDrawer = memo(function DetailDrawer({
   // Settings: reactive to changes from SettingsModal
   const [isVerbose, setIsVerbose] = useState(() => loadSettings().verboseMode)
   const [quickActions, setQuickActions] = useState(() => loadSettings().quickActions)
+  const editorLabel = useEditorLabel()
   useEffect(() => {
     const onSettingsChanged = () => {
       const s = loadSettings()
@@ -1234,7 +1236,7 @@ export const DetailDrawer = memo(function DetailDrawer({
                 className="w-full"
                 items={[
                   { icon: <Terminal size={12} />, label: 'Terminal', onClick: onOpenTerminal },
-                  { icon: <ArrowSquareOut size={12} />, label: 'Editor', onClick: onOpenInEditor }
+                  { icon: <ArrowSquareOut size={12} />, label: editorLabel, onClick: onOpenInEditor }
                 ]}
               />
               {onChangeModel && (

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -51,6 +51,7 @@ import {
   Wrench,
 } from '@phosphor-icons/react'
 import { loadSettings, SETTINGS_CHANGED_EVENT, isQuickActionValid, type QuickAction, type QuickActionIcon } from '../data/settings'
+import { useEditorLabel } from '../hooks/useEditorLabel'
 
 const quickActionIconMap: Record<QuickActionIcon, typeof Lightning> = {
   'git-pull-request': GitPullRequest,
@@ -587,6 +588,7 @@ function ContextMenu({
 }) {
   const menuRef = useRef<HTMLDivElement>(null)
   const [quickActions, setQuickActions] = useState(() => loadSettings().quickActions)
+  const editorLabel = useEditorLabel()
 
   useEffect(() => {
     const onSettingsChanged = () => setQuickActions(loadSettings().quickActions)
@@ -697,7 +699,7 @@ function ContextMenu({
         <Terminal size={13} /> Open Terminal
       </button>
       <button className={itemClass} onClick={onOpenInEditor}>
-        <ArrowSquareOut size={13} /> Open in Editor
+        <ArrowSquareOut size={13} /> Open in {editorLabel}
       </button>
 
       <div className="my-1 border-t border-kumo-line" />
@@ -1072,6 +1074,7 @@ function ArrowMenuPopover({
   onOpenTerminal: () => void
   onOpenInEditor: () => void
 }) {
+  const editorLabel = useEditorLabel()
   return (
     <PortaledMenu
       open={open}
@@ -1096,7 +1099,7 @@ function ArrowMenuPopover({
         className={arrowMenuItemClass}
         onClick={(event) => { event.stopPropagation(); onOpenInEditor() }}
       >
-        <ArrowSquareOut size={13} /> Editor
+        <ArrowSquareOut size={13} /> {editorLabel}
       </button>
     </PortaledMenu>
   )

--- a/src/renderer/src/data/settings.ts
+++ b/src/renderer/src/data/settings.ts
@@ -118,6 +118,22 @@ export function isQuickActionValid(qa: QuickAction): boolean {
   return Boolean(qa.label?.trim() && qa.prompt?.trim())
 }
 
+const EDITOR_DISPLAY_LABELS: Record<string, string> = {
+  vscode: 'VS Code',
+  cursor: 'Cursor',
+  windsurf: 'Windsurf',
+  goland: 'GoLand',
+  custom: 'Custom',
+}
+
+/**
+ * Returns the user-facing label for the configured editor (e.g. "GoLand").
+ * Falls back to "Editor" if the configured value is unknown.
+ */
+export function getEditorDisplayLabel(editor: string): string {
+  return EDITOR_DISPLAY_LABELS[editor] ?? 'Editor'
+}
+
 export const SETTINGS_CHANGED_EVENT = 'oc-orchestrator:settings-changed'
 
 export function saveSettings(settings: AppSettings): void {

--- a/src/renderer/src/hooks/useEditorLabel.ts
+++ b/src/renderer/src/hooks/useEditorLabel.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react'
+import { getEditorDisplayLabel, loadSettings, SETTINGS_CHANGED_EVENT } from '../data/settings'
+
+/**
+ * Reactive accessor for the user-facing label of the configured default editor
+ * (e.g. "GoLand", "VS Code", "Custom"). Updates when settings change.
+ */
+export function useEditorLabel(): string {
+  const [label, setLabel] = useState(() => getEditorDisplayLabel(loadSettings().editor))
+
+  useEffect(() => {
+    const onSettingsChanged = () => setLabel(getEditorDisplayLabel(loadSettings().editor))
+    window.addEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged)
+    return () => window.removeEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged)
+  }, [])
+
+  return label
+}


### PR DESCRIPTION
The dashboard arrow menu, row context menu, and transcript Open In dropdown all hard-coded "Editor" as the label. Replace it with the user's configured editor (e.g. "GoLand", "VS Code", "Custom") so the menu reflects what will actually open.

Adds a `useEditorLabel` hook that reads the setting and updates reactively on `SETTINGS_CHANGED_EVENT`, avoiding duplicated state across the three call sites.