### PR TITLE
NO-JIRA Show running tool calls in the transcript

### DIFF
--- a/src/__tests__/subagent-progress.test.ts
+++ b/src/__tests__/subagent-progress.test.ts
@@ -1,7 +1,12 @@
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import { shouldAutoExpandTool, ToolsUsage } from '../renderer/src/components/ToolsUsage'
+import { ToolGroupBubble } from '../renderer/src/components/DetailDrawer'
+import {
+  shouldAutoExpandTool,
+  ToolsUsage,
+  type ToolCall
+} from '../renderer/src/components/ToolsUsage'
 import type { LiveMessage } from '../renderer/src/hooks/useAgentStore'
 import {
   appendVisibleTextDelta,
@@ -207,5 +212,51 @@ describe('subagent progress', () => {
       state: 'running',
       timestamp: 0
     }, false, true)).toBe(false)
+  })
+
+  it('expands running commands after a completed todo update', () => {
+    const tools: ToolCall[] = [{
+      id: 'todo',
+      name: 'todowrite',
+      state: 'completed',
+      timestamp: 1,
+      input: JSON.stringify({ todos: [{ content: 'Run checks', status: 'in_progress' }] })
+    }, {
+      id: 'format',
+      name: 'bash',
+      state: 'running',
+      timestamp: 2,
+      input: JSON.stringify({ command: 'pnpm -w format:check' })
+    }, {
+      id: 'lint',
+      name: 'bash',
+      state: 'running',
+      timestamp: 2,
+      input: JSON.stringify({ command: 'pnpm -w lint' })
+    }, {
+      id: 'typecheck',
+      name: 'bash',
+      state: 'running',
+      timestamp: 2,
+      input: JSON.stringify({ command: 'pnpm -w type-check:go' })
+    }]
+
+    const toolsTab = renderToStaticMarkup(createElement(ToolsUsage, { tools }))
+    const transcript = renderToStaticMarkup(createElement(ToolGroupBubble, {
+      message: {
+        id: 'tools',
+        role: 'tool-group',
+        content: '4 tool calls',
+        timestamp: 'now',
+        toolCalls: tools
+      }
+    }))
+
+    expect(shouldAutoExpandTool(tools[0], false, false)).toBe(false)
+    expect(shouldAutoExpandTool(tools[1], false, false)).toBe(true)
+    for (const command of ['pnpm -w format:check', 'pnpm -w lint', 'pnpm -w type-check:go']) {
+      expect(toolsTab).toContain(command)
+      expect(transcript).toContain(command)
+    }
   })
 })

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -1960,7 +1960,7 @@ function summarizeToolInput(name: string, input: string | undefined): string | u
   }
 }
 
-const ToolGroupBubble = memo(function ToolGroupBubble({
+export const ToolGroupBubble = memo(function ToolGroupBubble({
   message,
   verbose = false,
   rootRef
@@ -1971,25 +1971,12 @@ const ToolGroupBubble = memo(function ToolGroupBubble({
 }) {
   const toolCalls = message.toolCalls ?? []
 
-  // Auto-expand the bubble when a `task` tool is still running so the user
-  // can see sub-agent progress without having to click. Otherwise the bubble
-  // looks frozen ("tool completed" only appears at the very end) and the user
-  // has no feedback until the child session finishes — which for CI-watching
-  // tasks can be many minutes.
-  const hasRunningTask = toolCalls.some((tool) => tool.name === 'task' && tool.state === 'running')
-  const [expanded, setExpanded] = useState(verbose || hasRunningTask)
+  const hasRunningTool = toolCalls.some((tool) => tool.state === 'running')
+  const [expanded, setExpanded] = useState(verbose || hasRunningTool)
 
-  // Sync with verbose prop changes (e.g. user toggles verbose mode)
   useEffect(() => {
-    if (verbose) setExpanded(true)
-  }, [verbose])
-
-  // Once a task starts running inside this group, force the bubble open.
-  // We don't collapse it again when the task finishes — the user may want to
-  // scroll back through the progress.
-  useEffect(() => {
-    if (hasRunningTask) setExpanded(true)
-  }, [hasRunningTask])
+    if (verbose || hasRunningTool) setExpanded(true)
+  }, [verbose, hasRunningTool])
 
   return (
     <div ref={rootRef} className="max-w-[95%] self-start">

--- a/src/renderer/src/components/ToolsUsage.tsx
+++ b/src/renderer/src/components/ToolsUsage.tsx
@@ -49,7 +49,7 @@ function formatRelativeTime(timestamp: number): string {
 }
 
 export function shouldAutoExpandTool(tool: ToolCall, verbose: boolean, manuallyCollapsed: boolean): boolean {
-  return !manuallyCollapsed && (verbose || (tool.name === 'task' && tool.state === 'running'))
+  return !manuallyCollapsed && (verbose || tool.state === 'running')
 }
 
 export const ToolsUsage = memo(function ToolsUsage({ tools, verbose = false }: ToolsUsageProps) {
@@ -60,7 +60,7 @@ export const ToolsUsage = memo(function ToolsUsage({ tools, verbose = false }: T
   // Track items the user explicitly collapsed so we don't re-expand them
   const manuallyCollapsedRef = useRef<Set<string>>(new Set())
 
-  // Auto-expand verbose entries and running tasks unless the user collapsed them.
+  // Expand verbose entries and running tools unless the user collapsed them.
   useEffect(() => {
     setExpandedIds((prev) => {
       const next = new Set(prev)


### PR DESCRIPTION
Commit 2e3c776a3fa moved updated subagent task progress to the transcript bottom, but only auto-expanded a tool group when a `task` tool was running. An ordinary long running Bash tool still stayed inside a collapsed tool group, so an agent could be correctly running while its visible transcript looked frozen right after a todowrite update.

This expands every running tool, not just `task`, in both the transcript's tool group bubble and the Tools tab. Added a regression test covering a completed todowrite next to three running Bash checks, verified against both `ToolGroupBubble` and `ToolsUsage`.

Ran lint, typecheck, and the full test suite locally; all pass (lint has 185 pre-existing warnings, 0 errors; 278 tests passed, 6 skipped). A focused second-opinion review found no issues. `ai-review` was invoked once as requested but its coordinator crashed before producing findings, so it wasn't rerun.
