### PR TITLE
NO-JIRA Show live subagent progress in agent details

### DIFF
--- a/src/__tests__/child-session-hydration.test.ts
+++ b/src/__tests__/child-session-hydration.test.ts
@@ -1,0 +1,118 @@
+import type { OpencodeClient } from '@opencode-ai/sdk/v2/client'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  buildSessionOwnerIndex,
+  collectChildSessionIds,
+  collectChildSessionTranscripts,
+  groupRequestsByOwner
+} from '../main/services/child-session-hydration'
+
+describe('child session hydration', () => {
+  it('hydrates concurrent children and nested descendants', async () => {
+    const children = new Map([
+      ['parent', [{ id: 'child-a', parentID: 'parent' }, { id: 'child-b', parentID: 'parent' }]],
+      ['child-a', [{ id: 'grandchild', parentID: 'child-a' }]],
+      ['child-b', []],
+      ['grandchild', []]
+    ])
+    const messages = new Map([
+      ['child-a', ['a message']],
+      ['child-b', ['b message']],
+      ['grandchild', ['nested message']]
+    ])
+    const client = {
+      session: {
+        children: vi.fn(async ({ sessionID }: { sessionID: string }) => ({
+          data: children.get(sessionID) ?? []
+        })),
+        messages: vi.fn(async ({ sessionID }: { sessionID: string }) => ({
+          data: messages.get(sessionID) ?? []
+        }))
+      }
+    } as unknown as OpencodeClient
+
+    const result = await collectChildSessionTranscripts(client, 'parent', '/repo')
+
+    expect(result).toEqual({
+      complete: true,
+      sessions: [
+        { info: { id: 'child-a', parentID: 'parent' }, messages: ['a message'] },
+        { info: { id: 'child-b', parentID: 'parent' }, messages: ['b message'] },
+        { info: { id: 'grandchild', parentID: 'child-a' }, messages: ['nested message'] }
+      ]
+    })
+    expect(client.session.children).toHaveBeenCalledTimes(4)
+    expect(client.session.messages).toHaveBeenCalledTimes(3)
+  })
+
+  it('retains healthy sibling transcripts when one child message fetch fails', async () => {
+    const client = {
+      session: {
+        children: vi.fn(async ({ sessionID }: { sessionID: string }) => ({
+          data: sessionID === 'parent' ? [{ id: 'healthy' }, { id: 'broken' }] : []
+        })),
+        messages: vi.fn(async ({ sessionID }: { sessionID: string }) => {
+          if (sessionID === 'broken') throw new Error('unavailable')
+          return { data: [`${sessionID} message`] }
+        })
+      }
+    } as unknown as OpencodeClient
+
+    const result = await collectChildSessionTranscripts(client, 'parent', '/repo')
+    expect(result.complete).toBe(false)
+    expect(result.sessions).toEqual([
+      { info: { id: 'healthy' }, messages: ['healthy message'] },
+      { info: { id: 'broken' }, messages: [] }
+    ])
+  })
+
+  it('discovers nested session ownership without fetching messages', async () => {
+    const client = {
+      session: {
+        children: vi.fn(async ({ sessionID }: { sessionID: string }) => ({
+          data: sessionID === 'parent'
+            ? [{ id: 'child' }]
+            : sessionID === 'child'
+              ? [{ id: 'grandchild' }]
+              : []
+        }))
+      }
+    } as unknown as OpencodeClient
+
+    const result = await collectChildSessionIds(client, 'parent', '/repo')
+    expect([...result]).toEqual(['parent', 'child', 'grandchild'])
+  })
+
+  it('keeps direct ownership when another child tree lookup fails', async () => {
+    const client = {
+      session: {
+        children: vi.fn(async ({ sessionID }: { sessionID: string }) => {
+          if (sessionID === 'broken-root') throw new Error('unavailable')
+          return { data: sessionID === 'healthy-root' ? [{ id: 'healthy-child' }] : [] }
+        })
+      }
+    } as unknown as OpencodeClient
+
+    const result = await buildSessionOwnerIndex(client, [
+      { agentId: 'broken-agent', sessionId: 'broken-root' },
+      { agentId: 'healthy-agent', sessionId: 'healthy-root' }
+    ], '/repo')
+
+    expect(result.owners.get('broken-root')).toBe('broken-agent')
+    expect(result.owners.get('healthy-child')).toBe('healthy-agent')
+    expect(result.incompleteAgentIds).toEqual(new Set(['broken-agent']))
+  })
+
+  it('returns empty groups so stale interrupt state can be pruned', () => {
+    const grouped = groupRequestsByOwner(
+      ['agent-a', 'agent-b'],
+      new Map([['child-a', 'agent-a']]),
+      [{ id: 'permission', sessionID: 'child-a' }]
+    )
+
+    expect(grouped).toEqual([
+      { agentId: 'agent-a', requests: [{ id: 'permission', sessionID: 'child-a' }] },
+      { agentId: 'agent-b', requests: [] }
+    ])
+  })
+})

--- a/src/__tests__/subagent-progress.test.ts
+++ b/src/__tests__/subagent-progress.test.ts
@@ -1,0 +1,183 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { shouldAutoExpandTool, ToolsUsage } from '../renderer/src/components/ToolsUsage'
+import type { LiveMessage } from '../renderer/src/hooks/useAgentStore'
+import {
+  appendVisibleTextDelta,
+  associateChildSessions,
+  buildChildTranscript,
+  getChildSessionId,
+  getToolMetadataOutput,
+  collectSessionSubtreeIds,
+  mergeLiveMessagePart,
+  type TaskPartDescriptor
+} from '../renderer/src/lib/subagent-progress'
+import { getPendingInterruptStatus } from '../renderer/src/lib/interrupt-status'
+
+function assistantMessage(sessionId: string, parts: LiveMessage['parts']): LiveMessage {
+  return {
+    id: `message-${sessionId}`,
+    role: 'assistant',
+    sessionId,
+    createdAt: 1,
+    parts
+  }
+}
+
+describe('subagent progress', () => {
+  it('reads the child and running output shapes emitted by OpenCode', () => {
+    const state = {
+      metadata: {
+        parentSessionId: 'parent',
+        sessionId: 'child',
+        output: 'live command output'
+      }
+    }
+
+    expect(getChildSessionId(state)).toBe('child')
+    expect(getToolMetadataOutput(state)).toBe('live command output')
+  })
+
+  it('streams visible assistant text without exposing reasoning deltas', () => {
+    const messages = [assistantMessage('child', [
+      { id: 'text', type: 'text', text: '' },
+      { id: 'reasoning', type: 'reasoning', text: '' }
+    ])]
+
+    expect(appendVisibleTextDelta(messages, messages[0].id, 'text', 'working')).toBe(true)
+    expect(appendVisibleTextDelta(messages, messages[0].id, 'reasoning', 'hidden')).toBe(false)
+    expect(messages[0].parts[0].text).toBe('working')
+    expect(messages[0].parts[1].text).toBe('')
+  })
+
+  it('associates concurrent children by task title when events arrive out of order', () => {
+    const first: TaskPartDescriptor = { toolInput: JSON.stringify({ description: 'First task' }) }
+    const second: TaskPartDescriptor = { toolInput: JSON.stringify({ description: 'Second task' }) }
+
+    associateChildSessions([first, second], [
+      { id: 'second-child', parentID: 'parent', title: 'Second task (@explore subagent)' },
+      { id: 'first-child', parentID: 'parent', title: 'First task (@general subagent)' }
+    ], 'parent')
+
+    expect(first.childSessionId).toBe('first-child')
+    expect(second.childSessionId).toBe('second-child')
+  })
+
+  it('associates a child created before task metadata when the relationship is unambiguous', () => {
+    const task: TaskPartDescriptor = {}
+    associateChildSessions([task], [
+      { id: 'early-child', parentID: 'parent' }
+    ], 'parent')
+    expect(task.childSessionId).toBe('early-child')
+  })
+
+  it('does not guess when child and task correlation data disagree', () => {
+    const task: TaskPartDescriptor = {
+      toolInput: JSON.stringify({ description: 'Expected task' })
+    }
+    associateChildSessions([task], [
+      { id: 'wrong-child', parentID: 'parent', title: 'Different task (@explore subagent)' }
+    ], 'parent')
+    expect(task.childSessionId).toBeUndefined()
+  })
+
+  it('keeps newer streamed parts when an older hydration snapshot arrives', () => {
+    const text = { id: 'text', type: 'text', text: 'complete streamed text' }
+    mergeLiveMessagePart(text, { id: 'text', type: 'text', text: 'complete' })
+    expect(text.text).toBe('complete streamed text')
+
+    const tool = { id: 'tool', type: 'tool', toolState: 'completed', text: 'final output' }
+    mergeLiveMessagePart(tool, { id: 'tool', type: 'tool', toolState: 'running', text: 'partial' })
+    expect(tool).toMatchObject({ toolState: 'completed', text: 'final output' })
+  })
+
+  it('collects a deleted child session and all nested descendants', () => {
+    const removed = collectSessionSubtreeIds([
+      { id: 'child', parentID: 'parent' },
+      { id: 'grandchild', parentID: 'child' },
+      { id: 'sibling', parentID: 'parent' }
+    ], 'child')
+    expect([...removed]).toEqual(['child', 'grandchild'])
+  })
+
+  it('keeps agents blocked while any concurrent interrupt remains', () => {
+    expect(getPendingInterruptStatus(
+      'agent',
+      [{ agentId: 'agent' }],
+      [{ agentId: 'agent' }]
+    )).toBe('needs_input')
+    expect(getPendingInterruptStatus('agent', [{ agentId: 'agent' }], [])).toBe('needs_approval')
+    expect(getPendingInterruptStatus('agent', [], [])).toBeUndefined()
+  })
+
+  it('builds assistant text, tool output, and nested subagent transcripts', () => {
+    const messages = new Map<string, LiveMessage[]>([
+      ['child', [assistantMessage('child', [
+        {
+          id: 'bash',
+          type: 'tool',
+          toolName: 'bash',
+          toolState: 'running',
+          toolInput: JSON.stringify({ command: 'npm test' }),
+          text: 'tests are running'
+        },
+        {
+          id: 'nested-task',
+          type: 'tool',
+          toolName: 'task',
+          toolState: 'completed',
+          childSessionId: 'grandchild'
+        }
+      ])]],
+      ['grandchild', [assistantMessage('grandchild', [
+        { id: 'final', type: 'text', text: 'nested final output' }
+      ])]]
+    ])
+
+    const transcript = buildChildTranscript('child', (sessionId) => messages.get(sessionId) ?? [])
+
+    expect(transcript[0]).toMatchObject({
+      label: 'bash',
+      toolState: 'running',
+      toolSummary: 'npm test',
+      toolOutput: 'tests are running'
+    })
+    expect(transcript[1].childTranscript?.[0]).toMatchObject({
+      kind: 'text',
+      label: 'nested final output'
+    })
+  })
+
+  it('expands running tasks immediately and keeps completed transcripts collapsible', () => {
+    const running = renderToStaticMarkup(createElement(ToolsUsage, {
+      tools: [{
+        id: 'running',
+        name: 'task',
+        state: 'running',
+        timestamp: Date.now()
+      }]
+    }))
+    const completed = renderToStaticMarkup(createElement(ToolsUsage, {
+      tools: [{
+        id: 'completed',
+        name: 'task',
+        state: 'completed',
+        timestamp: Date.now(),
+        childSessionId: 'child',
+        childTranscript: [{ id: 'final', kind: 'text', label: 'final child output' }]
+      }]
+    }))
+
+    expect(running).toContain('sub-agent starting')
+    expect(running).toContain('Creating child session...')
+    expect(completed).not.toContain('final child output')
+    expect(completed).toContain('Completed')
+    expect(shouldAutoExpandTool({
+      id: 'running',
+      name: 'task',
+      state: 'running',
+      timestamp: 0
+    }, false, true)).toBe(false)
+  })
+})

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -345,6 +345,16 @@ export function registerIpcHandlers(): void {
     }
   })
 
