### PR TITLE
NO-JIRA Move updated subagent progress to transcript bottom

### DIFF
--- a/src/__tests__/subagent-progress.test.ts
+++ b/src/__tests__/subagent-progress.test.ts
@@ -7,20 +7,24 @@ import {
   appendVisibleTextDelta,
   associateChildSessions,
   buildChildTranscript,
+  getLatestChildActivityAt,
   getChildSessionId,
   getToolMetadataOutput,
   collectSessionSubtreeIds,
   mergeLiveMessagePart,
+  orderTranscriptByActivity,
   type TaskPartDescriptor
 } from '../renderer/src/lib/subagent-progress'
 import { getPendingInterruptStatus } from '../renderer/src/lib/interrupt-status'
+import type { Message } from '../renderer/src/types'
 
-function assistantMessage(sessionId: string, parts: LiveMessage['parts']): LiveMessage {
+function assistantMessage(sessionId: string, parts: LiveMessage['parts'], updatedAt = 1): LiveMessage {
   return {
     id: `message-${sessionId}`,
     role: 'assistant',
     sessionId,
     createdAt: 1,
+    updatedAt,
     parts
   }
 }
@@ -129,10 +133,10 @@ describe('subagent progress', () => {
           toolState: 'completed',
           childSessionId: 'grandchild'
         }
-      ])]],
+      ], 2)]],
       ['grandchild', [assistantMessage('grandchild', [
         { id: 'final', type: 'text', text: 'nested final output' }
-      ])]]
+      ], 3)]]
     ])
 
     const transcript = buildChildTranscript('child', (sessionId) => messages.get(sessionId) ?? [])
@@ -147,6 +151,30 @@ describe('subagent progress', () => {
       kind: 'text',
       label: 'nested final output'
     })
+    expect(getLatestChildActivityAt(
+      'child',
+      (sessionId) => messages.get(sessionId) ?? [],
+      (sessionId) => sessionId === 'child' ? 4 : undefined
+    )).toBe(4)
+  })
+
+  it('places the most recently updated subagent at the bottom of the transcript', () => {
+    const userMessage: Message = {
+      id: 'user', role: 'user', content: 'continue', timestamp: 'now', activityAt: 15
+    }
+    const taskGroup: Message = {
+      id: 'tasks', role: 'tool-group', content: '2 tool calls', timestamp: 'now', activityAt: 1,
+      toolCalls: [{
+        id: 'older', name: 'task', state: 'completed', timestamp: 1,
+        childSessionId: 'older-child', childActivityAt: 10
+      }, {
+        id: 'newer', name: 'task', state: 'running', timestamp: 2,
+        childSessionId: 'newer-child', childActivityAt: 20
+      }]
+    }
+
+    expect(orderTranscriptByActivity([taskGroup, userMessage]).map((message) => message.id))
+      .toEqual(['tasks-older', 'user', 'tasks-newer'])
   })
 
   it('expands running tasks immediately and keeps completed transcripts collapsible', () => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -20,7 +20,12 @@ import type { FileChange } from './components/FilesChanged'
 import type { ToolCall } from './components/ToolsUsage'
 import type { EventEntry } from './components/EventLog'
 import { loadSettings, parseSlashCommand, type QuickAction } from './data/settings'
-import { buildChildTranscript, mapToolState } from './lib/subagent-progress'
+import {
+  buildChildTranscript,
+  getLatestChildActivityAt,
+  mapToolState,
+  orderTranscriptByActivity
+} from './lib/subagent-progress'
 
 const NEW_AGENT_COMMAND = '/new'
 const AGENT_MENTION_REGEX = /@(\w+)/
@@ -150,6 +155,7 @@ export function App() {
     listCommands,
     listAgentConfigs,
     getMessagesForSession,
+    getChildSessionActivityAt,
     getFileChangesForSession,
     getEventsForSession,
     hydrateFileChangesFromGit: storeHydrateFileChangesFromGit,
@@ -552,6 +558,7 @@ export function App() {
         role: 'tool-group',
         content: `${pendingToolCalls.length} tool call${pendingToolCalls.length === 1 ? '' : 's'}`,
         timestamp: formatTimeAgo(timestamp),
+        activityAt: timestamp,
         toolCalls: pendingToolCalls
       })
 
@@ -584,6 +591,13 @@ export function App() {
               output: part.text ?? undefined,
               timestamp: msg.createdAt,
               childSessionId: part.childSessionId,
+              childActivityAt: part.childSessionId
+                ? getLatestChildActivityAt(
+                    part.childSessionId,
+                    getMessagesForSession,
+                    getChildSessionActivityAt
+                  )
+                : undefined,
               childTranscript: part.childSessionId
                 ? buildChildTranscript(part.childSessionId, getMessagesForSession)
                 : undefined
@@ -619,6 +633,7 @@ export function App() {
             ? 'Session compacted automatically to free context window'
             : 'Session compacted',
           timestamp: formatTimeAgo(msg.createdAt),
+          activityAt: msg.createdAt,
           compactionActive: !!liveAgentForCompaction?.compacting,
           compactionAuto: compactionPart.auto
         })
@@ -634,6 +649,7 @@ export function App() {
           role: msg.role,
           content: textContent,
           timestamp: formatTimeAgo(msg.createdAt),
+          activityAt: msg.createdAt,
           ...(images.length > 0 ? { images } : {})
         })
       }
