### PR TITLE
NO-JIRA Fix Open in Terminal opening a stray tab and a window

### DIFF
--- a/src/__tests__/terminal.test.ts
+++ b/src/__tests__/terminal.test.ts
@@ -64,6 +64,22 @@ describe('buildTerminalTabScript', () => {
     expect(fallbackLine).not.toContain('in selected tab')
   })
 
+  it('accepts a new tab that arrives as its own window', () => {
+    // Terminal uses the system's window tab groups on macOS 26, where a new tab
+    // is a separate window to AppleScript: the front window id changes and the
+    // tab count stays at 1. Watching the count alone found no tab, so every
+    // launch left a stray tab behind and opened a window as well.
+    const script = buildTerminalTabScript('/tmp')
+    const condition = script.split('\n').find((line) => line.includes('id of front window) is not'))
+    expect(condition).toContain('count of tabs of front window) > tabsBefore')
+    // Both baselines have to be read while the old tab is still the front one.
+    const keystroke = script.indexOf('keystroke "t"')
+    for (const baseline of ['set frontBefore to', 'set tabsBefore to']) {
+      expect(script.indexOf(baseline)).toBeGreaterThan(-1)
+      expect(script.indexOf(baseline)).toBeLessThan(keystroke)
+    }
+  })
+
   it('waits for Terminal to come forward before sending the keystroke', () => {
     // An early keystroke opens a tab in whatever app still holds focus.
     const script = buildTerminalTabScript('/tmp')

--- a/src/main/terminal.ts
+++ b/src/main/terminal.ts
@@ -34,7 +34,6 @@ tell application "Terminal"
   if (count of windows) is 0 then
     do script ${command}
   else
-    set tabsBefore to count of tabs of front window
     -- Wait for Terminal to actually come forward rather than guessing a delay:
     -- a keystroke sent early lands in whichever app still holds focus, leaving a
     -- stray tab in the user's editor or browser.
@@ -47,10 +46,16 @@ tell application "Terminal"
       delay 0.05
     end repeat
     if not isFront then error "Terminal did not come to the front"
+    -- Two ways a new tab shows up, depending on the macOS version. Terminal now
+    -- uses the system's window tab groups, where each tab is a separate window to
+    -- AppleScript, so the front window id changes and its tab count stays at 1.
+    -- Older releases add the tab to the same window, where only the count moves.
+    set frontBefore to id of front window
+    set tabsBefore to count of tabs of front window
     tell application "System Events" to keystroke "t" using command down
     set madeTab to false
     repeat 40 times
-      if (count of tabs of front window) > tabsBefore then
+      if ((id of front window) is not frontBefore) or ((count of tabs of front window) > tabsBefore) then
         set madeTab to true
         exit repeat
       end if


### PR DESCRIPTION
Open in Terminal made a tab and then opened a window as well, so you got a stray shell in the wrong
directory next to the one you asked for.

On recent macOS a new tab appears as a separate window to AppleScript, so the tab count the script
watched never changed and it always concluded the tab had failed. It now accepts a change in the
front window id as well, and keeps the tab count check for older releases.
