### PR TITLE
Cap slash and agent picker height so they stay above the input

### DIFF
--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -1052,7 +1052,7 @@ export const DetailDrawer = memo(function DetailDrawer({
               matchTriggerWidth
               gap={8}
               onDismiss={() => {}}
-              className="rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl"
+              className="rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl max-h-60 overflow-y-auto"
             >
               {matchingCommands.map((item, index) => (
                 <button
@@ -1081,7 +1081,7 @@ export const DetailDrawer = memo(function DetailDrawer({
               matchTriggerWidth
               gap={8}
               onDismiss={() => setAgentPickerDismissed(true)}
-              className="rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl"
+              className="rounded-lg border border-kumo-line bg-kumo-overlay p-1 shadow-xl max-h-60 overflow-y-auto"
             >
               <div className="px-2.5 py-1.5 text-[10px] font-medium text-kumo-subtle uppercase tracking-wide">
                 Agents


### PR DESCRIPTION
The transcript-window pickers had no max-height, so with many matches (typing just \`/\` or \`@\`) the menu grew tall enough to overflow the viewport top. \`PortaledMenu\`'s flip logic then moved it below the input, where it sits behind the bottom of the window and is invisible to the user. As more characters were typed, the match list shrank, the menu fit above again, and the picker reappeared in the right place.

Cap both pickers at \`max-h-60\` with \`overflow-y-auto\`, matching the \`SettingsModal\` prompt picker. The menu now always fits above the textarea, scrolls internally when there are many matches, and never trips the upward-overflow branch in \`PortaledMenu\`'s placement resolver.