### PR TITLE
NO-JIRA Close the launch modal without waiting for the agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out/
 dist/
 .playwright-mcp/
 .DS_Store
+*.tsbuildinfo

--- a/src/__tests__/placeholderLaunch.test.ts
+++ b/src/__tests__/placeholderLaunch.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect } from 'vitest'
+import {
+  AbandonedLaunches,
+  advanceLaunchCleanup,
+  applyLaunchFailure,
+  buildPlaceholderAgent,
+  planArrival,
+  predictPlaceholderName,
+  type LaunchCleanup,
+  type LaunchEvent
+} from '../renderer/src/hooks/placeholderLaunch'
+// The real derivation, not a copy: the placeholder's whole job is predicting the
+// name the store will settle on, so a local reimplementation would drift and the
+// tests would stop saying anything about that prediction.
+import { deriveNameFromPrompt, type LiveAgent } from '../renderer/src/hooks/useAgentStore'
+
+describe('predictPlaceholderName', () => {
+  it('prefers an explicit title, matching upsertAgent for a user-set title', () => {
+    const name = predictPlaceholderName(
+      { directory: '/src/myrepo', title: 'Fix the parser', prompt: 'go fix the parser please' },
+      deriveNameFromPrompt
+    )
+    // A supplied title means isAutoTitle is false, so main keeps the title
+    // verbatim rather than deriving a name from the prompt.
+    expect(name).toBe('Fix the parser')
+  })
+
+  it('derives from the prompt when no title was given', () => {
+    const name = predictPlaceholderName(
+      { directory: '/src/myrepo', prompt: 'Refactor the event bridge' },
+      deriveNameFromPrompt
+    )
+    expect(name).toBe('refactor-the-event-bridge')
+  })
+
+  it('falls back to the project name when given neither', () => {
+    expect(predictPlaceholderName({ directory: '/src/myrepo' }, deriveNameFromPrompt)).toBe('myrepo')
+    expect(predictPlaceholderName({ directory: '/src/myrepo/' }, deriveNameFromPrompt)).toBe('myrepo')
+  })
+
+  it('truncates a long title to the 30 chars main keeps', () => {
+    const name = predictPlaceholderName(
+      { directory: '/src/myrepo', title: 'x'.repeat(50) },
+      deriveNameFromPrompt
+    )
+    expect(name).toBe('x'.repeat(30))
+  })
+
+  it('treats a whitespace-only title as absent, matching what the modal sends', () => {
+    // LaunchModal trims before handing the title over, so a blank one never
+    // reaches main either — the prediction and the real name agree on the prompt.
+    const name = predictPlaceholderName(
+      { directory: '/src/myrepo', title: '   ', prompt: 'do the thing' },
+      deriveNameFromPrompt
+    )
+    expect(name).toBe('do-the-thing')
+  })
+})
+
+describe('buildPlaceholderAgent', () => {
+  it('keys the synthetic session on the launch id so cleanup finds it', () => {
+    const agent = buildPlaceholderAgent('pending-1', { directory: '/src/myrepo' }, deriveNameFromPrompt)
+    expect(agent.id).toBe('pending-1')
+    expect(agent.sessionId).toBe('pending-1')
+    expect(agent.pending).toBe(true)
+    expect(agent.status).toBe('starting')
+  })
+
+  it('shows the prompt as the task summary, truncated', () => {
+    const long = 'a'.repeat(200)
+    const agent = buildPlaceholderAgent('pending-1', { directory: '/src/r', prompt: long }, deriveNameFromPrompt)
+    expect(agent.taskSummary).toHaveLength(120)
+  })
+
+  it('falls back to a placeholder summary with no prompt', () => {
+    const agent = buildPlaceholderAgent('pending-1', { directory: '/src/r' }, deriveNameFromPrompt)
+    expect(agent.taskSummary).toBe('Starting agent...')
+  })
+})
+
+describe('applyLaunchFailure', () => {
+  function placeholder(): LiveAgent {
+    return buildPlaceholderAgent('pending-1', { directory: '/src/r' }, deriveNameFromPrompt)
+  }
+
+  it('surfaces the real cause in the row summary', () => {
+    const agent = placeholder()
+    applyLaunchFailure(agent, 'spawn opencode ENOENT')
+    expect(agent.status).toBe('errored')
+    expect(agent.taskSummary).toBe('Launch failed: spawn opencode ENOENT')
+    expect(agent.lastError?.message).toBe('spawn opencode ENOENT')
+  })
+
+  it('still explains itself when no message was available', () => {
+    const agent = placeholder()
+    applyLaunchFailure(agent, '')
+    expect(agent.taskSummary).toBe('Launch failed')
+  })
+})
+
+describe('AbandonedLaunches', () => {
+  it('keeps recognising a dismissed launch across repeat arrivals', () => {
+    // The arrival handler runs twice per launch (broadcast + post-invoke
+    // fallback). Forgetting after the first call lets the second insert the row
+    // the user dismissed.
+    const abandoned = new AbandonedLaunches()
+    abandoned.abandon('pending-1')
+    expect(abandoned.recognise('pending-1', 'agent-7')).toBe('first')
+    expect(abandoned.recognise('pending-1', 'agent-7')).toBe('again')
+  })
+
+  it('recognises a repeat arrival that carries no launch id', () => {
+    // The fallback path can resolve without a launchId; matching on the agent id
+    // is what catches it.
+    const abandoned = new AbandonedLaunches()
+    abandoned.abandon('pending-1')
+    expect(abandoned.recognise('pending-1', 'agent-7')).toBe('first')
+    expect(abandoned.recognise(undefined, 'agent-7')).toBe('again')
+  })
+
+  it('reports only the first recognition, so teardown fires once', () => {
+    const abandoned = new AbandonedLaunches()
+    abandoned.abandon('pending-1')
+    const outcomes = [
+      abandoned.recognise('pending-1', 'agent-7'),
+      abandoned.recognise('pending-1', 'agent-7'),
+      abandoned.recognise(undefined, 'agent-7')
+    ]
+    expect(outcomes.filter((o) => o === 'first')).toHaveLength(1)
+  })
+
+  it('leaves launches that were never dismissed alone', () => {
+    const abandoned = new AbandonedLaunches()
+    expect(abandoned.recognise('pending-1', 'agent-7')).toBe('live')
+  })
+
+  it('does not treat an unrelated agent as dismissed just because a launch was', () => {
+    // Agents launched elsewhere carry no launchId; matching loosely would discard
+    // them.
+    const abandoned = new AbandonedLaunches()
+    abandoned.abandon('pending-1')
+    expect(abandoned.recognise(undefined, 'agent-9')).toBe('live')
+    expect(abandoned.recognise('pending-2', 'agent-9')).toBe('live')
+  })
+
+  it('tracks several dismissed launches independently', () => {
+    const abandoned = new AbandonedLaunches()
+    abandoned.abandon('pending-1')
+    abandoned.abandon('pending-2')
+    expect(abandoned.recognise('pending-2', 'agent-8')).toBe('first')
+    expect(abandoned.recognise('pending-1', 'agent-7')).toBe('first')
+  })
+
+  it('stops tracking the oldest dismissals rather than growing without bound', () => {
+    const abandoned = new AbandonedLaunches()
+    for (let i = 0; i < 70; i++) abandoned.abandon(`pending-${i}`)
+    // The 64-entry cap evicts oldest-first; recent dismissals are what matter,
+    // since an in-flight launch resolves within seconds.
+    expect(abandoned.recognise('pending-0', 'agent-0')).toBe('live')
+    expect(abandoned.recognise('pending-69', 'agent-69')).toBe('first')
+  })
+})
+
+describe('planArrival', () => {
+  const arrival = { id: 'agent-7', launchId: 'pending-1' }
+
+  /** Every launch is announced twice: once by the broadcast, once by the fallback
+   *  that covers a broadcast arriving before the listener attached. */
+  function bothArrivals(
+    abandoned: AbandonedLaunches,
+    pendingIds: Set<string>
+  ): ReturnType<typeof planArrival>[] {
+    const isPending = (id: string): boolean => pendingIds.has(id)
+    const first = planArrival(arrival, abandoned, isPending)
+    // The store retires the placeholder after the first insert.
+    if (first.action === 'insert' && first.retirePlaceholderId) pendingIds.delete(first.retirePlaceholderId)
+    return [first, planArrival(arrival, abandoned, isPending)]
+  }
+
+  it('inserts once and retires the placeholder exactly once', () => {
+    const [first, second] = bothArrivals(new AbandonedLaunches(), new Set(['pending-1']))
+    expect(first).toEqual({ action: 'insert', retirePlaceholderId: 'pending-1' })
+    // The second arrival must not repeat the destructive retire; the store's own
+    // has-the-agent check keeps it from double-inserting.
+    expect(second).toEqual({ action: 'insert', retirePlaceholderId: undefined })
+  })
+
+  it('drops both arrivals of a dismissed launch, tearing down once', () => {
+    // The regression this guards: recognising the dismissal only once let the
+    // second arrival insert the row the user had just thrown away.
+    const abandoned = new AbandonedLaunches()
+    abandoned.abandon('pending-1')
+    const plans = bothArrivals(abandoned, new Set())
+    expect(plans.every((p) => p.action === 'drop')).toBe(true)
+    expect(plans.filter((p) => p.action === 'drop' && p.teardown)).toHaveLength(1)
+  })
+
+  it('drops a repeat arrival that carries no launch id', () => {
+    const abandoned = new AbandonedLaunches()
+    abandoned.abandon('pending-1')
+    expect(planArrival(arrival, abandoned, () => false)).toEqual({ action: 'drop', teardown: true })
+    expect(planArrival({ id: 'agent-7' }, abandoned, () => false)).toEqual({ action: 'drop', teardown: false })
+  })
+
+  it('does not retire a live agent whose id collides with the launch id', () => {
+    // Main echoes launchId back verbatim; retiring without confirming the row is
+    // a placeholder would wipe a real agent's messages and events.
+    const plan = planArrival(arrival, new AbandonedLaunches(), () => false)
+    expect(plan).toEqual({ action: 'insert', retirePlaceholderId: undefined })
+  })
+
+  it('inserts agents launched elsewhere, which carry no launch id', () => {
+    const plan = planArrival({ id: 'agent-9' }, new AbandonedLaunches(), () => false)
+    expect(plan).toEqual({ action: 'insert', retirePlaceholderId: undefined })
+  })
+})
+
+describe('advanceLaunchCleanup', () => {
+  const worktree = { repoRoot: '/repo', worktreePath: '/repo/../wt-1' }
+
+  /** Replays a launch's events and reports every cleanup effect they produced. */
+  function replay(events: LaunchEvent[]): ReturnType<typeof advanceLaunchCleanup>['effect'][] {
+    let state: LaunchCleanup = { phase: 'live' }
+    const effects: ReturnType<typeof advanceLaunchCleanup>['effect'][] = []
+    for (const event of events) {
+      const result = advanceLaunchCleanup(state, event)
+      state = result.state
+      if (result.effect) effects.push(result.effect)
+    }
+    return effects
+  }
+
+  const created: LaunchEvent = { type: 'worktree-created', worktree }
+  const remove = { type: 'remove-worktree', worktree }
+  const release = { type: 'release-to-main' }
+
+  it('removes the worktree when a dismissed launch then fails', () => {
+    expect(replay([created, { type: 'dismissed' }, { type: 'failed' }])).toEqual([remove])
+  })
+
+  it('removes the worktree when a failed launch is then dismissed', () => {
+    // Same two facts in the other order: the user reads the error, then clears it.
+    expect(replay([created, { type: 'failed' }, { type: 'dismissed' }])).toEqual([remove])
+  })
+
+  it('removes the worktree when the row is dismissed before the worktree exists', () => {
+    // `git worktree add` is slow enough to dismiss during, and the path isn't
+    // known until it returns. Losing the record here was the original leak.
+    expect(replay([{ type: 'dismissed' }, created, { type: 'failed' }])).toEqual([remove])
+  })
+
+  it('leaves the worktree to main when a dismissed launch succeeds', () => {
+    // An agent exists, so removing the directory here would race main's teardown.
+    expect(replay([created, { type: 'dismissed' }, { type: 'succeeded' }])).toEqual([release])
+  })
+
+  it('leaves the worktree to main when dismissal precedes both the path and success', () => {
+    expect(replay([{ type: 'dismissed' }, created, { type: 'succeeded' }])).toEqual([release])
+  })
+
+  it('does nothing while a failed launch still has a row on screen', () => {
+    // The row shows the error and still owns its worktree; the user may retry or
+    // inspect it before dismissing.
+    expect(replay([created, { type: 'failed' }])).toEqual([])
+  })
+
+  it('does nothing when a launch simply succeeds', () => {
+    expect(replay([created, { type: 'succeeded' }])).toEqual([])
+  })
+
+  it('does not remove a worktree that was never created', () => {
+    expect(replay([{ type: 'dismissed' }, { type: 'failed' }])).toEqual([])
+  })
+
+  it('emits at most one effect however many times the outcome is reported', () => {
+    // The arrival handler runs twice per launch, and a failure can follow a
+    // dismissal that already settled ownership.
+    expect(replay([created, { type: 'dismissed' }, { type: 'succeeded' }, { type: 'succeeded' }])).toEqual([release])
+    expect(replay([created, { type: 'dismissed' }, { type: 'failed' }, { type: 'failed' }])).toEqual([remove])
+    expect(replay([created, { type: 'dismissed' }, { type: 'failed' }, { type: 'succeeded' }])).toEqual([remove])
+  })
+
+  it('ignores a repeat dismissal', () => {
+    expect(replay([created, { type: 'dismissed' }, { type: 'dismissed' }, { type: 'failed' }])).toEqual([remove])
+  })
+})

