### PR TITLE
NO-JIRA Move folder count next to name and deepen child indent

### DIFF
--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -1373,7 +1373,7 @@ function AgentRow({
       className={`group cursor-pointer transition-colors border-b border-kumo-line ${rowStateClass} ${flashingClass} ${draggingClass}`}
     >
       {show('agent') && (
-        <td className={`px-3 py-2 overflow-hidden ${indented ? 'pl-7' : ''}`}>
+        <td className={`px-3 py-2 overflow-hidden ${indented ? 'pl-10' : ''}`}>
           <div className="flex items-start gap-1.5">
             {/* Grip is a visual affordance only — the whole row is draggable. */}
             <div
@@ -1807,11 +1807,11 @@ function FolderRowGroup({
                 {folder.name}
               </span>
             )}
-            {/* Spacer pushes count/badges/actions to the right edge */}
-            <div className="flex-1" />
-            <span className="text-[10px] text-kumo-subtle font-mono shrink-0">
-              {childCount}
+            <span className="text-[11px] text-kumo-subtle shrink-0">
+              ({childCount})
             </span>
+            {/* Spacer pushes urgency badge + actions to the right edge */}
+            <div className="flex-1" />
             {urgentCount > 0 && (
               <span
                 className="flex items-center gap-0.5 text-[10px] font-medium text-kumo-danger px-1.5 py-0.5 rounded bg-kumo-danger/10 shrink-0"


### PR DESCRIPTION
Two small folder UX tweaks on top of #186.

## Count next to the folder name

The agent count rendered way out on the right edge, separated from the folder name by a flex spacer. Reads better as `(N)` immediately after the name. The urgency badge and action buttons keep their right-side position.

## Deeper indent for folder children

Folder children were indented by `pl-7` (28px) which barely distinguished them from root agents. `pl-10` (40px) makes the hierarchy obvious at a glance.