+  ipcMain.handle('agent:get-child-sessions', async (_event, agentId: string) => {
+    try {
+      const sessions = await agentController.getChildSessions(agentId)
+      return { ok: true, data: sessions }
+    } catch (error) {
+      logIpcError('agent:get-child-sessions', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
   ipcMain.handle('session:list', async (_event, directory: string) => {
     try {
       const sessions = await agentController.listSessions(directory)

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow } from 'electron'
 import type { OpencodeClient, TextPartInput, FilePartInput } from '@opencode-ai/sdk/v2/client'
+import { buildSessionOwnerIndex, collectChildSessionTranscripts, groupRequestsByOwner } from './child-session-hydration'
 import { runtimeManager, type RuntimeInfo } from './runtime-manager'
 import { EventBridge } from './event-bridge'
 import { notificationService, type NotifiableEventType } from './notification-service'
@@ -1021,6 +1022,16 @@ class AgentController {
     return result.data
   }
 
+  async getChildSessions(agentId: string): Promise<{ sessions: Array<{ info: unknown; messages: unknown }>; complete: boolean }> {
+    const handle = this.agents.get(agentId)
+    if (!handle) throw new Error(`Agent ${agentId} not found`)
+
+    const runtime = await this.ensureRuntimeForAgent(handle)
+    runtimeManager.touchRuntimeActivity(runtime.id)
+
+    return collectChildSessionTranscripts(runtime.client, handle.sessionId, handle.directory)
+  }
+
   /**
    * Fetch session status for all active agents.
    */
@@ -1068,8 +1079,8 @@ class AgentController {
   /**
    * Fetch all pending permissions across all agents.
    */
-  async getAllPendingPermissions(): Promise<Array<{ agentId: string; permissions: unknown[] }>> {
-    const result: Array<{ agentId: string; permissions: unknown[] }> = []
+  async getAllPendingPermissions(): Promise<Array<{ agentId: string; permissions: unknown[]; complete: boolean }>> {
+    const result: Array<{ agentId: string; permissions: unknown[]; complete: boolean }> = []
 
     const byRuntime = new Map<string, AgentHandle[]>()
     for (const handle of this.agents.values()) {
@@ -1089,12 +1100,24 @@ class AgentController {
         })
 
         if (permissionsResult.data && Array.isArray(permissionsResult.data)) {
-          for (const perm of permissionsResult.data as Array<{ id: string; sessionID: string }>) {
-            const agent = handles.find((h) => h.sessionId === perm.sessionID)
-            if (agent) {
-              result.push({ agentId: agent.id, permissions: [perm] })
-            }
-          }
+          const permissions = permissionsResult.data as Array<{ id: string; sessionID: string }>
+          const directOwners = new Map(handles.map((handle) => [handle.sessionId, handle.id]))
+          const ownerResult = permissions.some((permission) => !directOwners.has(permission.sessionID))
+            ? await buildSessionOwnerIndex(
+              runtime.client,
+              handles.map((handle) => ({ agentId: handle.id, sessionId: handle.sessionId })),
+              directory
+            )
+            : { owners: directOwners, incompleteAgentIds: new Set<string>() }
+          result.push(...groupRequestsByOwner(
+            handles.map((handle) => handle.id),
+            ownerResult.owners,
+            permissions
+          ).map((entry) => ({
+            agentId: entry.agentId,
+            permissions: entry.requests,
+            complete: !ownerResult.incompleteAgentIds.has(entry.agentId)
+          })))
         }
       } catch (error) {
         console.error(`[AgentController] Failed to get permissions for runtime ${runtimeId}:`, error)
@@ -1107,8 +1130,8 @@ class AgentController {
   /**
    * Fetch all pending questions across all agents.
    */
-  async getAllPendingQuestions(): Promise<Array<{ agentId: string; questions: unknown[] }>> {
-    const result: Array<{ agentId: string; questions: unknown[] }> = []
+  async getAllPendingQuestions(): Promise<Array<{ agentId: string; questions: unknown[]; complete: boolean }>> {
+    const result: Array<{ agentId: string; questions: unknown[]; complete: boolean }> = []
 
     const byRuntime = new Map<string, AgentHandle[]>()
     for (const handle of this.agents.values()) {
@@ -1128,12 +1151,24 @@ class AgentController {
         })
 
         if (questionsResult.data && Array.isArray(questionsResult.data)) {
-          for (const q of questionsResult.data as Array<{ id: string; sessionID: string }>) {
-            const agent = handles.find((h) => h.sessionId === q.sessionID)
-            if (agent) {
-              result.push({ agentId: agent.id, questions: [q] })
-            }
-          }
+          const questions = questionsResult.data as Array<{ id: string; sessionID: string }>
+          const directOwners = new Map(handles.map((handle) => [handle.sessionId, handle.id]))
+          const ownerResult = questions.some((question) => !directOwners.has(question.sessionID))
+            ? await buildSessionOwnerIndex(
+              runtime.client,
+              handles.map((handle) => ({ agentId: handle.id, sessionId: handle.sessionId })),
+              directory
+            )
+            : { owners: directOwners, incompleteAgentIds: new Set<string>() }
+          result.push(...groupRequestsByOwner(
+            handles.map((handle) => handle.id),
+            ownerResult.owners,
+            questions
+          ).map((entry) => ({
+            agentId: entry.agentId,
+            questions: entry.requests,
+            complete: !ownerResult.incompleteAgentIds.has(entry.agentId)
+          })))
         }
       } catch (error) {
         console.error(`[AgentController] Failed to get questions for runtime ${runtimeId}:`, error)

--- a/src/main/services/child-session-hydration.ts
+++ b/src/main/services/child-session-hydration.ts
@@ -1,0 +1,101 @@
+import type { OpencodeClient } from '@opencode-ai/sdk/v2/client'
+
+export async function collectChildSessionIds(
+  client: OpencodeClient,
+  rootSessionId: string,
+  directory: string
+): Promise<Set<string>> {
+  const result = new Set<string>()
+  const pending = [rootSessionId]
+
+  while (pending.length > 0) {
+    const parentSessionId = pending.shift()!
+    if (result.has(parentSessionId)) continue
+    result.add(parentSessionId)
+
+    const childrenResult = await client.session.children({
+      sessionID: parentSessionId,
+      directory
+    })
+    pending.push(...(childrenResult.data ?? []).map((child) => child.id))
+  }
+
+  return result
+}
+
+export async function buildSessionOwnerIndex(
+  client: OpencodeClient,
+  roots: Array<{ agentId: string; sessionId: string }>,
+  directory: string
+): Promise<{ owners: Map<string, string>; incompleteAgentIds: Set<string> }> {
+  const owners = new Map(roots.map((root) => [root.sessionId, root.agentId]))
+  const incompleteAgentIds = new Set<string>()
+  await Promise.all(roots.map(async (root) => {
+    try {
+      const sessionIds = await collectChildSessionIds(client, root.sessionId, directory)
+      for (const sessionId of sessionIds) owners.set(sessionId, root.agentId)
+    } catch {
+      incompleteAgentIds.add(root.agentId)
+    }
+  }))
+  return { owners, incompleteAgentIds }
+}
+
+export function groupRequestsByOwner<T extends { sessionID: string }>(
+  agentIds: string[],
+  owners: ReadonlyMap<string, string>,
+  requests: T[]
+): Array<{ agentId: string; requests: T[] }> {
+  const grouped = new Map(agentIds.map((agentId) => [agentId, [] as T[]]))
+  for (const request of requests) {
+    const agentId = owners.get(request.sessionID)
+    if (agentId) grouped.get(agentId)?.push(request)
+  }
+  return agentIds.map((agentId) => ({ agentId, requests: grouped.get(agentId) ?? [] }))
+}
+
+export async function collectChildSessionTranscripts(
+  client: OpencodeClient,
+  rootSessionId: string,
+  directory: string
+): Promise<{ sessions: Array<{ info: unknown; messages: unknown }>; complete: boolean }> {
+  const result: Array<{ info: unknown; messages: unknown }> = []
+  const visited = new Set<string>()
+  const pending = [rootSessionId]
+  let complete = true
+
+  while (pending.length > 0) {
+    const parentSessionId = pending.shift()!
+    if (visited.has(parentSessionId)) continue
+    visited.add(parentSessionId)
+
+    let childrenResult
+    try {
+      childrenResult = await client.session.children({
+        sessionID: parentSessionId,
+        directory
+      })
+    } catch {
+      complete = false
+      continue
+    }
+    const children = childrenResult.data ?? []
+    const hydrated = await Promise.all(children.map(async (child) => {
+      try {
+        const messagesResult = await client.session.messages({
+          sessionID: child.id,
+          directory
+        })
+        return { info: child, messages: messagesResult.data ?? [] }
+      } catch {
+        complete = false
+        return { info: child, messages: [] }
+      }
+    }))
+
+    result.push(...hydrated)
+    pending.push(...children.map((child) => child.id))
+  }
+
+  return { sessions: result, complete }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -60,6 +60,9 @@ const api = {
   getMessages: (agentId: string): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:get-messages', agentId),
 
+  getChildSessions: (agentId: string): Promise<IpcResult> =>
+    ipcRenderer.invoke('agent:get-child-sessions', agentId),
+
   listCommands: (agentId: string): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:list-commands', agentId),
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -17,10 +17,10 @@ import { useAgentStore, setViewedAgentId, type LiveAgent } from './hooks/useAgen
 import { useCustomLabels } from './hooks/useCustomLabels'
 import { type AgentRuntime, type Interrupt, type Message, type ColumnKey, type ColumnWidths, type SortDirection, loadColumnVisibility, saveColumnVisibility, loadColumnWidths, saveColumnWidths, loadSort, saveSort, compareStatusPriority } from './types'
 import type { FileChange } from './components/FilesChanged'
-import type { ToolCall, ChildTranscriptEntry } from './components/ToolsUsage'
-import type { LiveMessage } from './hooks/useAgentStore'
+import type { ToolCall } from './components/ToolsUsage'
 import type { EventEntry } from './components/EventLog'
 import { loadSettings, parseSlashCommand, type QuickAction } from './data/settings'
+import { buildChildTranscript, mapToolState } from './lib/subagent-progress'
 
 const NEW_AGENT_COMMAND = '/new'
 const AGENT_MENTION_REGEX = /@(\w+)/
@@ -35,74 +35,6 @@ function sanitizeSlugSegment(value: string, fallback: string): string {
     .slice(0, 50)
 
   return sanitized || fallback
-}
-
-function mapToolState(toolState?: string): ToolCall['state'] {
-  if (toolState === 'completed') return 'completed'
-  if (toolState === 'error' || toolState === 'failed') return 'failed'
-  return 'running'
-}
-
-/** Flatten a sub-agent's live messages into the compact transcript shape that
- *  a `task` tool bubble renders inline. We keep every text chunk and every
- *  tool invocation in chronological order; stale/step-start/finish parts are
- *  skipped because they don't help the user see progress. Called per-task-
- *  tool-call whenever the parent transcript rebuilds, so this stays cheap. */
-function buildChildTranscript(messages: LiveMessage[]): ChildTranscriptEntry[] {
-  const entries: ChildTranscriptEntry[] = []
-  for (const msg of messages) {
-    for (const part of msg.parts) {
-      if (part.type === 'text' && part.text) {
-        entries.push({
-          id: part.id,
-          kind: 'text',
-          label: part.text
-        })
-      } else if (part.type === 'tool' && part.toolName) {
-        entries.push({
-          id: part.id,
-          kind: 'tool',
-          label: part.toolName,
-          toolState: mapToolState(part.toolState),
-          toolSummary: summarizeChildToolInput(part.toolName, part.toolInput)
-        })
-      }
-    }
-  }
-  return entries
-}
-
-/** Single-line summary of a sub-agent tool's input. Mirrors the parent
- *  bubble's formatter (DetailDrawer.summarizeToolInput) but collapsed onto
- *  one line and truncated, because we're rendering inside a nested list. */
-function summarizeChildToolInput(name: string, input: string | undefined): string | undefined {
-  if (!input) return undefined
-  try {
-    const parsed = JSON.parse(input) as Record<string, unknown>
-    const pick = (...keys: string[]): string | undefined => {
-      for (const key of keys) {
-        const value = parsed[key]
-        if (typeof value === 'string' && value.trim()) return value
-      }
-      return undefined
-    }
-    const raw = (() => {
-      switch (name.toLowerCase()) {
-        case 'bash': return pick('command')
-        case 'read': case 'write': case 'edit': return pick('filePath', 'file_path', 'path')
-        case 'grep': return pick('pattern')
-        case 'glob': return pick('pattern')
-        case 'webfetch': return pick('url')
-        case 'task': return pick('description', 'prompt')
-        default: return undefined
-      }
-    })()
-    if (!raw) return undefined
-    const oneLine = raw.replace(/\s+/g, ' ').trim()
-    return oneLine.length > 80 ? oneLine.slice(0, 80) + '…' : oneLine
-  } catch {
-    return undefined
-  }
 }
 
 function extractLastAssistantMessage(messages: { role: string; parts: { type: string; text?: string }[] }[]): string | undefined {
@@ -653,7 +585,7 @@ export function App() {
               timestamp: msg.createdAt,
               childSessionId: part.childSessionId,
               childTranscript: part.childSessionId
-                ? buildChildTranscript(getMessagesForSession(part.childSessionId))
+                ? buildChildTranscript(part.childSessionId, getMessagesForSession)
                 : undefined
             })
             break

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -47,6 +47,7 @@ import { EventLog } from './EventLog'
 
 import type { FileChange } from './FilesChanged'
 import type { ToolCall } from './ToolsUsage'
+import { SubagentProgress } from './SubagentProgress'
 import type { EventEntry } from './EventLog'
 
 export type { FileChange, ToolCall, EventEntry }
@@ -2023,8 +2024,12 @@ const ToolGroupBubble = memo(function ToolGroupBubble({
                   useAgentStore; we just mirror them inline so the user can
                   watch what the sub-agent is doing. Rendered above the final
                   output so the transcript reads top-to-bottom. */}
-              {tool.name === 'task' && tool.childTranscript && tool.childTranscript.length > 0 && (
-                <ChildTaskTranscript entries={tool.childTranscript} running={tool.state === 'running'} />
+              {tool.name === 'task' && (tool.state === 'running' || tool.childTranscript?.length) && (
+                <SubagentProgress
+                  entries={tool.childTranscript ?? []}
+                  state={tool.state}
+                  childSessionId={tool.childSessionId}
+                />
               )}
               {tool.output && (
                 <pre className="mt-2 whitespace-pre-wrap break-all font-mono text-[10px] text-kumo-subtle bg-kumo-overlay rounded-md px-2 py-1.5 overflow-x-auto">
@@ -2043,48 +2048,6 @@ const ToolGroupBubble = memo(function ToolGroupBubble({
   prev.message.toolCalls === next.message.toolCalls &&
   prev.verbose === next.verbose
 )
-
-function ChildTaskTranscript({
-  entries,
-  running
-}: {
-  entries: NonNullable<ToolCall['childTranscript']>
-  running: boolean
-}) {
-  return (
-    <div className="mt-2 rounded-md border border-kumo-line bg-kumo-overlay px-2 py-1.5">
-      <div className="mb-1 flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-kumo-subtle">
-        {running && <CircleNotch size={10} className="animate-spin text-kumo-link" />}
-        <span>sub-agent {running ? 'working' : 'transcript'}</span>
-      </div>
-      <div className="flex flex-col gap-1">
-        {entries.map((entry) => (
-          <div key={entry.id} className="text-[10px] font-mono leading-tight">
-            {entry.kind === 'text' ? (
-              <div className="whitespace-pre-wrap break-words text-kumo-default">
-                {entry.label}
-              </div>
-            ) : (
-              <div className="flex items-start gap-1.5 text-kumo-subtle">
-                <span className={`shrink-0 ${toolIconStyle(entry.toolState)}`}>
-                  {entry.toolState === 'completed'
-                    ? '✓'
-                    : entry.toolState === 'failed'
-                    ? '✗'
-                    : '…'}
-                </span>
-                <span className="text-kumo-link">{entry.label}</span>
-                {entry.toolSummary && (
-                  <span className="truncate text-kumo-subtle">{entry.toolSummary}</span>
-                )}
-              </div>
-            )}
-          </div>
-        ))}
-      </div>
-    </div>
-  )
-}
 
 /**
  * Which banner the drawer should render, derived from the agent's transient

--- a/src/renderer/src/components/SubagentProgress.tsx
+++ b/src/renderer/src/components/SubagentProgress.tsx
@@ -1,0 +1,74 @@
+import { CircleNotch } from '@phosphor-icons/react'
+import type { ChildTranscriptEntry, DisplayToolState } from '../lib/subagent-progress'
+
+interface SubagentProgressProps {
+  entries: ChildTranscriptEntry[]
+  state: DisplayToolState
+  childSessionId?: string
+}
+
+function toolIconStyle(toolState: DisplayToolState | undefined): string {
+  if (toolState === 'failed') return 'text-kumo-danger'
+  if (toolState === 'completed') return 'text-kumo-success'
+  return 'text-kumo-link'
+}
+
+function progressLabel(state: DisplayToolState, childSessionId: string | undefined): string {
+  if (state === 'failed') return 'sub-agent failed'
+  if (state === 'completed') return 'sub-agent transcript'
+  return childSessionId ? 'sub-agent working' : 'sub-agent starting'
+}
+
+export function SubagentProgress({ entries, state, childSessionId }: SubagentProgressProps) {
+  const running = state === 'running'
+
+  return (
+    <div className="mt-2 rounded-md border border-kumo-line bg-kumo-overlay px-2 py-1.5">
+      <div className="mb-1 flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-kumo-subtle">
+        {running && <CircleNotch size={10} className="animate-spin text-kumo-link" />}
+        <span>{progressLabel(state, childSessionId)}</span>
+      </div>
+      {entries.length === 0 ? (
+        <div className="text-[10px] font-mono text-kumo-subtle">
+          {childSessionId ? 'Waiting for live output...' : 'Creating child session...'}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {entries.map((entry) => (
+            <div key={entry.id} className="text-[10px] font-mono leading-tight">
+              {entry.kind === 'text' ? (
+                <div className="whitespace-pre-wrap break-words text-kumo-default">
+                  {entry.label}
+                </div>
+              ) : (
+                <div>
+                  <div className="flex items-start gap-1.5 text-kumo-subtle">
+                    <span className={`shrink-0 ${toolIconStyle(entry.toolState)}`}>
+                      {entry.toolState === 'completed' ? '✓' : entry.toolState === 'failed' ? '✗' : '...'}
+                    </span>
+                    <span className="text-kumo-link">{entry.label}</span>
+                    {entry.toolSummary && (
+                      <span className="truncate text-kumo-subtle">{entry.toolSummary}</span>
+                    )}
+                  </div>
+                  {entry.toolOutput && (
+                    <pre className="mt-1 max-h-[160px] overflow-auto whitespace-pre-wrap break-all rounded bg-kumo-control px-2 py-1 text-kumo-subtle">
+                      {entry.toolOutput}
+                    </pre>
+                  )}
+                  {entry.label === 'task' && (entry.toolState === 'running' || entry.childTranscript?.length) && (
+                    <SubagentProgress
+                      entries={entry.childTranscript ?? []}
+                      state={entry.toolState ?? 'running'}
+                      childSessionId={entry.childSessionId}
+                    />
+                  )}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/ToolsUsage.tsx
+++ b/src/renderer/src/components/ToolsUsage.tsx
@@ -1,5 +1,7 @@
 import { useState, useMemo, useEffect, useRef, memo } from 'react'
 import { Wrench, CaretDown, CaretRight, MagnifyingGlass } from '@phosphor-icons/react'
+import { SubagentProgress } from './SubagentProgress'
+import type { ChildTranscriptEntry } from '../lib/subagent-progress'
 
 export interface ToolCall {
   id: string
@@ -15,21 +17,6 @@ export interface ToolCall {
    *  transcript, computed by the app whenever the parent message list
    *  rebuilds. Populated only when `childSessionId` is set. */
   childTranscript?: ChildTranscriptEntry[]
-}
-
-/** Compact representation of a sub-agent's live activity for display inside
- *  a `task` tool bubble. We flatten text and tool calls into a linear list
- *  because the nested rendering doesn't need the full message grouping. */
-export interface ChildTranscriptEntry {
-  id: string
-  kind: 'text' | 'tool'
-  /** For text entries: the assistant's text. For tool entries: the tool name. */
-  label: string
-  /** For tool entries: the lifecycle state (so we can show a spinner). */
-  toolState?: 'running' | 'completed' | 'failed'
-  /** For tool entries: a short input summary (matches the parent bubble's
-   *  `summarizeToolInput` output). */
-  toolSummary?: string
 }
 
 interface ToolsUsageProps {
@@ -60,21 +47,24 @@ function formatRelativeTime(timestamp: number): string {
   return `${days}d ago`
 }
 
+export function shouldAutoExpandTool(tool: ToolCall, verbose: boolean, manuallyCollapsed: boolean): boolean {
+  return !manuallyCollapsed && (verbose || (tool.name === 'task' && tool.state === 'running'))
+}
+
 export const ToolsUsage = memo(function ToolsUsage({ tools, verbose = false }: ToolsUsageProps) {
-  const [expandedIds, setExpandedIds] = useState<Set<string>>(() =>
-    verbose ? new Set(tools.map((t) => t.id)) : new Set()
-  )
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set(
+    tools.filter((tool) => shouldAutoExpandTool(tool, verbose, false)).map((tool) => tool.id)
+  ))
   const [filterQuery, setFilterQuery] = useState('')
   // Track items the user explicitly collapsed so we don't re-expand them
   const manuallyCollapsedRef = useRef<Set<string>>(new Set())
 
-  // When verbose is on, auto-expand only *new* items (not manually-collapsed ones)
+  // Auto-expand verbose entries and running tasks unless the user collapsed them.
   useEffect(() => {
-    if (!verbose) return
     setExpandedIds((prev) => {
       const next = new Set(prev)
       for (const tool of tools) {
-        if (!manuallyCollapsedRef.current.has(tool.id)) {
+        if (shouldAutoExpandTool(tool, verbose, manuallyCollapsedRef.current.has(tool.id))) {
           next.add(tool.id)
         }
       }
@@ -101,7 +91,7 @@ export const ToolsUsage = memo(function ToolsUsage({ tools, verbose = false }: T
       const next = new Set(prev)
       if (next.has(toolId)) {
         next.delete(toolId)
-        if (verbose) manuallyCollapsedRef.current.add(toolId)
+        manuallyCollapsedRef.current.add(toolId)
       } else {
         next.add(toolId)
         manuallyCollapsedRef.current.delete(toolId)
@@ -203,6 +193,13 @@ export const ToolsUsage = memo(function ToolsUsage({ tools, verbose = false }: T
                       </pre>
                     </div>
                   )}
+                  {tool.name === 'task' && (tool.state === 'running' || tool.childTranscript?.length) && (
+                    <SubagentProgress
+                      entries={tool.childTranscript ?? []}
+                      state={tool.state}
+                      childSessionId={tool.childSessionId}
+                    />
+                  )}
                   {tool.output && (
                     <div>
                       <div className="text-[10px] font-semibold uppercase tracking-wide text-kumo-subtle mb-1">
@@ -213,7 +210,7 @@ export const ToolsUsage = memo(function ToolsUsage({ tools, verbose = false }: T
                       </pre>
                     </div>
                   )}
-                  {!tool.input && !tool.output && (
+                  {!tool.input && !tool.output && tool.name !== 'task' && (
                     <div className="text-[11px] text-kumo-subtle italic">No input/output data</div>
                   )}
                 </div>

--- a/src/renderer/src/demoApi.ts
+++ b/src/renderer/src/demoApi.ts
@@ -271,10 +271,53 @@ function makeDemoMessages(agentId: string) {
           type: 'tool-invocation',
           tool: 'read_file',
           state: { status: 'completed', title: 'Read src/index.ts' }
-        }
+        },
+        ...(agentId === 'agent-1' ? [{
+          id: 'part-agent-1-task',
+          type: 'tool',
+          tool: 'task',
+          state: {
+            status: 'running',
+            input: { description: 'Inspect rate limiter implementation' },
+            metadata: { sessionId: 'session-1-child' }
+          }
+        }] : [])
       ]
     }
   ]
+}
+
+function makeDemoChildSessions(agentId: string) {
+  if (agentId !== 'agent-1') return []
+  const now = Date.now()
+  return [{
+    info: {
+      id: 'session-1-child',
+      parentID: 'session-1',
+      title: 'Inspect rate limiter implementation (@explore subagent)'
+    },
+    messages: [{
+      info: {
+        id: 'msg-agent-1-child',
+        sessionID: 'session-1-child',
+        role: 'assistant' as const,
+        time: { created: now - 30000 }
+      },
+      parts: [
+        { id: 'part-agent-1-child-text', type: 'text', text: 'Tracing the current request middleware and Redis client setup.' },
+        {
+          id: 'part-agent-1-child-tool',
+          type: 'tool',
+          tool: 'grep',
+          state: {
+            status: 'running',
+            input: { pattern: 'rateLimit', path: 'src' },
+            metadata: { output: 'src/middleware/rateLimit.ts:18' }
+          }
+        }
+      ]
+    }]
+  }]
 }
 
 export function createDemoApi(): OrchestratorApi {
@@ -288,6 +331,7 @@ export function createDemoApi(): OrchestratorApi {
     removeAgent: noop,
     resetSession: noop,
     getMessages: (agentId: string) => ok(makeDemoMessages(agentId)),
+    getChildSessions: (agentId: string) => ok({ sessions: makeDemoChildSessions(agentId), complete: true }),
     listCommands: () => ok([]),
     executeCommand: noop,
     getConfig: (agentId: string) => ok({ model: DEMO_MODELS[agentId] || 'claude-sonnet-4-6' }),

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -21,6 +21,16 @@ import {
   type LaunchEvent,
   type PlaceholderOptions
 } from './placeholderLaunch'
+import {
+  appendVisibleTextDelta,
+  associateChildSessions,
+  collectSessionSubtreeIds,
+  getChildSessionId,
+  getToolMetadataOutput,
+  mergeLiveMessagePart,
+  type ChildSessionDescriptor
+} from '../lib/subagent-progress'
+import { getPendingInterruptStatus } from '../lib/interrupt-status'
 
 // Deduplication cache for provider error toasts per runtime to avoid flicker.
 const toastDedup = new Map<string, { sig: string; expiresAt: number }>()
@@ -80,6 +90,30 @@ interface HistoricalMessagePart {
 interface HistoricalSessionMessage {
   info: HistoricalMessageInfo
   parts: HistoricalMessagePart[]
+}
+
+type ChildSessionInfo = ChildSessionDescriptor
+
+interface HydratedChildSession {
+  info: ChildSessionInfo
+  messages: unknown
+}
+
+interface ChildSessionHydrationResult {
+  sessions: HydratedChildSession[]
+  complete: boolean
+}
+
+interface PendingQuestionSnapshot {
+  agentId: string
+  questions: Array<{ id: string; sessionID: string; questions: LiveQuestionInfo[] }>
+  complete?: boolean
+}
+
+interface PendingPermissionSnapshot {
+  agentId: string
+  permissions: PermissionRequestPayload[]
+  complete?: boolean
 }
 
 // ── Agent State ──
@@ -392,6 +426,8 @@ const sessionStepDepth = new Map<string, number>()
 // tool part exposes its childSessionId via state.metadata so the parent's
 // lastActivityAt and the stalled-watchdog can see through the indirection.
 const childSessionToAgent = new Map<string, string>()
+const childSessions = new Map<string, ChildSessionInfo>()
+const childHydrationRetryAgents = new Set<string>()
 
 /** Clear step depth for a session and restore the parent model if it was
  *  overwritten by a sub-agent. Returns true if the model was restored. */
@@ -712,16 +748,6 @@ function getToolState(partState: Record<string, unknown> | undefined): string | 
   return typeof status === 'string' ? status : undefined
 }
 
-/** Extract a sub-agent sessionId from a tool part's state.metadata.
- *  The task tool sets `metadata: { sessionId }` via ctx.metadata() both when
- *  the sub-session is created (running) and in the final return (completed),
- *  so we can read it at any point in the tool's lifecycle. */
-function getChildSessionId(partState: Record<string, unknown> | undefined): string | undefined {
-  const metadata = partState?.metadata as Record<string, unknown> | undefined
-  const sessionId = metadata?.sessionId
-  return typeof sessionId === 'string' ? sessionId : undefined
-}
-
 function stringifyToolInput(input: unknown): string | undefined {
   if (input === undefined) return undefined
   try {
@@ -746,6 +772,9 @@ function getToolOutput(part: Record<string, unknown>, partState: Record<string, 
 
   const raw = partState?.raw
   if (typeof raw === 'string' && raw.trim()) return raw
+
+  const metadataOutput = getToolMetadataOutput(partState)
+  if (metadataOutput !== undefined) return metadataOutput
 
   return undefined
 }
@@ -824,13 +853,7 @@ function upsertMessage(message: LiveMessage): LiveMessage {
 function upsertMessagePart(message: LiveMessage, nextPart: LiveMessagePart): void {
   const existingPart = message.parts.find((candidate) => candidate.id === nextPart.id)
   if (existingPart) {
-    existingPart.type = nextPart.type
-    existingPart.text = nextPart.text
-    existingPart.toolName = nextPart.toolName
-    existingPart.toolState = nextPart.toolState
-    // Don't clobber a known childSessionId with undefined — the parent tool
-    // part may receive updates that omit metadata.
-    if (nextPart.childSessionId) existingPart.childSessionId = nextPart.childSessionId
+    mergeLiveMessagePart(existingPart, nextPart)
     return
   }
 
@@ -852,7 +875,12 @@ function mapHistoricalPart(part: HistoricalMessagePart): LiveMessagePart {
     nextPart.toolName = part.tool
     nextPart.toolState = part.state?.status
     nextPart.toolInput = stringifyToolInput(part.state?.input)
-    nextPart.text = part.text ?? part.state?.output ?? part.state?.error ?? part.state?.title ?? part.state?.raw
+    nextPart.text = part.text
+      ?? part.state?.output
+      ?? part.state?.error
+      ?? part.state?.title
+      ?? part.state?.raw
+      ?? getToolMetadataOutput(part.state as Record<string, unknown> | undefined)
     nextPart.childSessionId = getChildSessionId(part.state as Record<string, unknown> | undefined)
   }
 
@@ -959,14 +987,17 @@ function hydrateHistoricalMessages(entries: unknown): void {
     }
 
     const agent = findAgentBySession(entry.info.sessionID)
-    if (!agent) continue
+    const owner = agent ?? findAgentByChildSession(entry.info.sessionID)
 
-    // Re-index any sub-agent sessions surfaced by this restore so the watchdog
-    // and live-activity tracking can see through task-tool indirection on
-    // cold start.
-    for (const part of message.parts) {
-      if (part.childSessionId) registerChildSession(part.childSessionId, agent.id)
+    if (owner) {
+      for (const part of message.parts) {
+        if (part.childSessionId) registerChildSession(part.childSessionId, owner.id)
+      }
     }
+
+    associateKnownChildren(entry.info.sessionID)
+
+    if (!agent) continue
 
     agent.lastActivityAt = Math.max(agent.lastActivityAt, createdAt)
 
@@ -1043,6 +1074,44 @@ function hydrateHistoricalMessages(entries: unknown): void {
   }
 }
 
+function hydrateChildSessions(entries: unknown, parentAgentId: string): void {
+  if (!Array.isArray(entries)) return
+
+  for (const entry of entries as HydratedChildSession[]) {
+    if (!entry?.info?.id || !entry.info.parentID) continue
+    childSessions.set(entry.info.id, entry.info)
+  }
+
+  for (const entry of entries as HydratedChildSession[]) {
+    if (!entry?.info?.id || !entry.info.parentID) continue
+    const owner = findAgentBySession(entry.info.parentID)
+      ?? findAgentByChildSession(entry.info.parentID)
+      ?? state.agents.get(parentAgentId)
+    if (owner) registerChildSession(entry.info.id, owner.id)
+  }
+
+  for (const entry of entries as HydratedChildSession[]) {
+    if (!entry?.info?.id) continue
+    hydrateHistoricalMessages(entry.messages)
+    associateKnownChildren(entry.info.parentID)
+  }
+}
+
+function applyChildSessionHydration(result: unknown, parentAgentId: string): void {
+  const hydration = result as ChildSessionHydrationResult | undefined
+  if (!hydration || !Array.isArray(hydration.sessions)) return
+  hydrateChildSessions(hydration.sessions, parentAgentId)
+  if (hydration.complete) childHydrationRetryAgents.delete(parentAgentId)
+  else childHydrationRetryAgents.add(parentAgentId)
+}
+
+async function refetchChildSessions(agentId: string): Promise<void> {
+  if (!window.api) return
+  const result = await window.api.getChildSessions(agentId)
+  if (!result.ok || !result.data) return
+  applyChildSessionHydration(result.data, agentId)
+}
+
 // ── Viewed Agent Suppression ──
 
 let viewedAgentId: string | null = null
@@ -1106,6 +1175,24 @@ function processEvent(payload: OpenCodeEventPayload): void {
   }
 
   switch (type) {
+    case 'session.created': {
+      const info = props.info as Record<string, unknown> | undefined
+      const childSessionId = (info?.id ?? props.sessionID) as string | undefined
+      const parentSessionId = info?.parentID as string | undefined
+      if (!childSessionId || !parentSessionId) break
+
+      childSessions.set(childSessionId, {
+        id: childSessionId,
+        parentID: parentSessionId,
+        title: info?.title as string | undefined
+      })
+      const owner = findAgentBySession(parentSessionId) ?? findAgentByChildSession(parentSessionId)
+      if (owner) registerChildSession(childSessionId, owner.id)
+      associateKnownChildren(parentSessionId)
+      emit({ messages: true })
+      break
+    }
+
     case 'session.status': {
       const sessionId = props.sessionID as string
       const statusInfo = props.status as { type: string }
@@ -1303,6 +1390,17 @@ function processEvent(payload: OpenCodeEventPayload): void {
       const info = props.info as Record<string, unknown> | undefined
       const sessionId = info?.id as string | undefined
       if (!sessionId) break
+      const parentSessionId = info?.parentID as string | undefined
+      if (parentSessionId) {
+        childSessions.set(sessionId, {
+          id: sessionId,
+          parentID: parentSessionId,
+          title: info?.title as string | undefined
+        })
+        const owner = findAgentBySession(parentSessionId) ?? findAgentByChildSession(parentSessionId)
+        if (owner) registerChildSession(sessionId, owner.id)
+        associateKnownChildren(parentSessionId)
+      }
       const agent = findAgentBySession(sessionId)
       if (agent) {
         const time = info?.time as { updated?: number; compacting?: number } | undefined
@@ -1599,14 +1697,13 @@ function processEvent(payload: OpenCodeEventPayload): void {
         // Update agent activity (but don't clobber blocked/stopping/terminal states)
         let agentChanged = false
         const agent = findAgentBySession(sessionId)
+        const owner = agent ?? findAgentByChildSession(sessionId)
+        if (partType === 'tool') {
+          const childId = getChildSessionId(toolState)
+          if (childId && owner) registerChildSession(childId, owner.id)
+          associateKnownChildren(sessionId)
+        }
         if (agent) {
-          // Index any sub-agent session this tool just exposed so streaming
-          // events on the child session can still bump the parent's activity.
-          if (partType === 'tool') {
-            const childId = getChildSessionId(toolState)
-            if (childId) registerChildSession(childId, agent.id)
-          }
-
           // Extract PR URL from assistant text and tool output parts, but only
           // when the "Create PR" flow was explicitly triggered by the user.
           if (prExtractEnabled.has(agent.id) && message.role === 'assistant' && (partType === 'text' || partType === 'tool') && partText) {
@@ -1659,6 +1756,20 @@ function processEvent(payload: OpenCodeEventPayload): void {
       break
     }
 
+    case 'message.part.delta': {
+      if (props.field !== 'text' || typeof props.delta !== 'string') break
+      const sessionId = props.sessionID as string
+      const messageId = props.messageID as string
+      const partId = props.partID as string
+      const messages = state.messages.get(sessionId) ?? []
+      if (!appendVisibleTextDelta(messages, messageId, partId, props.delta)) break
+      const agent = findAgentBySession(sessionId)
+      if (agent) agent.lastActivityAt = Date.now()
+      else bumpParentActivityForChildSession(sessionId)
+      emitMessagesThrottled(false)
+      break
+    }
+
     case 'permission.asked': {
       const permissionId = props.id as string
       const sessionId = props.sessionID as string
@@ -1673,17 +1784,8 @@ function processEvent(payload: OpenCodeEventPayload): void {
 
       // Try session-based lookup first, fall back to runtime-based lookup
       // in case the sessionID doesn't match (e.g. event ordering race)
-      const agent = findAgentBySession(sessionId) ?? findAgentByRuntime(runtimeId)
+      const agent = findAgentBySession(sessionId) ?? findAgentByChildSession(sessionId) ?? findAgentByRuntime(runtimeId)
       if (agent) {
-        notifyIfNeeded(agent, 'needs_approval')
-
-        agent.status = 'needs_approval'
-        agent.blockedSince = agent.blockedSince ?? Date.now()
-        agent.lastActivityAt = Date.now()
-        // A new permission request means the server has moved on from whatever
-        // the user previously responded to, so clear the guard.
-        agent.respondedAt = undefined
-
         state.permissions.set(permissionId, {
           id: permissionId,
           agentId: agent.id,
@@ -1693,6 +1795,8 @@ function processEvent(payload: OpenCodeEventPayload): void {
           pattern: patterns,
           createdAt: Date.now()
         })
+        updateAgentAfterInterruptChange(agent, true, false)
+        agent.lastActivityAt = Date.now()
 
         emit({ agents: true, permissions: true })
       }
@@ -1704,14 +1808,10 @@ function processEvent(payload: OpenCodeEventPayload): void {
       state.permissions.delete(permissionId)
 
       const sessionId = props.sessionID as string
-      const agent = findAgentBySession(sessionId)
+      const agent = findAgentBySession(sessionId) ?? findAgentByChildSession(sessionId)
       if (agent) {
-        if (agent.status !== 'stopping') {
-          agent.status = 'running'
-          agent.blockedSince = undefined
-        }
+        updateAgentAfterInterruptChange(agent)
         agent.lastActivityAt = Date.now()
-
       }
 
       emit({ agents: true, permissions: true })
@@ -1725,7 +1825,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
 
       // Try session-based lookup first, fall back to runtime-based lookup
       // in case the sessionID doesn't match (e.g. event ordering race)
-      const agent = findAgentBySession(sessionId) ?? findAgentByRuntime(runtimeId)
+      const agent = findAgentBySession(sessionId) ?? findAgentByChildSession(sessionId) ?? findAgentByRuntime(runtimeId)
 
       if (!agent) {
         // No agent matched — log so we can diagnose. The 30s reconciliation
@@ -1741,13 +1841,6 @@ function processEvent(payload: OpenCodeEventPayload): void {
       // Without this the agent stays "running" in the UI while the server is
       // actually blocked waiting for an answer, and the user has no way to
       // know a question is pending.
-      notifyIfNeeded(agent, 'needs_input')
-      agent.status = 'needs_input'
-      agent.blockedSince = agent.blockedSince ?? Date.now()
-      agent.lastActivityAt = Date.now()
-      // A new question means the server has moved on, so clear the guard.
-      agent.respondedAt = undefined
-
       const hasUsableQuestions = Array.isArray(questions) && questions.length > 0
       if (hasUsableQuestions) {
         state.questions.set(requestId, {
@@ -1757,7 +1850,12 @@ function processEvent(payload: OpenCodeEventPayload): void {
           questions,
           createdAt: Date.now()
         })
+        updateAgentAfterInterruptChange(agent, true, false)
       } else {
+        notifyIfNeeded(agent, 'needs_input')
+        agent.status = 'needs_input'
+        agent.blockedSince = agent.blockedSince ?? Date.now()
+        agent.respondedAt = undefined
         // Malformed payload: agent went into needs_input but we don't have the
         // structured question content. Schedule a fast reconciliation so the
         // user isn't stuck looking at a bare placeholder. The next periodic
@@ -1767,6 +1865,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
         })
         scheduleQuestionReconcile()
       }
+      agent.lastActivityAt = Date.now()
 
       emit({ agents: true, questions: true })
       break
@@ -1777,14 +1876,10 @@ function processEvent(payload: OpenCodeEventPayload): void {
       state.questions.delete(requestId)
 
       const sessionId = props.sessionID as string
-      const agent = findAgentBySession(sessionId)
+      const agent = findAgentBySession(sessionId) ?? findAgentByChildSession(sessionId)
       if (agent) {
-        if (agent.status !== 'stopping') {
-          agent.status = 'running'
-          agent.blockedSince = undefined
-        }
+        updateAgentAfterInterruptChange(agent)
         agent.lastActivityAt = Date.now()
-
       }
 
       emit({ agents: true, questions: true })
@@ -1796,14 +1891,10 @@ function processEvent(payload: OpenCodeEventPayload): void {
       state.questions.delete(requestId)
 
       const sessionId = props.sessionID as string
-      const agent = findAgentBySession(sessionId)
+      const agent = findAgentBySession(sessionId) ?? findAgentByChildSession(sessionId)
       if (agent) {
-        if (agent.status !== 'stopping') {
-          agent.status = 'running'
-          agent.blockedSince = undefined
-        }
+        updateAgentAfterInterruptChange(agent)
         agent.lastActivityAt = Date.now()
-
       }
 
       emit({ agents: true, questions: true })
@@ -1987,7 +2078,8 @@ function processEvent(payload: OpenCodeEventPayload): void {
       // A session was deleted (from another client, or server cleanup).
       // Transition the bound agent to errored so the user knows the session
       // is gone and any further interaction would fail.
-      const sessionId = props.sessionID as string
+      const info = props.info as Record<string, unknown> | undefined
+      const sessionId = (props.sessionID ?? info?.id) as string
       const agent = findAgentBySession(sessionId)
       if (agent) {
         agent.status = 'errored'
@@ -1998,15 +2090,19 @@ function processEvent(payload: OpenCodeEventPayload): void {
 
         // Clean up any pending questions/permissions for this session
         for (const [questionId, question] of state.questions) {
-          if (question.sessionId === sessionId) state.questions.delete(questionId)
+          if (question.agentId === agent.id || question.sessionId === sessionId) state.questions.delete(questionId)
         }
         for (const [permissionId, permission] of state.permissions) {
-          if (permission.sessionId === sessionId) state.permissions.delete(permissionId)
+          if (permission.agentId === agent.id || permission.sessionId === sessionId) state.permissions.delete(permissionId)
         }
 
         state.messages.delete(sessionId)
+        clearChildSessionsForAgent(agent.id)
+        childHydrationRetryAgents.delete(agent.id)
         persistAgentMeta(agent.id, { persistedStatus: 'errored' })
         emit({ agents: true, messages: true, questions: true, permissions: true })
+      } else if (findAgentByChildSession(sessionId) || childSessions.has(sessionId)) {
+        removeChildSessionTree(sessionId)
       }
       break
     }
@@ -2222,6 +2318,7 @@ function handleAgentLaunched(payload: AgentLaunchedPayload): void {
       console.debug(`[handleAgentLaunched:hydrate] after hydration storeMsgs=${state.messages.get(payload.sessionId)?.length ?? 0} parts=${state.messages.get(payload.sessionId)?.map(m => `${m.role}:${m.parts.length}`).join(',')}`)
       emit({ messages: true })
     })
+    void refetchChildSessions(payload.id).then(() => emit({ messages: true }))
 
     // Seed configuredModel from runtime config as an authoritative fallback
     // in case step-depth tracking misses events or the resume window is too small.
@@ -2266,6 +2363,7 @@ function handleSessionReset(payload: { id: string; sessionId: string; oldSession
   sessionStepDepth.delete(agent.sessionId)
   clearChildSessionsForAgent(payload.id)
   pendingMessages.delete(payload.id)
+  childHydrationRetryAgents.delete(payload.id)
   agent.sessionId = payload.sessionId
   agent.branchName = payload.branchName
   agent.prUrl = null
@@ -2300,6 +2398,7 @@ function removeAgentState(agentId: string): void {
   taskSummaryLocked.delete(agentId)
   prExtractEnabled.delete(agentId)
   pendingMessages.delete(agentId)
+  childHydrationRetryAgents.delete(agentId)
   const compactingTimer = compactingTimers.get(agentId)
   if (compactingTimer) {
     clearTimeout(compactingTimer)
@@ -2496,15 +2595,17 @@ function scheduleQuestionReconcile(): void {
  * - Ensures agents with pending questions are in 'needs_input' status
  */
 function reconcileQuestions(
-  serverQuestions: Array<{ agentId: string; questions: Array<{ id: string; sessionID: string; questions: LiveQuestionInfo[] }> }>
+  serverQuestions: PendingQuestionSnapshot[]
 ): void {
   let changed = false
 
   // Build a set of all server-reported question IDs and which agents were queried
   const serverQuestionIds = new Set<string>()
   const reconciledAgentIds = new Set<string>()
+  const snapshotAgentIds = new Set<string>()
   for (const entry of serverQuestions) {
-    reconciledAgentIds.add(entry.agentId)
+    snapshotAgentIds.add(entry.agentId)
+    if (entry.complete !== false) reconciledAgentIds.add(entry.agentId)
     for (const q of entry.questions) {
       serverQuestionIds.add(q.id)
     }
@@ -2528,18 +2629,6 @@ function reconcileQuestions(
       }
     }
 
-    // If we have pending questions for this agent, ensure it shows needs_input
-    const agent = state.agents.get(entry.agentId)
-    if (agent && entry.questions.length > 0 && agent.status !== 'needs_input' && agent.status !== 'stopping') {
-      console.warn(
-        `[AgentStore] Reconciliation: agent ${agent.id} has pending questions but status is ${agent.status}, correcting to needs_input`
-      )
-
-      agent.status = 'needs_input'
-      agent.blockedSince = agent.blockedSince ?? Date.now()
-      agent.lastActivityAt = Date.now()
-      changed = true
-    }
   }
 
   // Remove stale local questions that the server no longer reports.
@@ -2556,18 +2645,12 @@ function reconcileQuestions(
     }
   }
 
-  // For agents whose questions were all cleaned up, clear blocked state
-  // so the interrupt guard doesn't permanently lock them in needs_input
-  for (const agentId of reconciledAgentIds) {
+  for (const agentId of snapshotAgentIds) {
     const agent = state.agents.get(agentId)
     if (!agent) continue
-    if (agent.status === 'needs_input' && !agentHasPendingInterrupts(agentId)) {
-      agent.status = 'running'
-      agent.blockedSince = undefined
-      agent.lastActivityAt = Date.now()
-
-      changed = true
-    }
+    const previousStatus = agent.status
+    updateAgentAfterInterruptChange(agent, false, false)
+    if (agent.status !== previousStatus) changed = true
   }
 
   if (changed) emit({ agents: true, questions: true })
@@ -2580,15 +2663,17 @@ function reconcileQuestions(
  * - Ensures agents with pending permissions are in 'needs_approval' status
  */
 function reconcilePermissions(
-  serverPermissions: Array<{ agentId: string; permissions: Array<PermissionRequestPayload> }>
+  serverPermissions: PendingPermissionSnapshot[]
 ): void {
   let changed = false
 
   // Build a set of all server-reported permission IDs and which agents were queried
   const serverPermissionIds = new Set<string>()
   const reconciledAgentIds = new Set<string>()
+  const snapshotAgentIds = new Set<string>()
   for (const entry of serverPermissions) {
-    reconciledAgentIds.add(entry.agentId)
+    snapshotAgentIds.add(entry.agentId)
+    if (entry.complete !== false) reconciledAgentIds.add(entry.agentId)
     for (const perm of entry.permissions) {
       serverPermissionIds.add(perm.id)
     }
@@ -2619,18 +2704,6 @@ function reconcilePermissions(
       }
     }
 
-    // If we have pending permissions for this agent, ensure it shows needs_approval
-    const agent = state.agents.get(entry.agentId)
-    if (agent && entry.permissions.length > 0 && agent.status !== 'needs_approval' && agent.status !== 'stopping') {
-      console.warn(
-        `[AgentStore] Reconciliation: agent ${agent.id} has pending permissions but status is ${agent.status}, correcting to needs_approval`
-      )
-
-      agent.status = 'needs_approval'
-      agent.blockedSince = agent.blockedSince ?? Date.now()
-      agent.lastActivityAt = Date.now()
-      changed = true
-    }
   }
 
   // Remove stale local permissions that the server no longer reports.
@@ -2645,18 +2718,12 @@ function reconcilePermissions(
     }
   }
 
-  // For agents whose permissions were all cleaned up, clear blocked state
-  // so the interrupt guard doesn't permanently lock them in needs_approval
-  for (const agentId of reconciledAgentIds) {
+  for (const agentId of snapshotAgentIds) {
     const agent = state.agents.get(agentId)
     if (!agent) continue
-    if (agent.status === 'needs_approval' && !agentHasPendingInterrupts(agentId)) {
-      agent.status = 'running'
-      agent.blockedSince = undefined
-      agent.lastActivityAt = Date.now()
-
-      changed = true
-    }
+    const previousStatus = agent.status
+    updateAgentAfterInterruptChange(agent, false, false)
+    if (agent.status !== previousStatus) changed = true
   }
 
   if (changed) emit({ agents: true, permissions: true })
@@ -2697,6 +2764,14 @@ function findAgentByChildSession(sessionId: string): LiveAgent | undefined {
   const agentId = childSessionToAgent.get(sessionId)
   if (!agentId) return undefined
   return state.agents.get(agentId)
+}
+
+function associateKnownChildren(parentSessionId: string): void {
+  const taskParts = (state.messages.get(parentSessionId) ?? [])
+    .flatMap((message) => message.parts)
+    .filter((part) => part.type === 'tool' && part.toolName === 'task')
+  if (taskParts.length === 0) return
+  associateChildSessions(taskParts, [...childSessions.values()], parentSessionId)
 }
 
 /** Bump lastActivityAt on the parent agent of a sub-agent's child session.
@@ -2742,7 +2817,11 @@ function registerChildSession(childSessionId: string, parentAgentId: string): vo
  *  and on session reset. */
 function clearChildSessionsForAgent(agentId: string): void {
   for (const [childSessionId, parentId] of childSessionToAgent.entries()) {
-    if (parentId === agentId) childSessionToAgent.delete(childSessionId)
+    if (parentId !== agentId) continue
+    childSessionToAgent.delete(childSessionId)
+    childSessions.delete(childSessionId)
+    state.messages.delete(childSessionId)
+    state.eventLog.delete(childSessionId)
   }
 }
 
@@ -2778,6 +2857,60 @@ function agentHasPendingInterrupts(agentId: string): boolean {
     if (permission.agentId === agentId) return true
   }
   return false
+}
+
+function updateAgentAfterInterruptChange(
+  agent: LiveAgent,
+  notify = false,
+  markResponded = true
+): void {
+  if (agent.status === 'stopping') return
+  const pendingStatus = getPendingInterruptStatus(agent.id, state.permissions.values(), state.questions.values())
+  if (pendingStatus) {
+    if (notify) notifyIfNeeded(agent, pendingStatus)
+    agent.status = pendingStatus
+    agent.blockedSince = agent.blockedSince ?? Date.now()
+    agent.respondedAt = undefined
+    return
+  }
+  if (!markResponded && agent.status !== 'needs_input' && agent.status !== 'needs_approval') return
+  agent.status = 'running'
+  agent.blockedSince = undefined
+  agent.respondedAt = markResponded ? Date.now() : undefined
+}
+
+function removeChildSessionTree(sessionId: string): void {
+  const owner = findAgentByChildSession(sessionId)
+  const removedIds = collectSessionSubtreeIds(childSessions.values(), sessionId)
+
+  for (const removedId of removedIds) {
+    childSessionToAgent.delete(removedId)
+    childSessions.delete(removedId)
+    state.messages.delete(removedId)
+    state.eventLog.delete(removedId)
+    for (const [questionId, question] of state.questions) {
+      if (question.sessionId === removedId) state.questions.delete(questionId)
+    }
+    for (const [permissionId, permission] of state.permissions) {
+      if (permission.sessionId === removedId) state.permissions.delete(permissionId)
+    }
+  }
+
+  for (const messages of state.messages.values()) {
+    for (const message of messages) {
+      for (const part of message.parts) {
+        if (part.childSessionId && removedIds.has(part.childSessionId)) {
+          part.childSessionId = undefined
+        }
+      }
+    }
+  }
+
+  if (owner && (owner.status === 'needs_input' || owner.status === 'needs_approval')) {
+    updateAgentAfterInterruptChange(owner, false, false)
+    owner.lastActivityAt = Date.now()
+  }
+  emit({ agents: true, messages: true, questions: true, permissions: true })
 }
 
 /**
@@ -2887,6 +3020,8 @@ async function refetchSessionMessages(agentId: string): Promise<void> {
       emit({ messages: true })
     }
   }
+  await refetchChildSessions(agentId)
+  emit({ messages: true })
 }
 
 function mapSessionStatus(statusType: string): AgentStatus {
@@ -3014,17 +3149,26 @@ export function useAgentStore() {
         }
 
         const messageResults = await Promise.all(
-          agentsResult.data.map(async (agent) => ({
-            result: await window.api.getMessages(agent.id)
-          }))
+          agentsResult.data.map(async (agent) => {
+            const [messages, children] = await Promise.all([
+              window.api.getMessages(agent.id),
+              window.api.getChildSessions(agent.id)
+            ])
+            return { agentId: agent.id, messages, children }
+          })
         )
 
         if (cancelled) return
 
-        for (const { result } of messageResults) {
-          if (!result.ok) continue
-          hydrateHistoricalMessages(result.data)
-          shouldEmit = true
+        for (const { agentId, messages, children } of messageResults) {
+          if (messages.ok) {
+            hydrateHistoricalMessages(messages.data)
+            shouldEmit = true
+          }
+          if (children.ok) {
+            applyChildSessionHydration(children.data, agentId)
+            shouldEmit = true
+          }
         }
       }
 
@@ -3039,7 +3183,7 @@ export function useAgentStore() {
       try {
         const questionsResult = await window.api.listQuestions()
         if (!cancelled && questionsResult.ok && questionsResult.data) {
-          for (const entry of questionsResult.data as Array<{ agentId: string; questions: Array<{ id: string; sessionID: string; questions: LiveQuestionInfo[] }> }>) {
+          for (const entry of questionsResult.data as PendingQuestionSnapshot[]) {
             for (const q of entry.questions) {
               state.questions.set(q.id, {
                 id: q.id,
@@ -3049,8 +3193,10 @@ export function useAgentStore() {
                 createdAt: Date.now()
               })
             }
+            const agent = state.agents.get(entry.agentId)
+            if (agent) updateAgentAfterInterruptChange(agent, false, false)
           }
-          emit({ questions: true })
+          emit({ agents: true, questions: true })
         }
       } catch {
         // Questions API may not be available on older servers
@@ -3060,7 +3206,7 @@ export function useAgentStore() {
       try {
         const permissionsResult = await window.api.listPermissions()
         if (!cancelled && permissionsResult.ok && permissionsResult.data) {
-          for (const entry of permissionsResult.data as Array<{ agentId: string; permissions: Array<PermissionRequestPayload> }>) {
+          for (const entry of permissionsResult.data as PendingPermissionSnapshot[]) {
             for (const perm of entry.permissions) {
               const permType = perm.permission ?? 'unknown'
               const title = perm.patterns?.length
@@ -3077,8 +3223,10 @@ export function useAgentStore() {
                 createdAt: Date.now()
               })
             }
+            const agent = state.agents.get(entry.agentId)
+            if (agent) updateAgentAfterInterruptChange(agent, false, false)
           }
-          emit({ permissions: true })
+          emit({ agents: true, permissions: true })
         }
       } catch {
         // Permissions API may not be available on older servers
@@ -3181,7 +3329,7 @@ export function useAgentStore() {
         const questionsResult = await window.api.listQuestions()
         if (cancelled) return
         if (questionsResult.ok && questionsResult.data) {
-          reconcileQuestions(questionsResult.data as Array<{ agentId: string; questions: Array<{ id: string; sessionID: string; questions: LiveQuestionInfo[] }> }>)
+          reconcileQuestions(questionsResult.data as PendingQuestionSnapshot[])
         }
 
         // Same for permissions — if a permission.asked SSE event was missed,
@@ -3189,7 +3337,13 @@ export function useAgentStore() {
         const permissionsResult = await window.api.listPermissions()
         if (cancelled) return
         if (permissionsResult.ok && permissionsResult.data) {
-          reconcilePermissions(permissionsResult.data as Array<{ agentId: string; permissions: Array<PermissionRequestPayload> }>)
+          reconcilePermissions(permissionsResult.data as PendingPermissionSnapshot[])
+        }
+
+        if (childHydrationRetryAgents.size > 0) {
+          await Promise.all([...childHydrationRetryAgents].map((agentId) => refetchChildSessions(agentId)))
+          if (cancelled) return
+          emit({ messages: true })
         }
 
         // Watchdog: if an agent has been 'running' with no activity for N minutes,
@@ -3462,32 +3616,28 @@ export function useAgentStore() {
     const previousLabelIds = agent?.labelIds ? [...agent.labelIds] : []
     const removedPermission = state.permissions.get(permissionId)
 
-    // Optimistically clear permission and set running
     state.permissions.delete(permissionId)
     if (agent) {
-      if (agent.status !== 'stopping') {
-        agent.status = 'running'
-        agent.blockedSince = undefined
-      }
+      updateAgentAfterInterruptChange(agent)
       agent.lastActivityAt = Date.now()
-      agent.respondedAt = Date.now()
-
     }
     emit({ agents: true, permissions: true })
 
     const result = await window.api.respondToPermission(agentId, permissionId, response)
 
     if (result && !result.ok) {
-      const agentAfter = state.agents.get(agentId)
-      if (agentAfter && agentAfter.status === 'running') {
-        agentAfter.status = previousStatus ?? 'idle'
-        agentAfter.blockedSince = previousBlockedSince
-        agentAfter.respondedAt = undefined
-        agentAfter.lastActivityAt = Date.now()
-        agentAfter.labelIds = previousLabelIds
-      }
       if (removedPermission) {
         state.permissions.set(permissionId, removedPermission)
+      }
+      const agentAfter = state.agents.get(agentId)
+      if (agentAfter) {
+        updateAgentAfterInterruptChange(agentAfter, false, false)
+        if (!removedPermission) {
+          agentAfter.status = previousStatus ?? 'idle'
+          agentAfter.blockedSince = previousBlockedSince
+        }
+        agentAfter.lastActivityAt = Date.now()
+        agentAfter.labelIds = previousLabelIds
       }
       emit({ agents: true, permissions: true })
     }
@@ -3504,30 +3654,28 @@ export function useAgentStore() {
     const previousLabelIds = agent?.labelIds ? [...agent.labelIds] : []
     const removedQuestion = state.questions.get(requestId)
 
-    // Optimistically clear question and set running
     state.questions.delete(requestId)
     if (agent) {
-      agent.status = 'running'
-      agent.blockedSince = undefined
+      updateAgentAfterInterruptChange(agent)
       agent.lastActivityAt = Date.now()
-      agent.respondedAt = Date.now()
-
     }
     emit({ agents: true, questions: true })
 
     const result = await window.api.replyToQuestion(agentId, requestId, answers)
 
     if (result && !result.ok) {
-      const agentAfter = state.agents.get(agentId)
-      if (agentAfter && agentAfter.status === 'running') {
-        agentAfter.status = previousStatus ?? 'idle'
-        agentAfter.blockedSince = previousBlockedSince
-        agentAfter.respondedAt = undefined
-        agentAfter.lastActivityAt = Date.now()
-        agentAfter.labelIds = previousLabelIds
-      }
       if (removedQuestion) {
         state.questions.set(requestId, removedQuestion)
+      }
+      const agentAfter = state.agents.get(agentId)
+      if (agentAfter) {
+        updateAgentAfterInterruptChange(agentAfter, false, false)
+        if (!removedQuestion) {
+          agentAfter.status = previousStatus ?? 'idle'
+          agentAfter.blockedSince = previousBlockedSince
+        }
+        agentAfter.lastActivityAt = Date.now()
+        agentAfter.labelIds = previousLabelIds
       }
       emit({ agents: true, questions: true })
     }
@@ -3544,30 +3692,28 @@ export function useAgentStore() {
     const previousLabelIds = agent?.labelIds ? [...agent.labelIds] : []
     const removedQuestion = state.questions.get(requestId)
 
-    // Optimistically clear question and set running
     state.questions.delete(requestId)
     if (agent) {
-      agent.status = 'running'
-      agent.blockedSince = undefined
+      updateAgentAfterInterruptChange(agent)
       agent.lastActivityAt = Date.now()
-      agent.respondedAt = Date.now()
-
     }
     emit({ agents: true, questions: true })
 
     const result = await window.api.rejectQuestion(agentId, requestId)
 
     if (result && !result.ok) {
-      const agentAfter = state.agents.get(agentId)
-      if (agentAfter && agentAfter.status === 'running') {
-        agentAfter.status = previousStatus ?? 'idle'
-        agentAfter.blockedSince = previousBlockedSince
-        agentAfter.respondedAt = undefined
-        agentAfter.lastActivityAt = Date.now()
-        agentAfter.labelIds = previousLabelIds
-      }
       if (removedQuestion) {
         state.questions.set(requestId, removedQuestion)
+      }
+      const agentAfter = state.agents.get(agentId)
+      if (agentAfter) {
+        updateAgentAfterInterruptChange(agentAfter, false, false)
+        if (!removedQuestion) {
+          agentAfter.status = previousStatus ?? 'idle'
+          agentAfter.blockedSince = previousBlockedSince
+        }
+        agentAfter.lastActivityAt = Date.now()
+        agentAfter.labelIds = previousLabelIds
       }
       emit({ agents: true, questions: true })
     }

--- a/src/renderer/src/lib/interrupt-status.ts
+++ b/src/renderer/src/lib/interrupt-status.ts
@@ -1,0 +1,17 @@
+export interface AgentInterrupt {
+  agentId: string
+}
+
+export function getPendingInterruptStatus(
+  agentId: string,
+  permissions: Iterable<AgentInterrupt>,
+  questions: Iterable<AgentInterrupt>
+): 'needs_input' | 'needs_approval' | undefined {
+  for (const question of questions) {
+    if (question.agentId === agentId) return 'needs_input'
+  }
+  for (const permission of permissions) {
+    if (permission.agentId === agentId) return 'needs_approval'
+  }
+  return undefined
+}

--- a/src/renderer/src/lib/subagent-progress.ts
+++ b/src/renderer/src/lib/subagent-progress.ts
@@ -1,0 +1,214 @@
+import type { LiveMessage, LiveMessagePart } from '../hooks/useAgentStore'
+
+export type DisplayToolState = 'running' | 'completed' | 'failed'
+
+export interface ChildTranscriptEntry {
+  id: string
+  kind: 'text' | 'tool'
+  label: string
+  toolState?: DisplayToolState
+  toolSummary?: string
+  toolOutput?: string
+  childSessionId?: string
+  childTranscript?: ChildTranscriptEntry[]
+}
+
+export interface ChildSessionDescriptor {
+  id: string
+  parentID: string
+  title?: string
+}
+
+export interface TaskPartDescriptor {
+  toolInput?: string
+  childSessionId?: string
+}
+
+export function mapToolState(toolState?: string): DisplayToolState {
+  if (toolState === 'completed') return 'completed'
+  if (toolState === 'error' || toolState === 'failed') return 'failed'
+  return 'running'
+}
+
+export function getChildSessionId(partState: Record<string, unknown> | undefined): string | undefined {
+  const metadata = partState?.metadata as Record<string, unknown> | undefined
+  const sessionId = metadata?.sessionId
+  return typeof sessionId === 'string' ? sessionId : undefined
+}
+
+export function getToolMetadataOutput(partState: Record<string, unknown> | undefined): string | undefined {
+  const metadata = partState?.metadata as Record<string, unknown> | undefined
+  const output = metadata?.output
+  return typeof output === 'string' && output.length > 0 ? output : undefined
+}
+
+export function appendVisibleTextDelta(
+  messages: LiveMessage[],
+  messageId: string,
+  partId: string,
+  delta: string
+): boolean {
+  const message = messages.find((candidate) => candidate.id === messageId)
+  const part = message?.parts.find((candidate) => candidate.id === partId)
+  if (!part || part.type !== 'text') return false
+  part.text = (part.text ?? '') + delta
+  return true
+}
+
+export function associateChildSessions(
+  taskParts: TaskPartDescriptor[],
+  sessions: ChildSessionDescriptor[],
+  parentSessionId: string
+): void {
+  const usedChildIds = new Set(taskParts.map((part) => part.childSessionId).filter(Boolean))
+  const unassignedChildren = sessions.filter(
+    (info) => info.parentID === parentSessionId && !usedChildIds.has(info.id)
+  )
+  const unassignedParts = taskParts.filter((part) => !part.childSessionId)
+
+  for (const child of unassignedChildren) {
+    const childTitle = child.title?.replace(/\s+\(@.+ subagent\)$/, '').trim()
+    const titleMatches = childTitle
+      ? unassignedParts.filter((part) => getTaskDescription(part) === childTitle)
+      : []
+    const hasCorrelationData = !!childTitle || unassignedParts.some((part) => !!getTaskDescription(part))
+    const match = titleMatches.length === 1
+      ? titleMatches[0]
+      : !hasCorrelationData && unassignedChildren.length === 1 && unassignedParts.length === 1
+        ? unassignedParts[0]
+        : undefined
+    if (!match) continue
+    match.childSessionId = child.id
+    unassignedParts.splice(unassignedParts.indexOf(match), 1)
+  }
+}
+
+export function mergeLiveMessagePart(existing: LiveMessagePart, next: LiveMessagePart): void {
+  const existingTerminal = isTerminalToolState(existing.toolState)
+  const nextTerminal = isTerminalToolState(next.toolState)
+
+  existing.type = next.type
+  existing.toolName = next.toolName ?? existing.toolName
+  existing.toolInput = next.toolInput ?? existing.toolInput
+  existing.synthetic = next.synthetic ?? existing.synthetic
+  existing.fileMime = next.fileMime ?? existing.fileMime
+  existing.fileUrl = next.fileUrl ?? existing.fileUrl
+  existing.fileName = next.fileName ?? existing.fileName
+  existing.compactionAuto = next.compactionAuto ?? existing.compactionAuto
+  existing.compactionOverflow = next.compactionOverflow ?? existing.compactionOverflow
+  existing.childSessionId = next.childSessionId ?? existing.childSessionId
+
+  if (!existingTerminal || nextTerminal) {
+    existing.toolState = next.toolState ?? existing.toolState
+  }
+
+  if (
+    next.text !== undefined &&
+    (
+      existing.text === undefined ||
+      (nextTerminal && !existingTerminal) ||
+      (!existingTerminal && next.text.length >= existing.text.length)
+    )
+  ) {
+    existing.text = next.text
+  }
+}
+
+export function collectSessionSubtreeIds(
+  sessions: Iterable<ChildSessionDescriptor>,
+  rootSessionId: string
+): Set<string> {
+  const result = new Set([rootSessionId])
+  let changed = true
+  while (changed) {
+    changed = false
+    for (const session of sessions) {
+      if (!result.has(session.parentID) || result.has(session.id)) continue
+      result.add(session.id)
+      changed = true
+    }
+  }
+  return result
+}
+
+export function buildChildTranscript(
+  sessionId: string,
+  getMessagesForSession: (sessionId: string) => LiveMessage[],
+  ancestors: ReadonlySet<string> = new Set()
+): ChildTranscriptEntry[] {
+  if (ancestors.has(sessionId)) return []
+
+  const nextAncestors = new Set(ancestors)
+  nextAncestors.add(sessionId)
+  const entries: ChildTranscriptEntry[] = []
+
+  for (const message of getMessagesForSession(sessionId)) {
+    if (message.role !== 'assistant') continue
+
+    for (const part of message.parts) {
+      if (part.type === 'text' && part.text) {
+        entries.push({ id: part.id, kind: 'text', label: part.text })
+      } else if (part.type === 'tool' && part.toolName) {
+        entries.push({
+          id: part.id,
+          kind: 'tool',
+          label: part.toolName,
+          toolState: mapToolState(part.toolState),
+          toolSummary: summarizeChildToolInput(part.toolName, part.toolInput),
+          toolOutput: part.text,
+          childSessionId: part.childSessionId,
+          childTranscript: part.childSessionId
+            ? buildChildTranscript(part.childSessionId, getMessagesForSession, nextAncestors)
+            : undefined
+        })
+      }
+    }
+  }
+
+  return entries
+}
+
+export function summarizeChildToolInput(name: string, input: string | undefined): string | undefined {
+  if (!input) return undefined
+  try {
+    const parsed = JSON.parse(input) as Record<string, unknown>
+    const pick = (...keys: string[]): string | undefined => {
+      for (const key of keys) {
+        const value = parsed[key]
+        if (typeof value === 'string' && value.trim()) return value
+      }
+      return undefined
+    }
+    const raw = (() => {
+      switch (name.toLowerCase()) {
+        case 'bash': return pick('command')
+        case 'read': case 'write': case 'edit': return pick('filePath', 'file_path', 'path')
+        case 'grep': return pick('pattern')
+        case 'glob': return pick('pattern')
+        case 'webfetch': return pick('url')
+        case 'task': return pick('description', 'prompt')
+        default: return undefined
+      }
+    })()
+    if (!raw) return undefined
+    const oneLine = raw.replace(/\s+/g, ' ').trim()
+    return oneLine.length > 80 ? oneLine.slice(0, 80) + '...' : oneLine
+  } catch {
+    return undefined
+  }
+}
+
+function getTaskDescription(part: TaskPartDescriptor): string | undefined {
+  if (!part.toolInput) return undefined
+  try {
+    const input = JSON.parse(part.toolInput) as Record<string, unknown>
+    const description = input.description
+    return typeof description === 'string' ? description : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function isTerminalToolState(state: string | undefined): boolean {
+  return state === 'completed' || state === 'error' || state === 'failed'
+}

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -23,6 +23,7 @@ export interface OrchestratorApi {
   removeAgent: (agentId: string) => Promise<IpcResult>
   resetSession: (agentId: string, prompt?: string) => Promise<IpcResult>
   getMessages: (agentId: string) => Promise<IpcResult>
+  getChildSessions: (agentId: string) => Promise<IpcResult>
   listCommands: (agentId: string) => Promise<IpcResult>
   executeCommand: (agentId: string, command: string, args: string) => Promise<IpcResult>
   getConfig: (agentId: string) => Promise<IpcResult>


### PR DESCRIPTION
Active OpenCode subagents could run for minutes without useful feedback. OCO ignored visible text
deltas, relied on late task metadata to discover child sessions, and only reloaded the parent
session after a restart.

OCO now discovers child sessions from the session tree and task metadata. It streams assistant
text, tool state, and tool output in the Transcript and Tools views. Running tasks open
automatically, while completed output stays collapsible. Nested sessions and child interrupts
keep their parent mapping through restarts and event races.

Verified with the full test suite, type checks, production build, and desktop and mobile browser
checks.