--- a/src/__tests__/terminal.test.ts
+++ b/src/__tests__/terminal.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { shellQuote, appleScriptQuote, buildTerminalTabScript } from '../main/terminal'
+
+describe('shellQuote', () => {
+  it('wraps a plain path in single quotes', () => {
+    expect(shellQuote('/Users/me/repo')).toBe("'/Users/me/repo'")
+  })
+
+  it('keeps spaces inside the quoted word', () => {
+    expect(shellQuote('/Users/me/My Repo')).toBe("'/Users/me/My Repo'")
+  })
+
+  it('closes and reopens the quote around an embedded apostrophe', () => {
+    // Worktrees under a directory like "Will's projects" would otherwise
+    // terminate the shell word early and run the remainder as a command.
+    expect(shellQuote("/Users/me/Will's repo")).toBe("'/Users/me/Will'\\''s repo'")
+  })
+
+  it('leaves shell metacharacters inert', () => {
+    expect(shellQuote('/tmp/a;rm -rf b$(x)`y`')).toBe("'/tmp/a;rm -rf b$(x)`y`'")
+  })
+})
+
+describe('appleScriptQuote', () => {
+  it('wraps a plain string in double quotes', () => {
+    expect(appleScriptQuote('cd /tmp')).toBe('"cd /tmp"')
+  })
+
+  it('escapes backslashes before double quotes so the pair cannot invert', () => {
+    expect(appleScriptQuote('a\\b')).toBe('"a\\\\b"')
+    expect(appleScriptQuote('say "hi"')).toBe('"say \\"hi\\""')
+    expect(appleScriptQuote('a\\"b')).toBe('"a\\\\\\"b"')
+  })
+
+  it('escapes line breaks that would terminate the literal', () => {
+    expect(appleScriptQuote('a\nb')).toBe('"a\\nb"')
+    expect(appleScriptQuote('a\r\nb')).toBe('"a\\r\\nb"')
+  })
+})
+
+describe('buildTerminalTabScript', () => {
+  it('cds into the path and targets the front window tab', () => {
+    const script = buildTerminalTabScript('/Users/me/repo')
+    expect(script).toContain('tell application "Terminal"')
+    expect(script).toContain('keystroke "t" using command down')
+    expect(script).toContain('do script "cd \'/Users/me/repo\'" in selected tab of front window')
+  })
+
+  it('opens a window instead when Terminal has none', () => {
+    expect(buildTerminalTabScript('/tmp')).toContain('if (count of windows) is 0 then')
+  })
+
+  it('opens its own window when no tab appeared, rather than erroring', () => {
+    // The cd must never land in whichever tab is selected — it may be running an
+    // interactive program. Erroring instead would let a late tab and the caller's
+    // fallback both open, giving the user two.
+    const script = buildTerminalTabScript('/tmp')
+    const elseBranch = script.slice(script.indexOf('if madeTab then'))
+    const fallbackLine = elseBranch
+      .split('\n')
+      .find((line, i, lines) => i > lines.findIndex((l) => l.trim() === 'else') && line.includes('do script'))
+    expect(fallbackLine).toBeDefined()
+    // A bare `do script` opens a window; the tab form qualifies it with a target.
+    expect(fallbackLine).not.toContain('in selected tab')
+  })
+
+  it('waits for Terminal to come forward before sending the keystroke', () => {
+    // An early keystroke opens a tab in whatever app still holds focus.
+    const script = buildTerminalTabScript('/tmp')
+    const frontCheck = script.indexOf('if frontmost then')
+    const keystroke = script.indexOf('keystroke "t"')
+    expect(frontCheck).toBeGreaterThan(-1)
+    expect(frontCheck).toBeLessThan(keystroke)
+  })
+
+  it('survives a path containing both an apostrophe and a backslash', () => {
+    const script = buildTerminalTabScript("/tmp/o'brien\\x")
+    // Single quote closed/reopened for the shell, backslash doubled for AppleScript.
+    expect(script).toContain('cd \'/tmp/o\'\\\\\'\'brien\\\\x\'')
+  })
+})

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -9,6 +9,7 @@ import { isWorktreeStrategy, type ProjectSettings } from '../shared/project'
 import { notificationService, type NotifiableEventType } from './services/notification-service'
 import { subscribeFileChanges, unsubscribeFileChanges } from './services/file-watcher'
 import { getAppVersion } from './version'