@@ -652,8 +668,8 @@ export function App() {
       flushPendingToolCalls(lastMessage.id, lastMessage.createdAt)
     }
 
-    return transcriptItems
-  }, [selectedAgent, store.agents, getMessagesForSession])
+    return orderTranscriptByActivity(transcriptItems)
+  }, [selectedAgent, store.agents, getMessagesForSession, getChildSessionActivityAt])
 
   // ── File changes for selected agent ──
   const selectedFiles: FileChange[] = useMemo(() => {

--- a/src/renderer/src/components/ToolsUsage.tsx
+++ b/src/renderer/src/components/ToolsUsage.tsx
@@ -10,6 +10,7 @@ export interface ToolCall {
   input?: string
   output?: string
   timestamp: number
+  childActivityAt?: number
   /** For the `task` tool — sessionId of the sub-agent, so the UI can
    *  render live progress by reading the child session's messages. */
   childSessionId?: string

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -225,6 +225,7 @@ export interface LiveMessage {
   role: 'user' | 'assistant'
   sessionId: string
   createdAt: number
+  updatedAt?: number
   parts: LiveMessagePart[]
 }
 
@@ -794,11 +795,13 @@ function injectOptimisticUserMessage(sessionId: string, text: string): void {
   if (!text.trim()) return
   const messages = state.messages.get(sessionId) ?? []
   const id = `${OPTIMISTIC_PREFIX}${++optimisticCounter}`
+  const now = Date.now()
   messages.push({
     id,
     role: 'user',
     sessionId,
-    createdAt: Date.now(),
+    createdAt: now,
+    updatedAt: now,
     parts: [{ id: `${id}-part`, type: 'text', text }]
   })
   state.messages.set(sessionId, messages)
@@ -831,6 +834,7 @@ function adoptOptimisticUserMessage(sessionId: string, serverMessageId: string, 
   if (!target) return false
   target.id = serverMessageId
   target.createdAt = createdAt
+  target.updatedAt = Date.now()
   return true
 }
 
@@ -841,6 +845,10 @@ function upsertMessage(message: LiveMessage): LiveMessage {
   if (existingMessage) {
     existingMessage.role = message.role
     existingMessage.createdAt = message.createdAt
+    existingMessage.updatedAt = Math.max(
+      existingMessage.updatedAt ?? existingMessage.createdAt,
+      message.updatedAt ?? message.createdAt
+    )
     return existingMessage
   }
 
@@ -978,6 +986,7 @@ function hydrateHistoricalMessages(entries: unknown): void {
       role: entry.info.role,
       sessionId: entry.info.sessionID,
       createdAt,
+      updatedAt: entry.info.time?.completed ?? createdAt,
       parts: []
     })
 
@@ -1079,7 +1088,19 @@ function hydrateChildSessions(entries: unknown, parentAgentId: string): void {
 
   for (const entry of entries as HydratedChildSession[]) {
     if (!entry?.info?.id || !entry.info.parentID) continue
-    childSessions.set(entry.info.id, entry.info)
+    const rawInfo = entry.info as ChildSessionInfo & { time?: { updated?: number } }
+    const existing = childSessions.get(rawInfo.id)
+    const hydratedUpdatedAt = rawInfo.updatedAt ?? rawInfo.time?.updated
+    childSessions.set(rawInfo.id, {
+      id: rawInfo.id,
+      parentID: rawInfo.parentID,
+      title: rawInfo.title ?? existing?.title,
+      updatedAt: Math.max(existing?.updatedAt ?? 0, hydratedUpdatedAt ?? 0) || undefined
+    })
+  }
+
+  for (const info of childSessions.values()) {
+    if (info.updatedAt !== undefined) setChildSessionActivity(info.id, info.updatedAt)
   }
 
   for (const entry of entries as HydratedChildSession[]) {
@@ -1390,20 +1411,23 @@ function processEvent(payload: OpenCodeEventPayload): void {
       const info = props.info as Record<string, unknown> | undefined
       const sessionId = info?.id as string | undefined
       if (!sessionId) break
+      const time = info?.time as { updated?: number; compacting?: number } | undefined
       const parentSessionId = info?.parentID as string | undefined
       if (parentSessionId) {
+        const existing = childSessions.get(sessionId)
         childSessions.set(sessionId, {
           id: sessionId,
           parentID: parentSessionId,
-          title: info?.title as string | undefined
+          title: (info?.title as string | undefined) ?? existing?.title,
+          updatedAt: Math.max(existing?.updatedAt ?? 0, time?.updated ?? 0) || undefined
         })
+        if (time?.updated !== undefined) setChildSessionActivity(sessionId, time.updated)
         const owner = findAgentBySession(parentSessionId) ?? findAgentByChildSession(parentSessionId)
         if (owner) registerChildSession(sessionId, owner.id)
         associateKnownChildren(parentSessionId)
       }
       const agent = findAgentBySession(sessionId)
       if (agent) {
-        const time = info?.time as { updated?: number; compacting?: number } | undefined
         agent.lastActivityAt = typeof time?.updated === 'number' ? time.updated : Date.now()
 
         // The server sets session.time.compacting to a timestamp while
@@ -1436,6 +1460,8 @@ function processEvent(payload: OpenCodeEventPayload): void {
           persistAgentMeta(agent.id, { taskSummary: agent.taskSummary })
         }
         emit({ agents: true })
+      } else if (parentSessionId) {
+        emit({ messages: true })
       }
       break
     }
@@ -1542,16 +1568,19 @@ function processEvent(payload: OpenCodeEventPayload): void {
       const messages = state.messages.get(sessionId) ?? []
       const existing = messages.find((msg) => msg.id === messageId)
       if (!existing && !adopted) {
+        const now = Date.now()
         messages.push({
           id: messageId,
           role,
           sessionId,
           createdAt,
+          updatedAt: now,
           parts: []
         })
         state.messages.set(sessionId, messages)
       } else if (existing) {
         existing.createdAt = createdAt
+        existing.updatedAt = Date.now()
         existing.role = role
       }
 
@@ -1599,6 +1628,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
       const message = messages.find((msg) => msg.id === messageId)
 
       if (message) {
+        message.updatedAt = Date.now()
         const existingPart = message.parts.find((partItem) => partItem.id === partId)
         const toolState = part.state as Record<string, unknown> | undefined
 
@@ -2779,7 +2809,22 @@ function associateKnownChildren(parentSessionId: string): void {
  *  heartbeat so the stalled-watchdog doesn't fire while a task tool runs. */
 function bumpParentActivityForChildSession(sessionId: string): void {
   const parent = findAgentByChildSession(sessionId)
-  if (parent) parent.lastActivityAt = Date.now()
+  if (!parent) return
+  const now = Date.now()
+  parent.lastActivityAt = now
+  setChildSessionActivity(sessionId, now)
+}
+
+function setChildSessionActivity(sessionId: string, updatedAt: number): void {
+  const visited = new Set<string>()
+  let currentId: string | undefined = sessionId
+  while (currentId && !visited.has(currentId)) {
+    visited.add(currentId)
+    const info = childSessions.get(currentId)
+    if (!info) return
+    info.updatedAt = Math.max(info.updatedAt ?? 0, updatedAt)
+    currentId = info.parentID
+  }
 }
 
 /** Returns true when any tool part in the agent's transcript has not reached a
@@ -3807,6 +3852,10 @@ export function useAgentStore() {
     return storeState.messages.get(sessionId) ?? []
   }, [messagesVersion])
 
+  const getChildSessionActivityAt = useCallback((sessionId: string): number | undefined => {
+    return childSessions.get(sessionId)?.updatedAt
+  }, [messagesVersion])
+
   const getFileChangesForSession = useCallback((sessionId: string): FileChangeRecord[] => {
     const raw = storeState.fileChanges.get(sessionId) ?? []
     if (raw.length === 0) return raw
@@ -4039,6 +4088,7 @@ export function useAgentStore() {
     compactSession,
     selectDirectory,
     getMessagesForSession,
+    getChildSessionActivityAt,
     getFileChangesForSession,
     getEventsForSession,
     getToolCallsForSession,
@@ -4052,7 +4102,7 @@ export function useAgentStore() {
     abortAgent, removeAgent, renameAgent, setAgentModel,
     toggleLabel, clearLabels, setPrUrl,
     dismissAgentError, compactSession, selectDirectory,
-    getMessagesForSession, getFileChangesForSession,
+    getMessagesForSession, getChildSessionActivityAt, getFileChangesForSession,
     getEventsForSession, getToolCallsForSession,
     hydrateFileChangesFromGit
   ])

--- a/src/renderer/src/lib/subagent-progress.ts
+++ b/src/renderer/src/lib/subagent-progress.ts
@@ -1,4 +1,5 @@
 import type { LiveMessage, LiveMessagePart } from '../hooks/useAgentStore'
+import type { Message } from '../types'
 
 export type DisplayToolState = 'running' | 'completed' | 'failed'
 
@@ -17,6 +18,7 @@ export interface ChildSessionDescriptor {
   id: string
   parentID: string
   title?: string
+  updatedAt?: number
 }
 
 export interface TaskPartDescriptor {
@@ -49,9 +51,11 @@ export function appendVisibleTextDelta(
   delta: string
 ): boolean {
   const message = messages.find((candidate) => candidate.id === messageId)
-  const part = message?.parts.find((candidate) => candidate.id === partId)
+  if (!message) return false
+  const part = message.parts.find((candidate) => candidate.id === partId)
   if (!part || part.type !== 'text') return false
   part.text = (part.text ?? '') + delta
+  message.updatedAt = Date.now()
   return true
 }
 
@@ -166,6 +170,76 @@ export function buildChildTranscript(
   }
 
   return entries
+}
+
+export function getLatestChildActivityAt(
+  sessionId: string,
+  getMessagesForSession: (sessionId: string) => LiveMessage[],
+  getSessionUpdatedAt?: (sessionId: string) => number | undefined,
+  ancestors: ReadonlySet<string> = new Set()
+): number | undefined {
+  if (ancestors.has(sessionId)) return undefined
+
+  const nextAncestors = new Set(ancestors)
+  nextAncestors.add(sessionId)
+  let latest = getSessionUpdatedAt?.(sessionId)
+
+  for (const message of getMessagesForSession(sessionId)) {
+    latest = Math.max(latest ?? 0, message.updatedAt ?? message.createdAt)
+    for (const part of message.parts) {
+      if (!part.childSessionId) continue
+      const nested = getLatestChildActivityAt(
+        part.childSessionId,
+        getMessagesForSession,
+        getSessionUpdatedAt,
+        nextAncestors
+      )
+      if (nested !== undefined) latest = Math.max(latest, nested)
+    }
+  }
+
+  return latest
+}
+
+export function orderTranscriptByActivity(messages: Message[]): Message[] {
+  return messages
+    .flatMap(splitTaskToolGroups)
+    .map((message, index) => ({
+      message,
+      index,
+      activityAt: message.toolCalls
+        ?.filter((tool) => tool.name === 'task')
+        .reduce((latest, tool) => Math.max(latest, tool.childActivityAt ?? latest), message.activityAt ?? 0)
+        ?? message.activityAt
+        ?? index
+    }))
+    .sort((left, right) => left.activityAt - right.activityAt || left.index - right.index)
+    .map(({ message }) => message)
+}
+
+export function splitTaskToolGroups(message: Message): Message[] {
+  const tools = message.toolCalls
+  if (message.role !== 'tool-group' || !tools?.some((tool) => tool.name === 'task')) {
+    return [message]
+  }
+
+  const groups = tools.reduce<Array<typeof tools>>((result, tool) => {
+    const previous = result[result.length - 1]
+    if (tool.name !== 'task' && previous?.every((item) => item.name !== 'task')) {
+      previous.push(tool)
+    } else {
+      result.push([tool])
+    }
+    return result
+  }, [])
+
+  if (groups.length === 1) return [message]
+  return groups.map((toolCalls) => ({
+    ...message,
+    id: `${message.id}-${toolCalls[0].id}`,
+    content: `${toolCalls.length} tool call${toolCalls.length === 1 ? '' : 's'}`,
+    toolCalls
+  }))
 }
 
 export function summarizeChildToolInput(name: string, input: string | undefined): string | undefined {

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -226,6 +226,7 @@ export interface Message {
   role: 'user' | 'assistant' | 'tool' | 'tool-group' | 'compaction'
   content: string
   timestamp: string
+  activityAt?: number
   toolName?: string
   toolState?: 'running' | 'completed' | 'failed'
   toolCalls?: ToolCall[]


### PR DESCRIPTION
Subagent progress stayed anchored to the tool call that launched it, so new child output could appear above messages sent later.

Subagent sections now follow their latest activity in the transcript. A child update moves its section below older messages, parallel children move independently, and newer parent output still remains last. Restored sessions use saved child activity to keep the same order.

Verified with tests, type checks, lint, a production build, and a focused semantic review.