### PR TITLE
Fix arrow menu Terminal/Editor clicks not registering

### DIFF
--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -45,7 +45,6 @@ function contextFraction(agent: AgentRuntime): number {
   }
   return contextTokens / contextLimit
 }
-import { useDismiss } from '../hooks/useDismiss'
 import {
   Lightning,
   Rocket,
@@ -1305,7 +1304,18 @@ function AgentRow({
   const [inlineValue, setInlineValue] = useState(agent.name)
   const inlineInputRef = useRef<HTMLInputElement>(null)
   const inlineSubmittedRef = useRef(false)
-  const arrowMenu = useDismiss<HTMLTableCellElement>()
+  // Note: don't use useDismiss here — its mousedown outside-click handler
+  // fires before the menu's onClick (the menu is portaled outside this <td>),
+  // closing the menu before clicks on items like Terminal/Editor register.
+  // PortaledMenu has its own portal-aware outside-click handling.
+  const [arrowMenuOpen, setArrowMenuOpen] = useState(false)
+  const arrowMenuRef = useRef<HTMLTableCellElement>(null)
+  const arrowMenu = {
+    open: arrowMenuOpen,
+    toggle: () => setArrowMenuOpen((prev) => !prev),
+    close: () => setArrowMenuOpen(false),
+    containerRef: arrowMenuRef
+  }
 
   useEffect(() => {
     if (!isInlineEditing) return


### PR DESCRIPTION
The row's right-arrow dropdown used useDismiss to manage open state, which
registers a mousedown outside-click handler scoped to the trigger <td>.
The menu items render via PortaledMenu (portaled to document.body), so
clicks on Terminal or Open in Editor are seen as outside the trigger.
useDismiss closed the menu on mousedown before the click event reached
the button, and the onClick never fired.

PortaledMenu already handles portal-aware outside-click dismissal via
onDismiss, so the duplicate handler in useDismiss is both redundant and
harmful. Replace it with plain useState + useRef and let PortaledMenu
own dismissal.