+import { buildTerminalTabScript } from './terminal'
 
 interface Attachment {
   id?: string
@@ -89,6 +90,7 @@ export function registerIpcHandlers(): void {
     model?: string
     modelVariant?: string
     attachments?: Attachment[]
+    launchId?: string
   }) => {
     try {
       const handle = await agentController.launchAgent(options)
@@ -370,6 +372,7 @@ export function registerIpcHandlers(): void {
     title?: string
     model?: string
     modelVariant?: string
+    launchId?: string
   }) => {
     try {
       const handle = await agentController.importSession(options)
@@ -993,13 +996,25 @@ export function registerIpcHandlers(): void {
     try {
       const terminal = options.terminal || 'default'
 
-      if (process.platform === 'darwin') {
-        const app = terminal === 'default' ? 'Terminal' : terminal
-        await run('open', ['-a', app, options.path])
-      } else {
+      if (process.platform !== 'darwin') {
         await run('xdg-open', [options.path])
+        return { ok: true }
       }
 
+      const app = terminal === 'default' ? 'Terminal' : terminal
+
+      if (app === 'Terminal') {
+        try {
+          await run('osascript', ['-e', buildTerminalTabScript(options.path)])
+          return { ok: true }
+        } catch (error) {
+          // Most likely Accessibility permission is not granted yet. A new
+          // window still beats doing nothing.
+          console.warn('[ipc] Terminal.app tab failed, opening a window instead:', error)
+        }
+      }
+
+      await run('open', ['-a', app, options.path])
       return { ok: true }
     } catch (error) {
       logIpcError('shell:open-terminal', error)

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -6,6 +6,7 @@ import { notificationService, type NotifiableEventType } from './notification-se
 import { database } from './database'
 import { workspaceManager } from './workspace-manager'
 import { leaseRegistry } from './lease-registry'
+import { getForkedTitle } from '../../shared/project'
 
 interface Attachment {
   id?: string
@@ -70,17 +71,6 @@ function sanitizeSlug(value: string, fallback: string): string {
     .slice(0, 50)
 
   return sanitized || fallback
-}
-
-/** Match OpenCode's fork title style so imported sessions stay easy to scan. */
-function getForkedTitle(title: string): string {
-  const match = title.match(/^(.*?)\s*\(fork(?:\s*#(\d+))?\)\s*$/)
-  if (match) {
-    const base = match[1].trim()
-    const num = match[2] ? parseInt(match[2], 10) + 1 : 2
-    return `${base} (fork #${num})`
-  }
-  return `${title} (fork)`
 }
 
 /** Subset of OpenCode's session.messages response used for import seeding. */
@@ -331,8 +321,11 @@ class AgentController {
     model?: string
     modelVariant?: string
     attachments?: Attachment[]
+    /** Renderer-generated correlation id. Echoed back on `agent:launched` so the
+     *  renderer can retire the optimistic placeholder row it created up front. */
+    launchId?: string
   }): Promise<AgentHandle> {
-    const { directory, prompt, title, model, modelVariant, attachments } = options
+    const { directory, prompt, title, model, modelVariant, attachments, launchId } = options
 
     // Ensure we have a runtime for this directory
     const runtime = await this.ensureBridgeForDirectory(directory)
@@ -405,7 +398,8 @@ class AgentController {
       isWorktree: handle.isWorktree,
       workspaceName: handle.workspaceName,
       prompt: prompt ?? '',
-      title: sessionTitle
+      title: sessionTitle,
+      launchId
     })
 
     // Only send the initial prompt if one was provided
@@ -1268,8 +1262,10 @@ class AgentController {
     title?: string
     model?: string
     modelVariant?: string
+    /** Renderer-generated correlation id. See `launchAgent`. */
+    launchId?: string
   }): Promise<AgentHandle> {
-    const { sourceSessionId, sourceDirectory, targetDirectory, title, model, modelVariant } = options
+    const { sourceSessionId, sourceDirectory, targetDirectory, title, model, modelVariant, launchId } = options
 
     // Target runtime hosts the new session. Source runtime only reads the
     // transcript. It may be the same runtime, but we do not rely on that.
@@ -1354,7 +1350,8 @@ class AgentController {
       isWorktree: handle.isWorktree,
       workspaceName: handle.workspaceName,
       prompt: '',
-      title: sessionTitle
+      title: sessionTitle,
+      launchId
     })
 
     // Seed the new session with the prior conversation as a single synthetic

--- a/src/main/terminal.ts
+++ b/src/main/terminal.ts
@@ -1,0 +1,70 @@
+/** Wraps a path for use inside a POSIX single-quoted shell word. */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`
+}
+
+/**
+ * Escapes a string for embedding in an AppleScript string literal. Line breaks
+ * are escaped too — a raw one would terminate the literal and break the script.
+ */
+export function appleScriptQuote(value: string): string {
+  return `"${value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')}"`
+}
+
+/**
+ * Builds AppleScript that opens `path` in a new Terminal.app tab of the
+ * existing window, falling back to a new window when Terminal has none open.
+ *
+ * Terminal.app's dictionary has no "create tab" command — `do script` on its
+ * own always spawns a window. The only way to get a tab is the Cmd+T keystroke
+ * via System Events, which needs Accessibility permission. The script opens a
+ * window itself if the tab never appears, so it only throws when System Events
+ * refuses outright; callers should treat that as a signal to fall back to plain
+ * `open -a`.
+ */
+export function buildTerminalTabScript(path: string): string {
+  const command = appleScriptQuote(`cd ${shellQuote(path)}`)
+  return `
+tell application "Terminal"
+  activate
+  if (count of windows) is 0 then
+    do script ${command}
+  else
+    set tabsBefore to count of tabs of front window
+    -- Wait for Terminal to actually come forward rather than guessing a delay:
+    -- a keystroke sent early lands in whichever app still holds focus, leaving a
+    -- stray tab in the user's editor or browser.
+    set isFront to false
+    repeat 20 times
+      if frontmost then
+        set isFront to true
+        exit repeat
+      end if
+      delay 0.05
+    end repeat
+    if not isFront then error "Terminal did not come to the front"
+    tell application "System Events" to keystroke "t" using command down
+    set madeTab to false
+    repeat 40 times
+      if (count of tabs of front window) > tabsBefore then
+        set madeTab to true
+        exit repeat
+      end if
+      delay 0.05
+    end repeat
+    if madeTab then
+      do script ${command} in selected tab of front window
+    else
+      -- Never cd in whatever tab was already selected: it could be sitting in
+      -- vim or a psql session. Open a window instead, and do it here rather than
+      -- erroring out — a late-arriving tab plus a caller-side fallback would
+      -- leave the user with two.
+      do script ${command}
+    end if
+  end if
+end tell`
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -21,6 +21,7 @@ interface ImportSessionOptions {
   title?: string
   model?: string
   modelVariant?: string
+  launchId?: string
 }
 
 interface AgentPayload {
@@ -38,7 +39,7 @@ interface AgentPayload {
 
 const api = {
   // ── Agent Operations ──
-  launchAgent: (options: { directory: string; prompt?: string; title?: string; model?: string; modelVariant?: string; attachments?: Attachment[] }): Promise<IpcResult> =>
+  launchAgent: (options: { directory: string; prompt?: string; title?: string; model?: string; modelVariant?: string; attachments?: Attachment[]; launchId?: string }): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:launch', options),
 
   sendMessage: (agentId: string, text: string, agent?: string, attachments?: Attachment[]): Promise<IpcResult> =>
@@ -302,7 +303,7 @@ const api = {
     return () => ipcRenderer.removeListener('opencode:event', handler)
   },
 
-  onAgentLaunched: (callback: (data: { id: string; runtimeId: string; sessionId: string; directory: string; projectName: string; branchName: string; isWorktree: boolean; workspaceName: string; prompt: string; title: string }) => void) => {
+  onAgentLaunched: (callback: (data: { id: string; runtimeId: string; sessionId: string; directory: string; projectName: string; branchName: string; isWorktree: boolean; workspaceName: string; prompt: string; title: string; launchId?: string }) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, data: unknown) => callback(data as never)
     ipcRenderer.on('agent:launched', handler)
     return () => ipcRenderer.removeListener('agent:launched', handler)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect } from 'react'
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
 import { TopBar } from './components/TopBar'
 import { InterruptBanner } from './components/InterruptBanner'
 import { FilterBar, matchesFilter, EMPTY_FILTER, cycleFilter, loadPersistedFilter, persistFilter, loadPersistedSearch, persistSearch, type FilterState, type StatusFilter } from './components/FilterBar'
@@ -10,6 +10,7 @@ import { SessionBrowser } from './components/SessionBrowser'
 import { SettingsModal, type SettingsTabId } from './components/SettingsModal'
 import { CommandPalette } from './components/CommandPalette'
 import { ModelPickerModal } from './components/ModelPickerModal'
+import { getForkedTitle } from '../../shared/project'
 import { McpModal } from './components/McpModal'
 import { WorkspaceView } from './components/WorkspaceView'
 import { useAgentStore, setViewedAgentId, type LiveAgent } from './hooks/useAgentStore'
@@ -147,6 +148,13 @@ export function App() {
       setDrawerScrollRequest(null)
     }
   }, [])
+  // A launch settles long after the render that started it, so it must not yank
+  // the drawer away from an agent the user has since clicked into. Counts
+  // selection changes rather than comparing ids: A→B→A is still a deliberate
+  // choice, and an id comparison would read it as untouched.
+  const selectionEpochRef = useRef(0)
+  useEffect(() => { selectionEpochRef.current += 1 }, [selectedAgentId])
+
   const [showLaunchModal, setShowLaunchModal] = useState(false)
   const [showSettings, setShowSettings] = useState(false)
   const [settingsTab, setSettingsTab] = useState<SettingsTabId>('general')
@@ -436,7 +444,8 @@ export function App() {
         } : undefined,
         compacting: agent.compacting,
         contextTokens: agent.contextTokens,
-        contextLimit: agent.contextLimit
+        contextLimit: agent.contextLimit,
+        pending: agent.pending
       }
     })
   }, [store.agents, tick, getMessagesForSession])
@@ -569,6 +578,17 @@ export function App() {
 
     return agents
   }, [displayAgents, filter, searchQuery, sortColumn, sortDirection])
+
+  /**
+   * Rows that can actually be opened. Placeholder launches have no session, so
+   * selecting one would open an empty drawer and fire per-agent IPC against an
+   * id main has never seen. FleetTable blocks clicking them; this list keeps
+   * keyboard navigation and the command palette in step.
+   */
+  const selectableAgents = useMemo(
+    () => filteredAgents.filter((agent) => !agent.pending),
+    [filteredAgents]
+  )
 
   // Look up in displayAgents first (preferred — includes latest derived fields),
   // but fall back to the full unfiltered list so notification-driven navigation
@@ -780,6 +800,13 @@ export function App() {
     [store.agents]
   )
 
+  /** Worktree/repo path for the drawer. Only live agents have one — demo-mode
+   *  agents exist solely as AgentRuntime rows. */
+  const selectedWorkspacePath = useMemo(
+    () => (selectedAgentId ? findLiveAgent(selectedAgentId)?.directory : undefined),
+    [selectedAgentId, findLiveAgent]
+  )
+
   // ── Helper: find permission for agent ──
   const findPermissionForAgent = useCallback(
     (agentId: string) => {
@@ -841,11 +868,15 @@ export function App() {
     const liveAgent = findLiveAgent(agentId)
     if (!liveAgent) return
 
-    const confirmMessage = liveAgent.isWorktree
-      ? `Remove ${liveAgent.name}? This will clean up the worktree and remove the agent from the UI.`
-      : `Remove ${liveAgent.name} from the UI?`
+    // Confirming a placeholder's removal would be asking about an agent that
+    // never existed. Any worktree it did create is cleaned up by the store.
+    if (!liveAgent.pending) {
+      const confirmMessage = liveAgent.isWorktree
+        ? `Remove ${liveAgent.name}? This will clean up the worktree and remove the agent from the UI.`
+        : `Remove ${liveAgent.name} from the UI?`
 
-    if (!window.confirm(confirmMessage)) return
+      if (!window.confirm(confirmMessage)) return
+    }
 
     storeRemoveAgent(agentId)
 
@@ -1142,7 +1173,14 @@ Then give me a brief summary of what the previous session was working on and whe
   }, [findLiveAgent])
 
   // ── Launch modal actions ──
-  const handleLaunch = useCallback(async (
+  /**
+   * Runs a launch to completion. Cold launches spend seconds spawning a runtime
+   * and creating a worktree, so this never blocks the modal — the caller kicks
+   * it off against an already-visible placeholder row (`launchId`) and failures
+   * land on that row instead of propagating.
+   */
+  const runLaunch = useCallback(async (
+    launchId: string,
     directory: string,
     prompt?: string,
     title?: string,
@@ -1155,6 +1193,12 @@ Then give me a brief summary of what the previous session was working on and whe
     labelIds?: string[]
   ) => {
     let launchDirectory = directory
+    // Auto-selecting the new agent is only welcome if the user hasn't moved on
+    // while the launch ran.
+    const epochAtStart = selectionEpochRef.current
+    const selectNewAgent = (agentId: string): void => {
+      if (selectionEpochRef.current === epochAtStart) setSelectedAgentId(agentId)
+    }
 
     if (worktreeStrategy === 'new-worktree') {
       const repoRootResult = await window.api.getRepoRoot(directory)
@@ -1185,6 +1229,9 @@ Then give me a brief summary of what the previous session was working on and whe
       }
 
       launchDirectory = worktreeResult.data.worktreePath
+      // The worktree exists but no agent owns it yet. Record it so dismissing a
+      // failed launch takes the directory with it.
+      store.noteLaunchWorktree(launchId, repoRootResult.data, launchDirectory)
     }
 
     // If importing a session, create a fresh session in the new directory and
@@ -1198,7 +1245,8 @@ Then give me a brief summary of what the previous session was working on and whe
         targetDirectory: launchDirectory,
         title: title || undefined,
         model: model && model !== 'auto' ? model : undefined,
-        modelVariant: modelVariant || undefined
+        modelVariant: modelVariant || undefined,
+        launchId
       })
 
       if (!importResult?.ok || !importResult.data) {
@@ -1206,7 +1254,8 @@ Then give me a brief summary of what the previous session was working on and whe
       }
 
       const agentId = importResult.data.id
-      setSelectedAgentId(agentId)
+      store.reconcileLaunch({ ...importResult.data, launchId })
+      selectNewAgent(agentId)
 
       if (labelIds?.length) {
         for (const labelId of labelIds) store.toggleLabel(agentId, labelId)
@@ -1235,16 +1284,21 @@ Then give me a brief summary of what the previous session was working on and whe
     // If the prompt needs special handling, launch without it — the
     // runtime must exist before we can route commands or agent mentions.
     const launchPrompt = needsPostLaunchHandling ? undefined : (prompt || undefined)
-    const result = await store.launchAgent(launchDirectory, launchPrompt, title, model, modelVariant, attachments)
+    const result = await store.launchAgent(launchDirectory, launchPrompt, title, model, modelVariant, attachments, launchId)
 
     if (!result?.ok) {
-      throw new Error('Failed to launch agent')
+      throw new Error(result?.error || 'Failed to launch agent')
     }
 
-    if (!result.data) return
+    if (!result.data) {
+      // Nothing to reconcile the placeholder against — drop it rather than
+      // leaving a row stuck at 'starting' forever.
+      store.discardLaunch(launchId)
+      return
+    }
 
     const agentId = (result.data as { id: string }).id
-    setSelectedAgentId(agentId)
+    selectNewAgent(agentId)
 
     if (labelIds?.length) {
       for (const labelId of labelIds) store.toggleLabel(agentId, labelId)
@@ -1290,9 +1344,45 @@ Then give me a brief summary of what the previous session was working on and whe
     }
   }, [store])
 
+  /**
+   * Entry point for the launch modal. Inserts the placeholder row and returns
+   * immediately so the modal can close, then drives the launch in the
+   * background. Deliberately not async — awaiting it would reintroduce the
+   * lockout it exists to remove.
+   */
+  const handleLaunch = useCallback((
+    directory: string,
+    prompt?: string,
+    title?: string,
+    model?: string,
+    modelVariant?: string,
+    worktreeStrategy?: string,
+    attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>,
+    freshWorktreeConfig?: FreshWorktreeConfig,
+    importSession?: ImportSessionConfig,
+    labelIds?: string[]
+  ) => {
+    const launchId = store.beginLaunch({
+      directory,
+      prompt,
+      // Imports with no explicit title get main's fork title, so predict the
+      // same string — otherwise the row renames itself on arrival.
+      title: title || (importSession?.sessionTitle ? getForkedTitle(importSession.sessionTitle) : undefined)
+    })
+
+    void runLaunch(
+      launchId, directory, prompt, title, model, modelVariant, worktreeStrategy,
+      attachments, freshWorktreeConfig, importSession, labelIds
+    ).catch((error) => {
+      console.error('[App] Launch failed:', error)
+      store.failLaunch(launchId, error instanceof Error ? error.message : String(error))
+    })
+  }, [store, runLaunch])
+
   const handleQuickLaunch = useCallback(async () => {
     if (quickLaunching) return
     setQuickLaunching(true)
+    let launchId: string | undefined
     try {
       const homeResult = await window.api.getHomeDirectory()
       if (!homeResult.ok || !homeResult.data) {
@@ -1301,14 +1391,28 @@ Then give me a brief summary of what the previous session was working on and whe
       }
 
       const title = `QuickStart-${Math.random().toString(36).slice(2, 10)}`
-      const result = await store.launchAgent(homeResult.data, undefined, title, 'auto')
+      // Same cold-start latency as the modal path, so show a placeholder row
+      // instead of leaving the button spinning with nothing on screen. Once the
+      // row is up the button is free again — progress is visible there.
+      launchId = store.beginLaunch({ directory: homeResult.data, title })
+      setQuickLaunching(false)
+      const epochAtStart = selectionEpochRef.current
+      const result = await store.launchAgent(homeResult.data, undefined, title, 'auto', undefined, undefined, launchId)
 
-      if (!result?.ok || !result.data) return
+      if (!result?.ok) {
+        store.failLaunch(launchId, result?.error || 'Failed to launch agent')
+        return
+      }
+      if (!result.data) {
+        store.discardLaunch(launchId)
+        return
+      }
 
       const agentId = (result.data as { id: string }).id
-      setSelectedAgentId(agentId)
+      if (selectionEpochRef.current === epochAtStart) setSelectedAgentId(agentId)
     } catch (error) {
       console.error('[App] Quick launch failed:', error)
+      if (launchId) store.failLaunch(launchId, error instanceof Error ? error.message : String(error))
     } finally {
       setQuickLaunching(false)
     }
@@ -1431,14 +1535,14 @@ Then give me a brief summary of what the previous session was working on and whe
 
       // J/K -> navigate rows
       if (event.key === 'j' || event.key === 'k') {
-        const currentIndex = filteredAgents.findIndex((agent) => agent.id === selectedAgentId)
+        const currentIndex = selectableAgents.findIndex((agent) => agent.id === selectedAgentId)
         let nextIndex: number
         if (event.key === 'j') {
-          nextIndex = currentIndex < filteredAgents.length - 1 ? currentIndex + 1 : 0
+          nextIndex = currentIndex < selectableAgents.length - 1 ? currentIndex + 1 : 0
         } else {
-          nextIndex = currentIndex > 0 ? currentIndex - 1 : filteredAgents.length - 1
+          nextIndex = currentIndex > 0 ? currentIndex - 1 : selectableAgents.length - 1
         }
-        setSelectedAgentId(filteredAgents[nextIndex]?.id ?? null)
+        setSelectedAgentId(selectableAgents[nextIndex]?.id ?? null)
         return
       }
 
@@ -1479,7 +1583,7 @@ Then give me a brief summary of what the previous session was working on and whe
         return
       }
     },
-    [filteredAgents, selectedAgentId, showLaunchModal, showSettings, showCommandPalette, showSessionBrowser, workspaceAgentId, findPermissionForAgent, store, handleQuickLaunch]
+    [filteredAgents, selectableAgents, selectedAgentId, showLaunchModal, showSettings, showCommandPalette, showSessionBrowser, workspaceAgentId, findPermissionForAgent, store, handleQuickLaunch]
   )
 
   useEffect(() => {
@@ -1618,6 +1722,7 @@ Then give me a brief summary of what the previous session was working on and whe
       {selectedAgent && (
         <DetailDrawer
           agent={selectedAgent}
+          workspacePath={selectedWorkspacePath}
           messages={selectedMessages}
           permission={selectedPermission}
           question={selectedQuestion}
@@ -1734,7 +1839,7 @@ Then give me a brief summary of what the previous session was working on and whe
 
       {showCommandPalette && (
         <CommandPalette
-          agents={displayAgents.map((agent) => ({
+          agents={displayAgents.filter((agent) => !agent.pending).map((agent) => ({
             id: agent.id,
             name: agent.name,
             projectName: agent.projectName,

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -31,6 +31,7 @@ import {
 import type { AgentRuntime, Message, LabelDefinition, LabelColorKey } from '../types'
 import { formatBranchLabel } from '../types'
 import type { LivePermission, LiveQuestion } from '../hooks/useAgentStore'
+import { UNRESOLVED_MODEL_LABEL } from '../hooks/placeholderLaunch'
 import { loadSettings, SETTINGS_CHANGED_EVENT, isQuickActionValid, type QuickAction, type QuickActionIcon } from '../data/settings'
 import { useImageAttachments } from '../hooks/useImageAttachments'
 import { useEditorLabel } from '../hooks/useEditorLabel'
@@ -170,6 +171,9 @@ export interface AgentConfigItem {
 
 interface DetailDrawerProps {
   agent: AgentRuntime
+  /** Absolute path to the agent's workspace (worktree or repo root). Lives on
+   *  the store's LiveAgent rather than AgentRuntime, so it's passed in. */
+  workspacePath?: string
   messages: Message[]
   permission?: LivePermission | null
   question?: LiveQuestion | null
@@ -225,6 +229,7 @@ interface DetailDrawerProps {
 
 export const DetailDrawer = memo(function DetailDrawer({
   agent,
+  workspacePath,
   messages,
   permission,
   question,
@@ -846,11 +851,11 @@ export const DetailDrawer = memo(function DetailDrawer({
               <span className="truncate">
                 {agent.projectName} · {formatBranchLabel(agent) || agent.taskSummary.slice(0, 40)}
               </span>
-
+              {workspacePath && <CopyPathButton path={workspacePath} />}
             </div>
           </div>
           <div className="flex items-center gap-1.5 shrink-0">
-            {onChangeModel ? (
+            {onChangeModel && agent.model !== UNRESOLVED_MODEL_LABEL ? (
               <button
                 onClick={onChangeModel}
                 className="text-[10px] text-kumo-subtle font-mono whitespace-nowrap hover:text-kumo-default transition-colors"
@@ -1667,6 +1672,51 @@ function QuestionCard({
         )}
       </div>
     </div>
+  )
+}
+
+/** Copies an absolute path to the clipboard, for pasting into a shell or Finder. */
+function CopyPathButton({ path }: { path: string }) {
+  // The counter restarts the timer on a repeat click; keying the effect on
+  // `result` alone would let a second copy inherit the first one's deadline and
+  // flash the checkmark for a few milliseconds.
+  const [{ result, attempt }, setState] = useState<{ result: 'idle' | 'copied' | 'failed'; attempt: number }>({ result: 'idle', attempt: 0 })
+  const setResult = (next: 'idle' | 'copied' | 'failed'): void =>
+    setState((prev) => ({ result: next, attempt: prev.attempt + 1 }))
+
+  useEffect(() => {
+    if (result === 'idle') return
+    const timer = setTimeout(() => setResult('idle'), 1500)
+    return () => clearTimeout(timer)
+  }, [result, attempt])
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(path)
+      setResult('copied')
+    } catch (error) {
+      // A denied clipboard permission looks identical to success unless the icon
+      // changes, and the user would paste stale content without knowing.
+      console.error('[DetailDrawer] Failed to copy path:', error)
+      setResult('failed')
+    }
+  }, [path])
+
+  const label = result === 'copied' ? 'Path copied' : result === 'failed' ? 'Copy failed' : 'Copy workspace path'
+
+  return (
+    <button
+      onClick={handleCopy}
+      aria-label={label}
+      className={`shrink-0 w-4 h-4 flex items-center justify-center rounded transition-colors ${
+        result === 'failed'
+          ? 'text-kumo-danger'
+          : 'text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill'
+      }`}
+      title={result === 'idle' ? `Copy path\n${path}` : label}
+    >
+      {result === 'copied' ? <Check size={10} /> : result === 'failed' ? <XCircle size={10} /> : <Copy size={10} />}
+    </button>
   )
 }
 

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -25,6 +25,7 @@ import {
 import type { AgentRuntime, AgentFolder, LabelDefinition, LabelColorKey, ColumnKey, ColumnWidths, SortDirection } from '../types'
 import { formatBranchLabel, isUrgent, labelSortKey, compareStatusPriority, ALL_COLUMNS } from '../types'
 import { isRecentlyAttached } from '../hooks/useAgentStore'
+import { UNRESOLVED_MODEL_LABEL } from '../hooks/placeholderLaunch'
 import { StatusBadge } from './StatusBadge'
 import { LabelDropdown } from './LabelDropdown'
 import { PortaledMenu } from './PortaledMenu'
@@ -750,46 +751,61 @@ export function FleetTable({
 
   // Render helper so we can reuse the AgentRow wiring for both root and
   // folder-nested agents. Keeps the JSX below readable.
-  const renderAgentRowFn = (agent: AgentRuntime, indented: boolean) => (
-    <AgentRow
-      key={agent.id}
-      agent={agent}
-      selected={agent.id === selectedId}
-      visibleColumns={visibleColumns}
-      indented={indented}
-      isDragging={dragItem?.kind === 'agent' && dragItem.id === agent.id}
-      isAnyDragActive={dragItem !== null}
-      onMouseDownStartDrag={(e) => beginDragPress('agent', agent.id, agent.name, e)}
-      suppressNextClickRef={suppressNextClick}
-      onSelect={() => onSelect(agent.id)}
-      onJumpToLastUserMessage={() => onSelect(agent.id, 'last-user-message')}
-      onContextMenu={(event) => handleContextMenu(event, agent.id)}
-      onApprove={onApprove ? () => onApprove(agent.id) : undefined}
-      onReply={onReply ? () => onReply(agent.id) : undefined}
-      onStop={onStop ? () => onStop(agent.id) : undefined}
-      onOpen={onOpen ? () => onOpen(agent.id) : () => onSelect(agent.id)}
-      onRemove={onRemove ? () => onRemove(agent.id) : undefined}
-      onChangeModel={onChangeModel ? () => onChangeModel(agent.id) : undefined}
-      onToggleLabel={onToggleLabel ? (labelId: string) => onToggleLabel(agent.id, labelId) : undefined}
-      onClearLabels={onClearLabels ? () => onClearLabels(agent.id) : undefined}
-      onReplaceLabel={onReplaceLabel ? (oldId: string, newId: string) => onReplaceLabel(agent.id, oldId, newId) : undefined}
-      allLabels={allLabels}
-      onCreateLabel={onCreateLabel}
-      onDeleteLabel={onDeleteLabel}
-      onEditPrLink={() => setPrLinkState({ agentId: agent.id, currentUrl: agent.prUrl ?? '' })}
-      onRemovePrLink={onSetPrUrl ? () => onSetPrUrl(agent.id, null) : undefined}
-      onOpenTerminal={onOpenTerminal ? () => onOpenTerminal(agent.id) : undefined}
-      onOpenInEditor={onOpenInEditor ? () => onOpenInEditor(agent.id) : undefined}
-      isInlineEditing={inlineEditId === agent.id}
-      onStartInlineEdit={() => setInlineEditId(agent.id)}
-      onInlineRename={(newName) => {
-        onRename?.(agent.id, newName)
-        setInlineEditId(null)
-      }}
-      onCancelInlineEdit={() => setInlineEditId(null)}
-      onLabelDropdownChange={handleLabelDropdownChange}
-    />
-  )
+  const renderAgentRowFn = (agent: AgentRuntime, indented: boolean) => {
+    // A placeholder row stands in for a launch that hasn't produced a session
+    // yet, so its `pending-N` id means nothing to the main process. Actions are
+    // withheld here so no nested control can route around the gate; AgentRow
+    // additionally hides the controls that would otherwise render dead. The
+    // store refuses pending ids too (getMutableAgent) — that is the real
+    // guarantee, and this layer is what keeps the row from looking operable.
+    // Dismiss is the deliberate exception and rides `onRemove`.
+    const pending = agent.pending === true
+    const noop = (): void => {}
+
+    return (
+      <AgentRow
+        key={agent.id}
+        agent={agent}
+        selected={agent.id === selectedId}
+        visibleColumns={visibleColumns}
+        indented={indented}
+        isDragging={dragItem?.kind === 'agent' && dragItem.id === agent.id}
+        isAnyDragActive={dragItem !== null}
+        onMouseDownStartDrag={pending ? undefined : (e) => beginDragPress('agent', agent.id, agent.name, e)}
+        suppressNextClickRef={suppressNextClick}
+        onSelect={pending ? noop : () => onSelect(agent.id)}
+        onJumpToLastUserMessage={pending ? noop : () => onSelect(agent.id, 'last-user-message')}
+        onContextMenu={pending ? noop : (event) => handleContextMenu(event, agent.id)}
+        onApprove={onApprove && !pending ? () => onApprove(agent.id) : undefined}
+        onReply={onReply && !pending ? () => onReply(agent.id) : undefined}
+        onStop={onStop && !pending ? () => onStop(agent.id) : undefined}
+        onOpen={pending ? noop : onOpen ? () => onOpen(agent.id) : () => onSelect(agent.id)}
+        // Withheld for pending rows so RowActions' Trash button doesn't duplicate
+        // the Dismiss link; the row wires Dismiss to onDismiss instead.
+        onRemove={onRemove && !pending ? () => onRemove(agent.id) : undefined}
+        onDismiss={onRemove && pending ? () => onRemove(agent.id) : undefined}
+        onChangeModel={onChangeModel && !pending ? () => onChangeModel(agent.id) : undefined}
+        onToggleLabel={onToggleLabel && !pending ? (labelId: string) => onToggleLabel(agent.id, labelId) : undefined}
+        onClearLabels={onClearLabels && !pending ? () => onClearLabels(agent.id) : undefined}
+        onReplaceLabel={onReplaceLabel && !pending ? (oldId: string, newId: string) => onReplaceLabel(agent.id, oldId, newId) : undefined}
+        allLabels={allLabels}
+        onCreateLabel={onCreateLabel}
+        onDeleteLabel={onDeleteLabel}
+        onEditPrLink={pending ? noop : () => setPrLinkState({ agentId: agent.id, currentUrl: agent.prUrl ?? '' })}
+        onRemovePrLink={onSetPrUrl && !pending ? () => onSetPrUrl(agent.id, null) : undefined}
+        onOpenTerminal={onOpenTerminal && !pending ? () => onOpenTerminal(agent.id) : undefined}
+        onOpenInEditor={onOpenInEditor && !pending ? () => onOpenInEditor(agent.id) : undefined}
+        isInlineEditing={inlineEditId === agent.id}
+        onStartInlineEdit={pending ? noop : () => setInlineEditId(agent.id)}
+        onInlineRename={(newName) => {
+          if (!pending) onRename?.(agent.id, newName)
+          setInlineEditId(null)
+        }}
+        onCancelInlineEdit={() => setInlineEditId(null)}
+        onLabelDropdownChange={handleLabelDropdownChange}
+      />
+    )
+  }
 
   if (agents.length === 0 && folders.length === 0) {
     return (
@@ -1242,6 +1258,7 @@ function AgentRow({
   onStop,
   onOpen,
   onRemove,
+  onDismiss,
   onChangeModel,
   onToggleLabel,
   onClearLabels,
@@ -1281,6 +1298,9 @@ function AgentRow({
   onStop?: () => void
   onOpen?: () => void
   onRemove?: () => void
+  /** Removal for a pending row. Separate from onRemove so the two never render
+   *  side by side as competing labels for the same operation. */
+  onDismiss?: () => void
   onChangeModel?: () => void
   onToggleLabel?: (labelId: string) => void
   onClearLabels?: () => void
@@ -1301,6 +1321,9 @@ function AgentRow({
   const urgent = isUrgent(agent)
   const isStale = !!agent.blockedSince
   const flashing = isRecentlyAttached(agent.id)
+  // A placeholder row has no session behind it yet. Its actions are withheld by
+  // the caller (see renderAgentRowFn); this flag only drives presentation.
+  const isPending = agent.pending === true
   const [inlineValue, setInlineValue] = useState(agent.name)
   const inlineInputRef = useRef<HTMLInputElement>(null)
   const inlineSubmittedRef = useRef(false)
@@ -1380,7 +1403,7 @@ function AgentRow({
       }}
       onClick={onSelect}
       onContextMenu={onContextMenu}
-      className={`group cursor-pointer transition-colors border-b border-kumo-line ${rowStateClass} ${flashingClass} ${draggingClass}`}
+      className={`group transition-colors border-b border-kumo-line ${isPending ? 'cursor-default' : 'cursor-pointer'} ${rowStateClass} ${flashingClass} ${draggingClass}`}
     >
       {show('agent') && (
         <td className={`px-3 py-2 overflow-hidden ${indented ? 'pl-10' : ''}`}>
@@ -1405,10 +1428,13 @@ function AgentRow({
                 />
               ) : (
                 <div
-                  onClick={(event) => { event.stopPropagation(); onStartInlineEdit() }}
-                  className={`font-semibold text-kumo-strong rounded px-1.5 py-0.5 -mx-1.5 -my-0.5 cursor-text outline outline-1 outline-transparent transition-[outline-color] truncate ${
-                    isAnyDragActive ? '' : 'hover:outline-kumo-subtle/40'
-                  }`}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    onStartInlineEdit()
+                  }}
+                  className={`font-semibold text-kumo-strong rounded px-1.5 py-0.5 -mx-1.5 -my-0.5 outline outline-1 outline-transparent transition-[outline-color] truncate ${
+                    isPending ? 'cursor-default' : 'cursor-text'
+                  } ${isAnyDragActive || isPending ? '' : 'hover:outline-kumo-subtle/40'}`}
                   title={agent.name}
                 >
                   {agent.name}
@@ -1448,7 +1474,24 @@ function AgentRow({
       )}
       {show('task') && (
         <td className="px-3 py-2 truncate text-kumo-default">
-          {agent.taskSummary && (
+          {isPending ? (
+            // A placeholder has no transcript to jump to. Dismiss is offered
+            // unconditionally, not just on failure — it's the row's only exit,
+            // so a launch that never settles must not become unremovable.
+            <div className="flex items-center gap-2 min-w-0">
+              <span className="truncate" title={agent.lastError?.message || agent.taskSummary}>
+                {agent.taskSummary}
+              </span>
+              {onDismiss && (
+                <button
+                  onClick={(event) => { event.stopPropagation(); onDismiss() }}
+                  className="shrink-0 text-[10px] text-kumo-subtle hover:text-kumo-default underline"
+                >
+                  Dismiss
+                </button>
+              )}
+            </div>
+          ) : agent.taskSummary && (
             <span
               className="cursor-pointer hover:text-kumo-strong"
               title={`${agent.taskSummary}\n\nClick to jump to your last message`}
@@ -1471,7 +1514,14 @@ function AgentRow({
       )}
       {show('model') && (
         <td className="px-3 py-2 overflow-hidden">
-          {agent.model && agent.model !== 'starting...' && (
+          {agent.model && (agent.model === UNRESOLVED_MODEL_LABEL ? (
+            // There's nothing to switch to until the model is known — on a
+            // placeholder because no session exists, on a real agent until the
+            // first getConfig lands.
+            <span className="font-mono text-[10px] px-1.5 py-0.5 text-kumo-muted max-w-full truncate block">
+              {agent.model}
+            </span>
+          ) : (
             <button
               onClick={(event) => { event.stopPropagation(); onChangeModel?.() }}
               className="font-mono text-[10px] px-1.5 py-0.5 bg-kumo-fill rounded text-kumo-subtle hover:bg-kumo-fill-hover hover:text-kumo-default transition-colors max-w-full truncate block cursor-pointer"
@@ -1479,7 +1529,7 @@ function AgentRow({
             >
               {agent.model}
             </button>
-          )}
+          ))}
         </td>
       )}
       {show('context') && (
@@ -1522,7 +1572,7 @@ function AgentRow({
                 <GitPullRequest size={13} weight="bold" />
               </button>
             </Tooltip>
-          ) : (
+          ) : !isPending && (
             <button
               onClick={(event) => { event.stopPropagation(); onEditPrLink?.() }}
               className="w-6 h-6 flex items-center justify-center rounded text-kumo-subtle/40 hover:text-kumo-subtle hover:bg-kumo-fill transition-colors cursor-pointer"
@@ -1531,31 +1581,39 @@ function AgentRow({
               <GitPullRequest size={13} />
             </button>
           )}
-          <button
-            onClick={(event) => { event.stopPropagation(); onContextMenu(event) }}
-            className="w-6 h-6 flex items-center justify-center rounded text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill transition-colors cursor-pointer"
-            title="Agent actions"
-          >
-            <GearSix size={13} />
-          </button>
+          {!isPending && (
+            <button
+              onClick={(event) => { event.stopPropagation(); onContextMenu(event) }}
+              className="w-6 h-6 flex items-center justify-center rounded text-kumo-subtle hover:text-kumo-default hover:bg-kumo-fill transition-colors cursor-pointer"
+              title="Agent actions"
+            >
+              <GearSix size={13} />
+            </button>
+          )}
         </div>
       </td>
       <td
         ref={arrowMenu.containerRef}
-        className="p-0 border-l border-kumo-line bg-kumo-fill/50 cursor-pointer hover:bg-kumo-fill transition-colors relative"
-        onClick={(event) => { event.stopPropagation(); arrowMenu.toggle() }}
+        className={`p-0 border-l border-kumo-line bg-kumo-fill/50 relative ${
+          isPending ? '' : 'cursor-pointer hover:bg-kumo-fill transition-colors'
+        }`}
+        onClick={isPending ? undefined : (event) => { event.stopPropagation(); arrowMenu.toggle() }}
       >
-        <div className="w-full flex items-center justify-center py-2 text-kumo-subtle group-hover:text-kumo-default">
-          <ArrowRight size={14} weight="bold" />
-        </div>
-        <ArrowMenuPopover
-          open={arrowMenu.open}
-          triggerRef={arrowMenu.containerRef}
-          onDismiss={arrowMenu.close}
-          onOpen={() => { arrowMenu.close(); onOpen?.() }}
-          onOpenTerminal={() => { arrowMenu.close(); onOpenTerminal?.() }}
-          onOpenInEditor={() => { arrowMenu.close(); onOpenInEditor?.() }}
-        />
+        {!isPending && (
+          <>
+            <div className="w-full flex items-center justify-center py-2 text-kumo-subtle group-hover:text-kumo-default">
+              <ArrowRight size={14} weight="bold" />
+            </div>
+            <ArrowMenuPopover
+              open={arrowMenu.open}
+              triggerRef={arrowMenu.containerRef}
+              onDismiss={arrowMenu.close}
+              onOpen={() => { arrowMenu.close(); onOpen?.() }}
+              onOpenTerminal={() => { arrowMenu.close(); onOpenTerminal?.() }}
+              onOpenInEditor={() => { arrowMenu.close(); onOpenInEditor?.() }}
+            />
+          </>
+        )}
       </td>
     </tr>
   )
@@ -1607,8 +1665,9 @@ function RowActions({
         <Square size={12} weight="fill" />
       </button>
       <button
-        className={destructiveButton}
+        className={`${destructiveButton} ${onRemove ? '' : 'invisible'}`}
         title="Remove"
+        disabled={!onRemove}
         onClick={(event) => { event.stopPropagation(); onRemove?.() }}
       >
         <Trash size={12} />

--- a/src/renderer/src/components/LaunchModal.tsx
+++ b/src/renderer/src/components/LaunchModal.tsx
@@ -447,7 +447,11 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
 
   // Project dropdown outside-click handling is delegated to PortaledMenu.
 
-  const persistProjectSettings = async (dir: string) => {
+  /**
+   * `refreshList` is skipped when launching — the modal is already unmounting,
+   * so reloading the project dropdown would only set state on a dead component.
+   */
+  const persistProjectSettings = async (dir: string, refreshList = true) => {
     try {
       const repoRootResult = await window.api.getRepoRoot(dir)
       const canonicalRoot = repoRootResult.ok && repoRootResult.data ? repoRootResult.data : dir
@@ -460,14 +464,19 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
       })
       if (!settingsResult.ok) console.warn('Failed to persist worktree settings:', settingsResult.error)
       await window.api.setPreference('launch:last-directory', canonicalRoot)
-      await loadProjects()
+      if (refreshList) await loadProjects()
     } catch (err) {
       console.warn('Failed to persist project settings:', err)
     }
   }
 
-  const handleLaunch = async () => {
-    if (!directory.trim() || dirError || validating) return
+  /**
+   * Closes the modal as soon as the launch is handed off. The launch itself
+   * takes seconds on a cold runtime; the fleet table shows a placeholder row
+   * for it in the meantime, and reports any failure there.
+   */
+  const handleLaunch = () => {
+    if (!directory.trim() || dirError || validating || launching) return
     if (activeTab === 'import' && !selectedSession) return
     setLaunching(true)
     try {
@@ -487,9 +496,11 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
             }
           : undefined
 
+      // Trimmed: main keeps a whitespace-only title verbatim, which would name
+      // the agent with a run of spaces.
       const effectiveTitle = activeTab === 'import'
         ? (importName.trim() || selectedSession?.title || undefined)
-        : (title || undefined)
+        : (title.trim() || undefined)
 
       const effectivePrompt = activeTab === 'import'
         ? (importPrompt.trim() || undefined)
@@ -501,9 +512,9 @@ export function LaunchModal({ onClose, onLaunch, onSelectDirectory, onValidateDi
 
       const effectiveLabels = labelIds.length > 0 ? labelIds : undefined
 
-      await persistProjectSettings(directory.trim())
       const effectiveModelVariant = selectedEffort === 'auto' ? undefined : selectedEffort
-      await onLaunch(directory, effectivePrompt, effectiveTitle, model, effectiveModelVariant, effectiveStrategy, effectiveAttachments, freshConfig, importConfig, effectiveLabels)
+      onLaunch(directory, effectivePrompt, effectiveTitle, model, effectiveModelVariant, effectiveStrategy, effectiveAttachments, freshConfig, importConfig, effectiveLabels)
+      void persistProjectSettings(directory.trim(), false)
 
       clearAttachments()
       onClose()

--- a/src/renderer/src/hooks/placeholderLaunch.ts
+++ b/src/renderer/src/hooks/placeholderLaunch.ts
@@ -1,0 +1,270 @@
+import type { LiveAgent } from './useAgentStore'
+
+/**
+ * A launch takes seconds to produce an agent — spawning `opencode serve` and
+ * creating a worktree — so the fleet table shows an optimistic row in the
+ * meantime. This module owns the shape and naming of that row, and the
+ * bookkeeping for launches the user dismissed while they were still in flight.
+ *
+ * Kept free of store state so the reconciliation rules can be tested directly:
+ * they are ordering-sensitive and the ways they can go wrong (a stale row left
+ * at 'starting', a dismissed launch reappearing) are invisible until they bite.
+ */
+
+/** Placeholder ids are namespaced so they can never collide with main's `agent-N`. */
+export const PLACEHOLDER_ID_PREFIX = 'pending-'
+
+/**
+ * Stands in for a model that isn't known yet — both on a placeholder and on a
+ * real agent between arrival and the first `getConfig`. Exported because the UI
+ * has to suppress the model picker while it's showing, and a copy of the literal
+ * in the table would silently stop matching if this changed.
+ */
+export const UNRESOLVED_MODEL_LABEL = 'starting...'
+
+export interface PlaceholderOptions {
+  directory: string
+  prompt?: string
+  title?: string
+}
+
+export function projectNameFromDirectory(directory: string): string {
+  return directory.split('/').filter(Boolean).pop() ?? directory
+}
+
+/**
+ * Predicts the name the real agent will arrive with, so the row doesn't visibly
+ * rename itself on arrival. An explicit title wins outright; a prompt-only launch
+ * gets an auto-title that the store derives a name from. With neither, main mints
+ * `<slug>-N` from a counter this side can't see, so the project name is the
+ * closest available guess and a rename is unavoidable.
+ */
+export function predictPlaceholderName(
+  options: PlaceholderOptions,
+  deriveNameFromPrompt: (prompt: string) => string
+): string {
+  const title = options.title?.trim()
+  if (title) return title.slice(0, 30)
+  const prompt = options.prompt?.trim()
+  if (prompt) return deriveNameFromPrompt(prompt)
+  return projectNameFromDirectory(options.directory)
+}
+
+export function buildPlaceholderAgent(
+  launchId: string,
+  options: PlaceholderOptions,
+  deriveNameFromPrompt: (prompt: string) => string
+): LiveAgent {
+  const projectName = projectNameFromDirectory(options.directory)
+  return {
+    id: launchId,
+    runtimeId: '',
+    // Placeholders have no session. Reusing the launch id keeps the per-session
+    // maps keyed consistently so removeAgentState() cleans up after itself.
+    sessionId: launchId,
+    directory: options.directory,
+    name: predictPlaceholderName(options, deriveNameFromPrompt),
+    projectName,
+    branchName: '',
+    isWorktree: false,
+    workspaceName: projectName,
+    taskSummary: options.prompt?.trim().slice(0, 120) || 'Starting agent...',
+    status: 'starting',
+    labelIds: [],
+    model: UNRESOLVED_MODEL_LABEL,
+    prUrl: null,
+    lastActivityAt: Date.now(),
+    cost: 0,
+    tokens: { input: 0, output: 0 },
+    pending: true
+  }
+}
+
+/**
+ * Turns a placeholder into an errored row rather than letting it vanish, so the
+ * user can read why the launch never produced an agent.
+ */
+export function applyLaunchFailure(agent: LiveAgent, message: string): void {
+  agent.status = 'errored'
+  agent.taskSummary = message ? `Launch failed: ${message}` : 'Launch failed'
+  agent.lastActivityAt = Date.now()
+  agent.lastError = {
+    name: 'LaunchError',
+    message,
+    sessionId: agent.sessionId,
+    occurredAt: Date.now()
+  }
+}
+
+/** Keeps the newest `limit` entries, evicting oldest-first. */
+class BoundedSet {
+  private items = new Set<string>()
+
+  constructor(private readonly limit: number) {}
+
+  add(value: string): void {
+    // Re-adding must refresh position, or a repeatedly-seen id could age out
+    // while still relevant.
+    this.items.delete(value)
+    this.items.add(value)
+    if (this.items.size > this.limit) {
+      const oldest = this.items.values().next()
+      if (!oldest.done) this.items.delete(oldest.value)
+    }
+  }
+
+  has(value: string): boolean {
+    return this.items.has(value)
+  }
+}
+
+/**
+ * Tracks launches dismissed mid-flight. The launch itself can't be recalled —
+ * main is already spawning a runtime — so the agent it eventually produces has
+ * to be recognised and discarded on arrival instead of appearing as a row the
+ * user explicitly threw away.
+ *
+ * Recognition is deliberately not consume-once. A single launch reaches the
+ * arrival handler twice: once from the `agent:launched` broadcast and once from
+ * the fallback that covers a broadcast arriving before the listener attached. A
+ * check that forgot the launch after the first call would let the second insert
+ * the very row the user dismissed.
+ */
+export class AbandonedLaunches {
+  private launchIds = new BoundedSet(64)
+  private agentIds = new BoundedSet(64)
+
+  abandon(launchId: string): void {
+    this.launchIds.add(launchId)
+  }
+
+  /**
+   * Classifies an arrival against the dismissed launches. Matches on the resolved
+   * agent id too, so repeat arrivals are recognised even when they carry no
+   * launchId. The 'first'/'again' split lets the caller clean up main-side state
+   * exactly once.
+   */
+  recognise(launchId: string | undefined, agentId: string): 'live' | 'first' | 'again' {
+    if (this.agentIds.has(agentId)) return 'again'
+    if (launchId && this.launchIds.has(launchId)) {
+      this.agentIds.add(agentId)
+      return 'first'
+    }
+    return 'live'
+  }
+}
+
+/** What to do with an incoming launched-agent notification. */
+export type ArrivalPlan =
+  /** The user dismissed this launch. `teardown` asks main to remove the agent it
+   *  created, and is set on only one of the repeat arrivals. */
+  | { action: 'drop'; teardown: boolean }
+  /** Insert the agent, first retiring the placeholder at `retirePlaceholderId`. */
+  | { action: 'insert'; retirePlaceholderId?: string }
+
+/**
+ * Decides what an arrival means. Split out from the store because the same launch
+ * arrives twice — once on the `agent:launched` broadcast, once from the fallback
+ * covering a broadcast that beat the listener — and getting that wrong either
+ * duplicates the row or resurrects a dismissed one, neither of which is visible
+ * from reading the handler.
+ */
+export function planArrival(
+  payload: { id: string; launchId?: string },
+  abandoned: AbandonedLaunches,
+  isPendingPlaceholder: (id: string) => boolean
+): ArrivalPlan {
+  const recognised = abandoned.recognise(payload.launchId, payload.id)
+  if (recognised !== 'live') {
+    return { action: 'drop', teardown: recognised === 'first' }
+  }
+
+  // Main echoes the launchId back verbatim, so confirm the row really is this
+  // renderer's placeholder before retiring it — a colliding id would otherwise
+  // wipe a live agent's messages and events.
+  const retirePlaceholderId =
+    payload.launchId && isPendingPlaceholder(payload.launchId) ? payload.launchId : undefined
+  return { action: 'insert', retirePlaceholderId }
+}
+
+export interface WorktreeRef {
+  repoRoot: string
+  worktreePath: string
+}
+
+/**
+ * A launch's worktree ownership, tracked separately from the placeholder row
+ * because the row can disappear while the launch is still running.
+ */
+export type LaunchCleanup =
+  /** Launch in flight, row on screen. */
+  | { phase: 'live'; worktree?: WorktreeRef }
+  /** Row dismissed, launch still in flight. Outcome decides who cleans up. */
+  | { phase: 'dismissed'; worktree?: WorktreeRef }
+  /** Launch failed, row still on screen showing why. */
+  | { phase: 'failed'; worktree?: WorktreeRef }
+  /** Ownership settled; nothing further to do. */
+  | { phase: 'settled' }
+
+export type LaunchEvent =
+  | { type: 'worktree-created'; worktree: WorktreeRef }
+  | { type: 'dismissed' }
+  | { type: 'failed' }
+  | { type: 'succeeded' }
+
+export type LaunchEffect =
+  /** No agent will ever own this directory; delete it. */
+  | { type: 'remove-worktree'; worktree: WorktreeRef }
+  /** An agent exists, so main owns the worktree and removes it with the agent. */
+  | { type: 'release-to-main' }
+
+/**
+ * Decides who deletes a worktree created for a launch, given that the four
+ * things that settle it — the worktree appearing, the user dismissing the row,
+ * the launch failing, and the launch succeeding — arrive in any order.
+ *
+ * This lives here as a reducer rather than as branches in the store because the
+ * rule is not obvious and has been wrong three times: the dismiss handler can't
+ * decide anything on its own, since a dismissal usually lands while the launch
+ * is still running and only the outcome says whether an agent will ever exist to
+ * own the directory. Dismissing during `git worktree add` is the case that keeps
+ * getting missed — the row is gone before the path is even known, so the record
+ * has to outlive it.
+ */
+export function advanceLaunchCleanup(
+  state: LaunchCleanup,
+  event: LaunchEvent
+): { state: LaunchCleanup; effect?: LaunchEffect } {
+  if (state.phase === 'settled') return { state }
+
+  switch (event.type) {
+    case 'worktree-created':
+      // Recorded whatever the row is doing, including after a dismissal — this is
+      // the ordering that used to strand the directory.
+      return { state: { ...state, worktree: event.worktree } }
+
+    case 'dismissed':
+      // A dismissal after the failure is the last word: the launch already
+      // resolved without producing an agent, so nothing else will claim it.
+      if (state.phase === 'failed') {
+        return state.worktree
+          ? { state: { phase: 'settled' }, effect: { type: 'remove-worktree', worktree: state.worktree } }
+          : { state: { phase: 'settled' } }
+      }
+      return { state: { phase: 'dismissed', worktree: state.worktree } }
+
+    case 'failed':
+      // While the row is still on screen it keeps its worktree: the user can see
+      // the failure and may yet dismiss it.
+      if (state.phase !== 'dismissed') return { state: { phase: 'failed', worktree: state.worktree } }
+      return state.worktree
+        ? { state: { phase: 'settled' }, effect: { type: 'remove-worktree', worktree: state.worktree } }
+        : { state: { phase: 'settled' } }
+
+    case 'succeeded':
+      // An agent exists either way, so main owns the directory from here.
+      return state.phase === 'dismissed'
+        ? { state: { phase: 'settled' }, effect: { type: 'release-to-main' } }
+        : { state: { phase: 'settled' } }
+  }
+}

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -9,6 +9,18 @@ import type {
   PermissionRequest as PermissionRequestPayload
 } from '../types/api'
 import { ensureProvidersLoaded, invalidateProviderCache, lookupContextLimit, subscribeToContextLimits } from './useModelOptions'
+import {
+  AbandonedLaunches,
+  applyLaunchFailure,
+  buildPlaceholderAgent,
+  planArrival,
+  PLACEHOLDER_ID_PREFIX,
+  UNRESOLVED_MODEL_LABEL,
+  advanceLaunchCleanup,
+  type LaunchCleanup,
+  type LaunchEvent,
+  type PlaceholderOptions
+} from './placeholderLaunch'
 
 // Deduplication cache for provider error toasts per runtime to avoid flicker.
 const toastDedup = new Map<string, { sig: string; expiresAt: number }>()
@@ -122,6 +134,15 @@ export interface LiveAgent {
    *  compaction but session.compacted hasn't arrived yet. Drives the spinner and
    *  disabled states on the Compact buttons so the user can see progress. */
   compacting?: boolean
+  /** True for a placeholder row created the instant the user hits Launch, before
+   *  main has spawned a runtime and created a session. It has no server-side
+   *  counterpart, so callers must not send IPC for it. Retired by
+   *  handleAgentLaunched once the real agent arrives, or flipped to 'errored'
+   *  in place if the launch fails. */
+  pending?: boolean
+  /** Worktree created for a placeholder before the launch reached main. If the
+   *  launch then fails, no agent will ever own this directory, so dismissing the
+   *  row has to clean it up. */
 }
 
 export interface LiveAgentError {
@@ -435,7 +456,7 @@ function persistAgentMeta(agentId: string, meta: { displayName?: string; taskSum
  * Derive a short kebab-case agent name from a prompt string.
  * Takes the first few meaningful words (up to 30 chars).
  */
-function deriveNameFromPrompt(prompt: string): string {
+export function deriveNameFromPrompt(prompt: string): string {
   const cleaned = prompt
     .replace(/[^a-zA-Z0-9\s-]/g, '')
     .trim()
@@ -2060,7 +2081,122 @@ function processEvent(payload: OpenCodeEventPayload): void {
 /** Number of recent messages to pre-load when a session is resumed. */
 const RESUME_MESSAGE_LIMIT = 10
 
+/**
+ * Inserts an optimistic row so the fleet table shows the launch immediately.
+ * Cold launches spend seconds spawning `opencode serve` and creating a worktree
+ * before main can broadcast `agent:launched`; without this the dashboard looks
+ * like nothing happened.
+ */
+function createPlaceholderAgent(options: PlaceholderOptions): string {
+  const launchId = `${PLACEHOLDER_ID_PREFIX}${crypto.randomUUID()}`
+  launchCleanups.set(launchId, { phase: 'live' })
+  state.agents.set(launchId, buildPlaceholderAgent(launchId, options, deriveNameFromPrompt))
+  emit({ agents: true })
+  return launchId
+}
+
+/**
+ * Looks up an agent that is safe to mutate and persist. A placeholder's
+ * `pending-N` id means nothing to the main process, so mutators resolve through
+ * this rather than `state.agents.get` — the guard then can't be bypassed by a UI
+ * control that forgot to check `pending`.
+ *
+ * Reach for this in any new mutator that persists or sends IPC. It doesn't fit
+ * everywhere: the session operations (sendMessage, abortAgent, resetSession) need
+ * their own early return because they key off the id rather than the record, and
+ * the event handlers that mutate on incoming SSE must accept any agent.
+ */
+function getMutableAgent(agentId: string): LiveAgent | undefined {
+  const agent = state.agents.get(agentId)
+  if (!agent || agent.pending) return undefined
+  return agent
+}
+
+const abandonedLaunches = new AbandonedLaunches()
+
+/**
+ * Worktree ownership per launch. Keyed by launchId rather than held on the agent
+ * because a dismissal removes the row while the launch is still running, and the
+ * record has to outlive it. See `advanceLaunchCleanup` for the rule.
+ */
+const launchCleanups = new Map<string, LaunchCleanup>()
+
+function advanceLaunch(launchId: string, event: LaunchEvent): void {
+  const current = launchCleanups.get(launchId)
+  if (!current) return
+
+  const { state: next, effect } = advanceLaunchCleanup(current, event)
+  if (next.phase === 'settled') launchCleanups.delete(launchId)
+  else launchCleanups.set(launchId, next)
+
+  if (effect?.type === 'remove-worktree') {
+    void window.api?.removeWorktree(effect.worktree).then((result) => {
+      if (!result?.ok) console.error('[useAgentStore] failed to remove abandoned launch worktree:', result?.error)
+    })
+  }
+}
+
+/** Drops a placeholder row and everything keyed off its synthetic session. */
+function discardPlaceholderAgent(launchId: string): void {
+  const agent = state.agents.get(launchId)
+  if (!agent?.pending) return
+
+  abandonedLaunches.abandon(launchId)
+  advanceLaunch(launchId, { type: 'dismissed' })
+
+  removeAgentState(launchId)
+  emit({ agents: true, messages: true })
+}
+
+/**
+ * Records a worktree created for a launch, so no outcome strands the directory.
+ * Deliberately not gated on the row still existing — a dismissal during
+ * `git worktree add` is exactly when the path needs remembering.
+ */
+function notePlaceholderWorktree(launchId: string, repoRoot: string, worktreePath: string): void {
+  advanceLaunch(launchId, { type: 'worktree-created', worktree: { repoRoot, worktreePath } })
+}
+
+/**
+ * Keeps a failed placeholder on screen as an errored row so the user sees why
+ * the launch never produced an agent, rather than the row silently vanishing.
+ */
+function failPlaceholderAgent(launchId: string, message: string): void {
+  advanceLaunch(launchId, { type: 'failed' })
+
+  const agent = state.agents.get(launchId)
+  if (!agent?.pending) return
+  applyLaunchFailure(agent, message)
+  emit({ agents: true })
+}
+
 function handleAgentLaunched(payload: AgentLaunchedPayload): void {
+  const plan = planArrival(payload, abandonedLaunches, (id) => state.agents.get(id)?.pending === true)
+
+  if (plan.action === 'drop') {
+    // Removing the agent is main's job — it owns the worktree. The renderer just
+    // declines to show a row for a launch the user threw away.
+    if (plan.teardown) {
+      // The launch succeeded, so main owns the worktree and removeAgent takes it
+      // down with the agent. Release this side's claim to avoid a second removal.
+      if (payload.launchId) advanceLaunch(payload.launchId, { type: 'succeeded' })
+      void window.api?.removeAgent(payload.id).then((result) => {
+        // The one failure here that matters: main keeps the worktree on disk and
+        // nothing in the UI refers to it any more.
+        if (!result?.ok) console.error('[handleAgentLaunched] failed to remove dismissed agent:', result?.error)
+      })
+    }
+    return
+  }
+
+  // Retire the optimistic row before inserting the real one so the table never
+  // shows both.
+  if (plan.retirePlaceholderId) {
+    // The real agent takes over the placeholder's worktree along with its row.
+    advanceLaunch(plan.retirePlaceholderId, { type: 'succeeded' })
+    removeAgentState(plan.retirePlaceholderId)
+  }
+
   const existingMsgs = state.messages.get(payload.sessionId)
   console.debug(`[handleAgentLaunched] id=${payload.id} session=${payload.sessionId.slice(-8)} existingMsgs=${existingMsgs?.length ?? 'none'} agentExists=${state.agents.has(payload.id)}`)
   upsertAgent(payload)
@@ -2097,7 +2233,7 @@ function handleAgentLaunched(payload: AgentLaunchedPayload): void {
       if (!agent || agent.configuredModel) return
       const formatted = formatModelName(config.model)
       agent.configuredModel = formatted
-      if (agent.model === 'starting...') {
+      if (agent.model === UNRESOLVED_MODEL_LABEL) {
         agent.model = formatted
         emit({ agents: true })
       }
@@ -2220,7 +2356,7 @@ function upsertAgent(payload: AgentLaunchedPayload, initialStatus?: AgentStatus)
     taskSummary: payload.taskSummary || existingAgent?.taskSummary || (hasPrompt ? payload.prompt.slice(0, 120) : 'Waiting for prompt...'),
     status: initialStatus ?? existingAgent?.status ?? (hasPrompt ? 'running' : 'idle'),
     labelIds: existingAgent?.labelIds ?? [],
-    model: existingAgent?.model ?? 'starting...',
+    model: existingAgent?.model ?? UNRESOLVED_MODEL_LABEL,
     configuredModel: existingAgent?.configuredModel,
     prUrl: existingAgent?.prUrl ?? payload.prUrl ?? null,
     lastActivityAt: existingAgent?.lastActivityAt ?? Date.now(),
@@ -3121,9 +3257,35 @@ export function useAgentStore() {
     [questionsVersion]
   )
 
-  const launchAgent = useCallback(async (directory: string, prompt?: string, title?: string, model?: string, modelVariant?: string, attachments?: MessageAttachment[]) => {
+  const beginLaunch = useCallback((options: { directory: string; prompt?: string; title?: string }) => {
+    return createPlaceholderAgent(options)
+  }, [])
+
+  const failLaunch = useCallback((launchId: string, message: string) => {
+    failPlaceholderAgent(launchId, message)
+  }, [])
+
+  const discardLaunch = useCallback((launchId: string) => {
+    discardPlaceholderAgent(launchId)
+  }, [])
+
+  const noteLaunchWorktree = useCallback((launchId: string, repoRoot: string, worktreePath: string) => {
+    notePlaceholderWorktree(launchId, repoRoot, worktreePath)
+  }, [])
+
+  /**
+   * Adds a launched agent the `agent:launched` broadcast never delivered — it can
+   * fire before the listener is attached. Without this the placeholder sits at
+   * 'starting' forever and the real agent never appears at all.
+   */
+  const reconcileLaunch = useCallback((payload: AgentLaunchedPayload) => {
+    if (state.agents.has(payload.id)) return
+    handleAgentLaunched(payload)
+  }, [])
+
+  const launchAgent = useCallback(async (directory: string, prompt?: string, title?: string, model?: string, modelVariant?: string, attachments?: MessageAttachment[], launchId?: string) => {
     if (!window.api) return
-    const result = await window.api.launchAgent({ directory, prompt, title, model, modelVariant, attachments })
+    const result = await window.api.launchAgent({ directory, prompt, title, model, modelVariant, attachments, launchId })
     if (!result.ok) {
       console.error('Failed to launch agent:', result.error)
     } else if (result.data) {
@@ -3142,7 +3304,8 @@ export function useAgentStore() {
           isWorktree: data.isWorktree ?? false,
           workspaceName: data.workspaceName ?? (directory.split('/').pop() ?? directory),
           prompt: data.prompt ?? prompt ?? '',
-          title: data.title ?? title ?? (prompt ? prompt.slice(0, 80) : projectSlug)
+          title: data.title ?? title ?? (prompt ? prompt.slice(0, 80) : projectSlug),
+          launchId
         })
       }
     }
@@ -3151,6 +3314,8 @@ export function useAgentStore() {
 
   const sendMessage = useCallback(async (agentId: string, text: string, agentConfig?: string, attachments?: MessageAttachment[], taskSummaryOverride?: string) => {
     if (!window.api) return
+    // No session exists to send to yet.
+    if (state.agents.get(agentId)?.pending) return
 
     // Queue the message if the agent is still stopping — it will be dispatched
     // automatically once the abort completes.
@@ -3412,6 +3577,8 @@ export function useAgentStore() {
 
   const abortAgent = useCallback(async (agentId: string) => {
     if (!window.api) return
+    // Nothing running to abort. Dismiss is the placeholder's cancel.
+    if (state.agents.get(agentId)?.pending) return
 
     // Optimistically set 'stopping' so the UI reflects intent immediately
     const agent = state.agents.get(agentId)
@@ -3454,11 +3621,20 @@ export function useAgentStore() {
 
   const resetSession = useCallback(async (agentId: string, prompt?: string) => {
     if (!window.api) return
+    // No session exists to reset yet.
+    if (state.agents.get(agentId)?.pending) return
     return window.api.resetSession(agentId, prompt)
   }, [])
 
   const removeAgent = useCallback((agentId: string) => {
     if (!window.api) return
+
+    // Main has no agent under a placeholder's id, so dismissing one takes the
+    // placeholder-specific path rather than the agent teardown below.
+    if (state.agents.get(agentId)?.pending) {
+      discardPlaceholderAgent(agentId)
+      return { ok: true }
+    }
 
     removeAgentState(agentId)
     fileChangesHydrated.delete(agentId)
@@ -3561,7 +3737,7 @@ export function useAgentStore() {
   }, [messagesVersion])
 
   const setAgentModel = useCallback((agentId: string, modelPath: string, variant?: string) => {
-    const agent = state.agents.get(agentId)
+    const agent = getMutableAgent(agentId)
     if (!agent) return
     const formatted = formatModelName(modelPath)
     agent.model = formatted
@@ -3571,7 +3747,7 @@ export function useAgentStore() {
   }, [])
 
   const renameAgent = useCallback((agentId: string, newName: string) => {
-    const agent = state.agents.get(agentId)
+    const agent = getMutableAgent(agentId)
     if (!agent) return
     agent.name = newName
     agent.autoNamed = false
@@ -3580,7 +3756,7 @@ export function useAgentStore() {
   }, [])
 
   const toggleLabel = useCallback((agentId: string, labelId: string) => {
-    const agent = state.agents.get(agentId)
+    const agent = getMutableAgent(agentId)
     if (!agent) return
     const has = agent.labelIds.includes(labelId)
     agent.labelIds = has
@@ -3592,7 +3768,7 @@ export function useAgentStore() {
   }, [])
 
   const clearLabels = useCallback((agentId: string) => {
-    const agent = state.agents.get(agentId)
+    const agent = getMutableAgent(agentId)
     if (!agent) return
     agent.labelIds = []
     agent.lastActivityAt = Date.now()
@@ -3601,7 +3777,7 @@ export function useAgentStore() {
   }, [])
 
   const replaceLabel = useCallback((agentId: string, oldLabelId: string, newLabelId: string) => {
-    const agent = state.agents.get(agentId)
+    const agent = getMutableAgent(agentId)
     if (!agent) return
     agent.labelIds = agent.labelIds.map((id) => id === oldLabelId ? newLabelId : id)
     agent.lastActivityAt = Date.now()
@@ -3614,7 +3790,10 @@ export function useAgentStore() {
    * decides when (and whether) to compact, switch models, or retry.
    */
   const dismissAgentError = useCallback((agentId: string) => {
-    const agent = state.agents.get(agentId)
+    // getMutableAgent excludes placeholders, which is what we want here for a
+    // second reason: a failed placeholder's error is the row's whole reason for
+    // existing, so clearing it would leave a row with no explanation.
+    const agent = getMutableAgent(agentId)
     if (!agent?.lastError) return
     agent.lastError = undefined
     emit({ agents: true })
@@ -3628,7 +3807,7 @@ export function useAgentStore() {
    */
   const compactSession = useCallback(async (agentId: string): Promise<IpcResult | undefined> => {
     if (!window.api) return
-    const agent = state.agents.get(agentId)
+    const agent = getMutableAgent(agentId)
     if (!agent) {
       console.error('[compactSession] agent not found', agentId)
       return
@@ -3674,7 +3853,7 @@ export function useAgentStore() {
   }, [])
 
   const setPrUrl = useCallback((agentId: string, prUrl: string | null) => {
-    const agent = state.agents.get(agentId)
+    const agent = getMutableAgent(agentId)
     if (!agent) return
     agent.prUrl = prUrl
     persistAgentMeta(agentId, { prUrl: prUrl ?? '' })
@@ -3688,6 +3867,11 @@ export function useAgentStore() {
     healthy: storeState.healthy,
     initializing: storeState.initializing,
     launchAgent,
+    beginLaunch,
+    failLaunch,
+    discardLaunch,
+    noteLaunchWorktree,
+    reconcileLaunch,
     sendMessage,
     listCommands,
     listAgentConfigs,
@@ -3715,7 +3899,8 @@ export function useAgentStore() {
     hydrateFileChangesFromGit
   }), [
     agents, permissions, questions, storeState.healthy, storeState.initializing,
-    launchAgent, sendMessage, listCommands, listAgentConfigs,
+    launchAgent, beginLaunch, failLaunch, discardLaunch, noteLaunchWorktree, reconcileLaunch,
+    sendMessage, listCommands, listAgentConfigs,
     executeCommand, prepareFreshAgent, resetSession,
     respondToPermission, replyToQuestion, rejectQuestion,
     abortAgent, removeAgent, renameAgent, setAgentModel,

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -16,7 +16,7 @@ export interface MessageAttachment {
 }
 
 export interface OrchestratorApi {
-  launchAgent: (options: { directory: string; prompt?: string; title?: string; model?: string; modelVariant?: string; attachments?: MessageAttachment[] }) => Promise<IpcResult>
+  launchAgent: (options: { directory: string; prompt?: string; title?: string; model?: string; modelVariant?: string; attachments?: MessageAttachment[]; launchId?: string }) => Promise<IpcResult>
   sendMessage: (agentId: string, text: string, agent?: string, attachments?: MessageAttachment[]) => Promise<IpcResult>
   respondToPermission: (agentId: string, permissionId: string, response: 'once' | 'always' | 'reject') => Promise<IpcResult>
   abortAgent: (agentId: string) => Promise<IpcResult>
@@ -45,6 +45,7 @@ export interface OrchestratorApi {
     title?: string
     model?: string
     modelVariant?: string
+    launchId?: string
   }) => Promise<IpcResult<{ id: string; runtimeId: string; sessionId: string; directory: string; projectName: string; branchName: string; isWorktree: boolean; workspaceName: string; prompt: string; title: string }>>
   resumeAgent: (options: { directory: string; sessionId: string; title?: string }) => Promise<IpcResult>
   listAgents: () => Promise<IpcResult<ListAgentsPayload>>
@@ -252,6 +253,9 @@ export interface AgentLaunchedPayload {
   /** @deprecated Use labelIds. Kept for reading legacy persisted data. */
   labelId?: string
   prUrl?: string
+  /** Correlation id from the renderer's launch request. Present only for
+   *  launches this renderer started; used to retire the placeholder row. */
+  launchId?: string
 }
 
 export interface SessionResetPayload {

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -96,6 +96,9 @@ export interface AgentRuntime {
   contextLimit?: number
   /** Spike: folder this agent belongs to. Undefined or empty = top level. */
   folderId?: string
+  /** Placeholder row for a launch that main hasn't acknowledged yet. It has no
+   *  session, so row actions other than dismissal are unavailable. */
+  pending?: boolean
 }
 
 /**

--- a/src/shared/project.ts
+++ b/src/shared/project.ts
@@ -9,3 +9,18 @@ export interface ProjectSettings {
 export function isWorktreeStrategy(value: unknown): value is WorktreeStrategy {
   return value === 'new-worktree' || value === 'current-directory'
 }
+
+/**
+ * Match OpenCode's fork title style so imported sessions stay easy to scan.
+ * Shared because the renderer predicts this name for its optimistic launch row —
+ * if the two drift, the row visibly renames itself when the real agent lands.
+ */
+export function getForkedTitle(title: string): string {
+  const match = title.match(/^(.*?)\s*\(fork(?:\s*#(\d+))?\)\s*$/)
+  if (match) {
+    const base = match[1].trim()
+    const num = match[2] ? parseInt(match[2], 10) + 1 : 2
+    return `${base} (fork #${num})`
+  }
+  return `${title} (fork)`
+}


### PR DESCRIPTION
Three unrelated annoyances in the same corner of the app.

Launching an agent blocked the launch modal until the whole chain finished: a cold `opencode serve`
spawn, the git worktree creation, then five sequential settings writes. On a project whose runtime
was not already up, that left the window unresponsive for several seconds with no sign anything was
happening. The modal now closes as soon as you submit and a placeholder row appears in the fleet
table straight away. The real agent takes that row over when it arrives. If the launch fails the row
stays behind as an errored entry with the reason, since there is no toast system to report it
anywhere else.

Placeholder rows have no session behind them, so every action that would talk to one is withheld in
the store rather than only hidden in the table. Worktree cleanup was the fiddly part. A row can be
dismissed while `git worktree add` is still running, and whether this side or the main process owns
the directory depends on how the launch ends, so that rule is a small reducer with tests covering
each ordering. Deciding it inline got it wrong three times.

The other two changes are small. The detail drawer gets a button to copy the workspace path for
pasting into a shell, and "Open in Terminal" now opens a tab in the existing Terminal.app window
rather than piling up windows. Terminal.app has no AppleScript for making a tab, so this goes
through System Events and needs Accessibility permission. If the keystroke does not land it falls
back to opening its own window. Other terminal apps are untouched.
