### PR TITLE
Resize pasted images to fit Anthropic's 2000px vision limit

### DIFF
--- a/src/renderer/src/hooks/useImageAttachments.ts
+++ b/src/renderer/src/hooks/useImageAttachments.ts
@@ -5,6 +5,15 @@ const ACCEPTED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/web
 const MAX_ATTACHMENT_SIZE = 20 * 1024 * 1024 // 20 MB
 const MAX_ATTACHMENT_COUNT = 10
 
+// Anthropic rejects multi-image requests where any dimension exceeds 2000px.
+// 1568px is Anthropic's documented sweet spot for vision (~1.15 megapixels)
+// and keeps margin under the hard limit.
+const MAX_IMAGE_DIMENSION = 1568
+
+// Animated GIFs lose animation when re-encoded via canvas, so we leave them
+// alone and rely on the upstream size check to reject anything too large.
+const RESIZABLE_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp'])
+
 let nextAttachmentId = 0
 function generateAttachmentId(): string {
   return `att-${Date.now()}-${nextAttachmentId++}`
@@ -17,6 +26,55 @@ function readFileAsDataUrl(file: File): Promise<string> {
     reader.onerror = () => reject(reader.error)
     reader.readAsDataURL(file)
   })
+}
+
+function loadImage(dataUrl: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error('Failed to decode image'))
+    img.src = dataUrl
+  })
+}
+
+/**
+ * Downscale an image data URL if its largest dimension exceeds MAX_IMAGE_DIMENSION.
+ * Returns the original data URL if no resize is needed or if resizing fails.
+ * Re-encodes to JPEG for non-PNG sources to keep payload small.
+ */
+async function maybeResizeDataUrl(
+  dataUrl: string,
+  mime: string
+): Promise<{ dataUrl: string; mime: string }> {
+  if (!RESIZABLE_TYPES.has(mime)) return { dataUrl, mime }
+
+  try {
+    const img = await loadImage(dataUrl)
+    const { naturalWidth: w, naturalHeight: h } = img
+    if (w <= MAX_IMAGE_DIMENSION && h <= MAX_IMAGE_DIMENSION) {
+      return { dataUrl, mime }
+    }
+
+    const scale = MAX_IMAGE_DIMENSION / Math.max(w, h)
+    const targetW = Math.max(1, Math.round(w * scale))
+    const targetH = Math.max(1, Math.round(h * scale))
+
+    const canvas = document.createElement('canvas')
+    canvas.width = targetW
+    canvas.height = targetH
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return { dataUrl, mime }
+    ctx.drawImage(img, 0, 0, targetW, targetH)
+
+    // Preserve PNG transparency; everything else becomes JPEG for smaller payload.
+    const outMime = mime === 'image/png' ? 'image/png' : 'image/jpeg'
+    const quality = outMime === 'image/jpeg' ? 0.9 : undefined
+    const resized = canvas.toDataURL(outMime, quality)
+    return { dataUrl: resized, mime: outMime }
+  } catch {
+    // If anything goes wrong (CORS, decode failure) fall back to the original.
+    return { dataUrl, mime }
+  }
 }
 
 export function useImageAttachments() {
@@ -32,12 +90,16 @@ export function useImageAttachments() {
     if (imageFiles.length === 0) return
 
     const results = await Promise.allSettled(
-      imageFiles.map(async (f): Promise<MessageAttachment> => ({
-        id: generateAttachmentId(),
-        mime: f.type,
-        dataUrl: await readFileAsDataUrl(f),
-        filename: f.name
-      }))
+      imageFiles.map(async (f): Promise<MessageAttachment> => {
+        const rawDataUrl = await readFileAsDataUrl(f)
+        const { dataUrl, mime } = await maybeResizeDataUrl(rawDataUrl, f.type)
+        return {
+          id: generateAttachmentId(),
+          mime,
+          dataUrl,
+          filename: f.name
+        }
+      })
     )
 
     const succeeded = results


### PR DESCRIPTION
## Summary

Pasted screenshots from high-DPI displays routinely exceed 2000px on their longest edge, which Anthropic rejects on multi-image requests with a 400. The error poisons the session because the oversized image sticks in message history and every retry replays it.

## Fix

Downscale anything past 1568px (Anthropic's documented vision sweet spot, ~1.15 megapixels) inside `useImageAttachments` before the data URL reaches the agent.

- PNGs stay PNG so transparency survives.
- JPEG/WebP get re-encoded as JPEG at quality 0.9 for a smaller payload.
- Animated GIFs are left alone because canvas re-encoding kills the animation.
- Decode failures fall back to the original so we never silently drop an image.

Covers paste, drag-drop, and file-picker paths through a single shared helper.

## Repro

1. Take a full-screen screenshot on a Retina/4K display.
2. Paste it into the launch modal or detail drawer prompt.
3. Send.

Before this change: session errors with `image dimensions exceed max allowed size for many-image requests: 2000 pixels` and any retry replays the same bad message.
After: image is downscaled to 1568px max before send and the request goes through.