### PR TITLE
NO-JIRA Add agent controls to the detail drawer

### DIFF
--- a/src/__tests__/agent-controller-commands.test.ts
+++ b/src/__tests__/agent-controller-commands.test.ts
@@ -1,7 +1,9 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
+  sessionCreate: vi.fn(),
   sessionCommand: vi.fn(),
+  configUpdate: vi.fn(),
   touchRuntimeActivity: vi.fn(),
 }))
 
@@ -23,6 +25,13 @@ const persistedAgents = [
     title: 'Bare model session',
     modelOverride: { providerID: '', modelID: 'local-model' },
   },
+  {
+    id: 'agent-3',
+    sessionId: 'default-model-session',
+    directory: '/tmp/project',
+    prompt: '',
+    title: 'Default model session',
+  },
 ]
 
 const runtime = {
@@ -30,7 +39,11 @@ const runtime = {
   directory: '/tmp/project',
   client: {
     session: {
+      create: mocks.sessionCreate,
       command: mocks.sessionCommand,
+    },
+    config: {
+      update: mocks.configUpdate,
     },
   },
 }
@@ -52,6 +65,7 @@ vi.mock('../main/services/runtime-manager', () => ({
 vi.mock('../main/services/event-bridge', () => ({
   EventBridge: class {
     async start(): Promise<void> {}
+    async ensureStreaming(): Promise<void> {}
   },
 }))
 
@@ -91,6 +105,10 @@ describe('AgentController.executeCommand', () => {
   beforeEach(() => {
     mocks.sessionCommand.mockReset()
     mocks.sessionCommand.mockResolvedValue({ data: undefined })
+    mocks.sessionCreate.mockReset()
+    mocks.sessionCreate.mockResolvedValue({ data: { id: 'new-session' } })
+    mocks.configUpdate.mockReset()
+    mocks.configUpdate.mockResolvedValue({ data: undefined })
   })
 
   it('uses the selected model for an existing session with an unavailable previous model', async () => {
@@ -119,6 +137,51 @@ describe('AgentController.executeCommand', () => {
 
     expect(mocks.sessionCommand).toHaveBeenCalledWith(expect.objectContaining({
       model: 'local-model',
+    }))
+  })
+
+  it('changes one agent model without updating the shared directory config', async () => {
+    await agentController.updateConfig('agent-3', {
+      model: 'anthropic/claude-sonnet-4-6',
+      variant: 'high',
+    })
+    await agentController.executeCommand('agent-3', 'review', '')
+    await agentController.executeCommand('agent-2', 'review', '')
+
+    expect(mocks.configUpdate).not.toHaveBeenCalled()
+    expect(mocks.sessionCommand).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      model: 'anthropic/claude-sonnet-4-6',
+      variant: 'high',
+    }))
+    expect(mocks.sessionCommand).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      model: 'local-model',
+    }))
+  })
+
+  it('launches a selected model without updating the shared directory config', async () => {
+    const handle = await agentController.launchAgent({
+      directory: '/tmp/project',
+      model: 'openai/gpt-5.6-sol',
+      modelVariant: 'high',
+    })
+
+    expect(handle.modelOverride).toEqual({ providerID: 'openai', modelID: 'gpt-5.6-sol' })
+    expect(handle.variantOverride).toBe('high')
+    expect(mocks.configUpdate).not.toHaveBeenCalled()
+  })
+
+  it('keeps the previous override when another config update fails', async () => {
+    mocks.configUpdate.mockRejectedValueOnce(new Error('config write failed'))
+
+    await expect(agentController.updateConfig('agent-1', {
+      model: 'anthropic/claude-opus-5',
+      theme: 'dark',
+    })).rejects.toThrow('config write failed')
+    await agentController.executeCommand('agent-1', 'review', '')
+
+    expect(mocks.sessionCommand).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'openai/gpt-5.6-sol',
+      variant: 'high',
     }))
   })
 })

--- a/src/__tests__/output-verbosity.test.ts
+++ b/src/__tests__/output-verbosity.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  DEFAULT_SETTINGS,
+  SETTINGS_STORAGE_KEY,
+  loadSettings
+} from '../renderer/src/data/settings'
+import {
+  AGENT_SETTINGS_STORAGE_KEY,
+  loadAgentOutputVerbosity,
+  saveAgentOutputVerbosity
+} from '../renderer/src/data/agentSettings'
+
+class MemoryStorage {
+  private values = new Map<string, string>()
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value)
+  }
+}
+
+describe('output verbosity settings', () => {
+  let storage: MemoryStorage
+
+  beforeEach(() => {
+    storage = new MemoryStorage()
+    vi.stubGlobal('localStorage', storage)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('migrates saved boolean verbosity without changing other settings', () => {
+    storage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify({
+      model: 'openai/gpt-5',
+      verboseMode: true
+    }))
+
+    const settings = loadSettings()
+
+    expect(settings.model).toBe('openai/gpt-5')
+    expect(settings.outputVerbosity).toBe('all')
+    expect(settings).not.toHaveProperty('verboseMode')
+  })
+
+  it('maps a saved false value and new installs to None', () => {
+    storage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify({ verboseMode: false }))
+    expect(loadSettings().outputVerbosity).toBe('none')
+
+    storage = new MemoryStorage()
+    vi.stubGlobal('localStorage', storage)
+    expect(loadSettings().outputVerbosity).toBe(DEFAULT_SETTINGS.outputVerbosity)
+  })
+
+  it('stores output detail independently for each existing agent', () => {
+    saveAgentOutputVerbosity('agent-one', 'some')
+    saveAgentOutputVerbosity('agent-two', 'all')
+
+    expect(loadAgentOutputVerbosity('agent-one')).toBe('some')
+    expect(loadAgentOutputVerbosity('agent-two')).toBe('all')
+    expect(loadAgentOutputVerbosity('existing-agent')).toBeUndefined()
+    expect(storage.getItem(AGENT_SETTINGS_STORAGE_KEY)).toContain('agent-one')
+  })
+})

--- a/src/__tests__/subagent-progress.test.ts
+++ b/src/__tests__/subagent-progress.test.ts
@@ -211,7 +211,46 @@ describe('subagent progress', () => {
       name: 'task',
       state: 'running',
       timestamp: 0
-    }, false, true)).toBe(false)
+    }, 'none', true)).toBe(false)
+  })
+
+  it('uses Some for parent output and All for completed subagent output', () => {
+    const ordinaryTool = {
+      id: 'bash',
+      name: 'bash',
+      state: 'completed' as const,
+      timestamp: Date.now(),
+      input: 'npm test',
+      output: 'tests passed'
+    }
+    const completedTask = {
+      id: 'task',
+      name: 'task',
+      state: 'completed' as const,
+      timestamp: Date.now(),
+      childSessionId: 'child',
+      childTranscript: [{ id: 'final', kind: 'text' as const, label: 'final child output' }]
+    }
+
+    const someOrdinary = renderToStaticMarkup(createElement(ToolsUsage, {
+      tools: [ordinaryTool],
+      verbosity: 'some'
+    }))
+    const someTask = renderToStaticMarkup(createElement(ToolsUsage, {
+      tools: [completedTask],
+      verbosity: 'some'
+    }))
+    const allTask = renderToStaticMarkup(createElement(ToolsUsage, {
+      tools: [completedTask],
+      verbosity: 'all'
+    }))
+
+    expect(someOrdinary).toContain('tests passed')
+    expect(someTask).not.toContain('final child output')
+    expect(allTask).toContain('final child output')
+    expect(shouldAutoExpandTool(ordinaryTool, 'some', false)).toBe(true)
+    expect(shouldAutoExpandTool(completedTask, 'some', false)).toBe(false)
+    expect(shouldAutoExpandTool(completedTask, 'all', false)).toBe(true)
   })
 
   it('expands running commands after a completed todo update', () => {
@@ -252,8 +291,8 @@ describe('subagent progress', () => {
       }
     }))
 
-    expect(shouldAutoExpandTool(tools[0], false, false)).toBe(false)
-    expect(shouldAutoExpandTool(tools[1], false, false)).toBe(true)
+    expect(shouldAutoExpandTool(tools[0], 'none', false)).toBe(false)
+    expect(shouldAutoExpandTool(tools[1], 'none', false)).toBe(true)
     for (const command of ['pnpm -w format:check', 'pnpm -w lint', 'pnpm -w type-check:go']) {
       expect(toolsTab).toContain(command)
       expect(transcript).toContain(command)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -29,6 +29,8 @@ function toAgentPayload(handle: AgentHandle): {
   workspaceName: string
   prompt: string
   title: string
+  modelOverride?: { providerID: string; modelID: string }
+  variantOverride?: string
 } {
   return {
     id: handle.id,
@@ -40,7 +42,9 @@ function toAgentPayload(handle: AgentHandle): {
     isWorktree: handle.isWorktree,
     workspaceName: handle.workspaceName,
     prompt: handle.prompt,
-    title: handle.title
+    title: handle.title,
+    modelOverride: handle.modelOverride,
+    variantOverride: handle.variantOverride
   }
 }
 
@@ -436,7 +440,9 @@ export function registerIpcHandlers(): void {
         taskSummary: agent.taskSummary,
         persistedStatus: agent.persistedStatus,
         labelIds: agent.labelIds ?? [],
-        prUrl: agent.prUrl
+        prUrl: agent.prUrl,
+        modelOverride: agent.modelOverride,
+        variantOverride: agent.variantOverride
       }))
     }
   })

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -378,14 +378,6 @@ class AgentController {
     this.agents.set(agentId, handle)
     this.persistAgents()
 
-    // Also set directory-level config so the OpenCode UI reflects the choice
-    if (handle.modelOverride) {
-      await client.config.update({
-        directory,
-        config: { model }
-      })
-    }
-
     // Notify the renderer before sending the prompt so the agent exists in
     // the store before SSE events arrive — otherwise processEvent() silently
     // drops them because findAgentBySession() returns undefined.
@@ -687,30 +679,27 @@ class AgentController {
     const runtime = await this.ensureRuntimeForAgent(handle)
     runtimeManager.touchRuntimeActivity(runtime.id)
 
-    // Track model changes on the handle so every subsequent promptAsync
-    // uses the selected model instead of relying on directory-level config.
-    if (typeof config.model === 'string') {
-      handle.modelOverride = parseModelString(config.model)
-      this.persistAgents()
+    const nextModelOverride = typeof config.model === 'string'
+      ? parseModelString(config.model)
+      : handle.modelOverride
+    const nextVariantOverride = 'variant' in config
+      ? typeof config.variant === 'string' ? config.variant : undefined
+      : handle.variantOverride
+    const { model: _model, variant: _variant, ...forwardConfig } = config
+
+    let result: unknown
+    if (Object.keys(forwardConfig).length > 0) {
+      const response = await runtime.client.config.update({
+        directory: handle.directory,
+        config: forwardConfig as never
+      })
+      result = response.data
     }
 
-    // Track variant changes on the handle so every subsequent promptAsync
-    // uses the selected variant (thinking level).
-    if ('variant' in config) {
-      handle.variantOverride = typeof config.variant === 'string' ? config.variant : undefined
-      this.persistAgents()
-    }
-
-    // Strip variant from the config before forwarding — it's not a top-level
-    // opencode config key; we handle it locally via promptAsync params.
-    const { variant: _variant, ...forwardConfig } = config
-
-    const result = await runtime.client.config.update({
-      directory: handle.directory,
-      config: forwardConfig as never
-    })
-
-    return result.data
+    handle.modelOverride = nextModelOverride
+    handle.variantOverride = nextVariantOverride
+    this.persistAgents()
+    return result
   }
 
   /**
@@ -1370,13 +1359,6 @@ class AgentController {
 
     this.agents.set(agentId, handle)
     this.persistAgents()
-
-    if (handle.modelOverride) {
-      await targetClient.config.update({
-        directory: targetDirectory,
-        config: { model }
-      })
-    }
 
     // Broadcast before seeding so the renderer can attach SSE events to this
     // agent. This matches `launchAgent`.

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -358,6 +358,7 @@ export function App() {
 
       return {
         id: agent.id,
+        sessionId: agent.sessionId,
         name: agent.name,
         projectId: agent.directory,
         projectName: agent.projectName,
@@ -368,6 +369,7 @@ export function App() {
         status: displayStatus,
         labelIds: agent.labelIds,
         model: agent.model,
+        configuredModelPath: agent.configuredModelPath,
         variant: agent.variant,
         prUrl: agent.prUrl,
         lastActivityAt: formatTimeAgo(agent.lastActivityAt),
@@ -988,10 +990,19 @@ export function App() {
     if (selectedAgentId) void handleRemoveAgent(selectedAgentId)
   }, [selectedAgentId, handleRemoveAgent])
 
-  const handleDrawerChangeModel = useCallback(() => {
-    setModelPickerAgentId(selectedAgentId)
-    setShowModelPicker(true)
-  }, [selectedAgentId])
+  const handleDrawerChangeModel = useCallback(async (modelPath: string, variant?: string): Promise<boolean> => {
+    if (!selectedAgentId) return false
+    const result = await window.api.updateConfig(selectedAgentId, {
+      model: modelPath,
+      variant: variant ?? null
+    })
+    if (!result.ok) {
+      console.error('Failed to set model:', result.error)
+      return false
+    }
+    storeSetAgentModel(selectedAgentId, modelPath, variant)
+    return true
+  }, [selectedAgentId, storeSetAgentModel])
 
   const handleDrawerToggleLabel = useCallback((labelId: string) => {
     if (selectedAgentId) handleToggleLabel(selectedAgentId, labelId)
@@ -1669,6 +1680,7 @@ Then give me a brief summary of what the previous session was working on and whe
 
       {selectedAgent && (
         <DetailDrawer
+          key={selectedAgent.id}
           agent={selectedAgent}
           workspacePath={selectedWorkspacePath}
           messages={selectedMessages}

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -12,7 +12,6 @@ import {
   CaretRight,
   Trash,
   ChatCircleDots,
-  Brain,
   PaperPlaneTilt,
   ArrowUp,
   Stop,
@@ -27,14 +26,25 @@ import {
   Warning,
   ArrowsInLineHorizontal,
   Copy,
+  SlidersHorizontal,
 } from '@phosphor-icons/react'
 import type { AgentRuntime, Message, LabelDefinition, LabelColorKey } from '../types'
 import { formatBranchLabel } from '../types'
 import type { LivePermission, LiveQuestion } from '../hooks/useAgentStore'
 import { UNRESOLVED_MODEL_LABEL } from '../hooks/placeholderLaunch'
-import { loadSettings, SETTINGS_CHANGED_EVENT, isQuickActionValid, type QuickAction, type QuickActionIcon } from '../data/settings'
+import {
+  loadSettings,
+  OUTPUT_VERBOSITY_OPTIONS,
+  SETTINGS_CHANGED_EVENT,
+  isQuickActionValid,
+  type OutputVerbosity,
+  type QuickAction,
+  type QuickActionIcon
+} from '../data/settings'
+import { loadAgentOutputVerbosity, saveAgentOutputVerbosity } from '../data/agentSettings'
 import { useImageAttachments } from '../hooks/useImageAttachments'
 import { useEditorLabel } from '../hooks/useEditorLabel'
+import { getVariantOptionsForModel, useModelOptions } from '../hooks/useModelOptions'
 import { StatusBadge } from './StatusBadge'
 import { LabelDropdown } from './LabelDropdown'
 import { ContextUsageIndicator } from './ContextUsageIndicator'
@@ -42,12 +52,12 @@ import { PortaledMenu } from './PortaledMenu'
 import { TextInputModal } from './TextInputModal'
 import { Markdown } from './Markdown'
 import { FilesChanged } from './FilesChanged'
-import { ToolsUsage } from './ToolsUsage'
+import { CollapsibleSubagentProgress, ToolsUsage } from './ToolsUsage'
 import { EventLog } from './EventLog'
+import { SelectField } from './SelectField'
 
 import type { FileChange } from './FilesChanged'
 import type { ToolCall } from './ToolsUsage'
-import { SubagentProgress } from './SubagentProgress'
 import type { EventEntry } from './EventLog'
 
 export type { FileChange, ToolCall, EventEntry }
@@ -106,7 +116,7 @@ function loadInputHeight(): number {
   return Math.max(MIN_INPUT_HEIGHT, Math.round(window.innerHeight * DEFAULT_INPUT_HEIGHT_RATIO))
 }
 
-type TabKey = 'transcript' | 'todos' | 'files' | 'tools' | 'events'
+type TabKey = 'transcript' | 'todos' | 'files' | 'tools' | 'events' | 'config'
 
 type TodoStatus = 'pending' | 'in_progress' | 'completed' | 'cancelled'
 
@@ -210,7 +220,7 @@ interface DetailDrawerProps {
    *  an optional file path to pre-select (used when the user clicks a row
    *  in Files Changed). */
   onOpenWorkspace?: (filePath?: string) => void
-  onChangeModel?: () => void
+  onChangeModel?: (modelPath: string, variant?: string) => Promise<boolean>
   onOpenTerminal?: () => void
   onToggleLabel?: (labelId: string) => void
   onClearLabels?: () => void
@@ -312,19 +322,26 @@ export const DetailDrawer = memo(function DetailDrawer({
     setVisibleMessageCount((prev) => prev + LOAD_MORE_INCREMENT)
   }, [])
 
-  // Settings: reactive to changes from SettingsModal
-  const [isVerbose, setIsVerbose] = useState(() => loadSettings().verboseMode)
+  // Global settings provide the default; a drawer choice is persisted per agent.
+  const [outputVerbosity, setOutputVerbosity] = useState<OutputVerbosity>(() =>
+    loadAgentOutputVerbosity(agent.sessionId ?? agent.id) ?? loadSettings().outputVerbosity
+  )
   const [quickActions, setQuickActions] = useState(() => loadSettings().quickActions)
   const editorLabel = useEditorLabel()
   useEffect(() => {
     const onSettingsChanged = () => {
       const s = loadSettings()
-      setIsVerbose(s.verboseMode)
+      if (!loadAgentOutputVerbosity(agent.sessionId ?? agent.id)) setOutputVerbosity(s.outputVerbosity)
       setQuickActions(s.quickActions)
     }
     window.addEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged)
     return () => window.removeEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged)
-  }, [])
+  }, [agent.id, agent.sessionId])
+
+  const handleOutputVerbosityChange = useCallback((value: OutputVerbosity) => {
+    setOutputVerbosity(value)
+    saveAgentOutputVerbosity(agent.sessionId ?? agent.id, value)
+  }, [agent.id, agent.sessionId])
   const {
     attachments, isDragOver, fileInputRef,
     removeAttachment, clearAttachments,
@@ -808,7 +825,8 @@ export const DetailDrawer = memo(function DetailDrawer({
     { key: 'todos', label: 'TODO', count: latestTodos.length },
     { key: 'files', label: 'Files Changed', count: uniqueFileCount },
     { key: 'tools', label: 'Tools', count: tools.length },
-    { key: 'events', label: 'Events', count: events.length }
+    { key: 'events', label: 'Events', count: events.length },
+    { key: 'config', label: 'Config' }
   ]
 
   return (
@@ -856,9 +874,9 @@ export const DetailDrawer = memo(function DetailDrawer({
             </div>
           </div>
           <div className="flex items-center gap-1.5 shrink-0">
-            {onChangeModel && agent.model !== UNRESOLVED_MODEL_LABEL ? (
+            {agent.model !== UNRESOLVED_MODEL_LABEL ? (
               <button
-                onClick={onChangeModel}
+                onClick={() => setActiveTab('config')}
                 className="text-[10px] text-kumo-subtle font-mono whitespace-nowrap hover:text-kumo-default transition-colors"
                 title="Change model"
               >
@@ -888,7 +906,7 @@ export const DetailDrawer = memo(function DetailDrawer({
         </div>
 
         {/* Tabs */}
-        <div className="flex border-b border-kumo-line shrink-0">
+        <div className="flex overflow-x-auto border-b border-kumo-line shrink-0">
           {tabs.map((tab) => (
             <Tab
               key={tab.key}
@@ -938,7 +956,7 @@ export const DetailDrawer = memo(function DetailDrawer({
                       <MessageBubble
                         key={message.id}
                         message={message}
-                        verbose={isVerbose}
+                        verbosity={outputVerbosity}
                         registerRef={registerMessageRef}
                       />
                     ))}
@@ -1034,8 +1052,16 @@ export const DetailDrawer = memo(function DetailDrawer({
                 onFileClick={onOpenWorkspace ? (path) => onOpenWorkspace(path) : undefined}
               />
             )}
-            {activeTab === 'tools' && <ToolsUsage tools={tools} verbose={isVerbose} />}
-            {activeTab === 'events' && <EventLog events={events} verbose={isVerbose} />}
+            {activeTab === 'tools' && <ToolsUsage tools={tools} verbosity={outputVerbosity} />}
+            {activeTab === 'events' && <EventLog events={events} verbosity={outputVerbosity} />}
+            {activeTab === 'config' && (
+              <AgentConfigPanel
+                agent={agent}
+                outputVerbosity={outputVerbosity}
+                onOutputVerbosityChange={handleOutputVerbosityChange}
+                onChangeModel={onChangeModel}
+              />
+            )}
           </div>
 
           {/* Jump to latest — absolutely positioned over the scroll area
@@ -1329,9 +1355,9 @@ export const DetailDrawer = memo(function DetailDrawer({
               />
               {onChangeModel && (
                 <ActionButton
-                  icon={<Brain size={12} />}
-                  label="Model"
-                  onClick={onChangeModel}
+                  icon={<SlidersHorizontal size={12} />}
+                  label="Config"
+                  onClick={() => setActiveTab('config')}
                   className="w-full"
                 />
               )}
@@ -1735,7 +1761,7 @@ function Tab({
   return (
     <button
       onClick={onClick}
-      className={`px-4 py-2 text-xs font-medium cursor-pointer border-b-2 transition-colors flex items-center gap-1.5 ${
+      className={`shrink-0 px-4 py-2 text-xs font-medium cursor-pointer border-b-2 transition-colors flex items-center gap-1.5 ${
         active
           ? 'text-kumo-strong border-kumo-brand'
           : 'text-kumo-subtle border-transparent hover:text-kumo-default'
@@ -1757,15 +1783,160 @@ function Tab({
   )
 }
 
+const outputVerbosityDescriptions: Record<OutputVerbosity, string> = {
+  none: 'Keep tool and event details collapsed.',
+  some: 'Expand parent tools and events, but collapse subagent transcripts.',
+  all: 'Expand parent tools, events, and subagent transcripts.'
+}
+
+function AgentConfigPanel({
+  agent,
+  outputVerbosity,
+  onOutputVerbosityChange,
+  onChangeModel
+}: {
+  agent: AgentRuntime
+  outputVerbosity: OutputVerbosity
+  onOutputVerbosityChange: (value: OutputVerbosity) => void
+  onChangeModel?: (modelPath: string, variant?: string) => Promise<boolean>
+}) {
+  const { options, loading, providerData, configModel } = useModelOptions(agent.id)
+  const [selectedModel, setSelectedModel] = useState(agent.configuredModelPath ?? agent.model)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const savingRef = useRef(false)
+
+  useEffect(() => {
+    setSelectedModel(agent.configuredModelPath ?? configModel ?? agent.model)
+    setSaveError(null)
+  }, [agent.id, agent.configuredModelPath, agent.model, configModel])
+
+  const modelOptions = useMemo(() => {
+    const concreteOptions = options.filter((option) => option.value !== 'auto')
+    if (concreteOptions.some((option) => option.value === selectedModel)) return concreteOptions
+    return [
+      { value: selectedModel, label: `Current (${agent.model})` },
+      ...concreteOptions
+    ]
+  }, [agent.model, options, selectedModel])
+
+  const effortOptions = useMemo(
+    () => getVariantOptionsForModel(selectedModel, providerData, configModel),
+    [selectedModel, providerData, configModel]
+  )
+  const selectedEffort = effortOptions.some((option) => option.value === agent.variant)
+    ? agent.variant ?? 'auto'
+    : 'auto'
+
+  const updateModel = async (modelPath: string, variant?: string): Promise<void> => {
+    if (!onChangeModel || savingRef.current) return
+    savingRef.current = true
+    setSaving(true)
+    setSaveError(null)
+    try {
+      const updated = await onChangeModel(modelPath, variant)
+      if (updated) {
+        setSelectedModel(modelPath)
+        return
+      }
+      setSaveError('Could not update this agent. Its current configuration is unchanged.')
+    } catch {
+      setSaveError('Could not update this agent. Its current configuration is unchanged.')
+    } finally {
+      savingRef.current = false
+      setSaving(false)
+    }
+  }
+
+  const selectButtonClasses =
+    'flex w-full items-center justify-between gap-3 rounded-md border border-kumo-line bg-kumo-control px-3 py-2 text-sm text-kumo-default outline-none transition-colors hover:bg-kumo-fill focus:border-kumo-ring'
+  const selectMenuClasses =
+    'max-h-[min(24rem,calc(100vh-1rem))] overflow-y-auto rounded-md border border-kumo-line bg-kumo-overlay shadow-xl'
+
+  return (
+    <div className="flex flex-col gap-6 py-2">
+      <section className="flex flex-col gap-2">
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-kumo-subtle">Output Detail</h3>
+          <p className="mt-1 text-[11px] text-kumo-subtle">Applies only to this agent.</p>
+        </div>
+        <div className="grid grid-cols-3 gap-2">
+          {OUTPUT_VERBOSITY_OPTIONS.map((option) => {
+            const selected = outputVerbosity === option.value
+            return (
+              <button
+                key={option.value}
+                type="button"
+                role="radio"
+                aria-checked={selected}
+                onClick={() => onOutputVerbosityChange(option.value)}
+                className={`rounded-lg border px-3 py-2.5 text-left transition-colors ${
+                  selected
+                    ? 'border-kumo-brand/40 bg-kumo-brand/10 text-kumo-strong'
+                    : 'border-kumo-line bg-kumo-control text-kumo-default hover:bg-kumo-fill'
+                }`}
+              >
+                <span className="block text-xs font-semibold">{option.label}</span>
+                <span className="mt-1 block text-[10px] leading-snug text-kumo-subtle">
+                  {outputVerbosityDescriptions[option.value]}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-kumo-subtle">Model</h3>
+          <p className="mt-1 text-[11px] text-kumo-subtle">Changes the model for this agent's next prompt.</p>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <label className="text-[11px] font-medium text-kumo-default">Model</label>
+          <SelectField
+            value={selectedModel}
+            options={modelOptions}
+            disabled={saving || !onChangeModel}
+            onChange={(value) => void updateModel(value)}
+            searchable
+            searchPlaceholder="Search models..."
+            buttonClassName={selectButtonClasses}
+            menuClassName={selectMenuClasses}
+          />
+          {loading && <span className="text-[10px] text-kumo-subtle">Loading provider models...</span>}
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <label className="text-[11px] font-medium text-kumo-default">Effort</label>
+          <SelectField
+            value={selectedEffort}
+            options={effortOptions}
+            disabled={saving || !onChangeModel}
+            onChange={(value) => void updateModel(selectedModel, value === 'auto' ? undefined : value)}
+            buttonClassName={selectButtonClasses}
+            menuClassName={selectMenuClasses}
+          />
+          <span className="text-[10px] text-kumo-subtle">
+            {effortOptions.length === 1
+              ? 'This model does not expose explicit effort levels.'
+              : "Provider Default removes this agent's effort override."}
+          </span>
+        </div>
+        {saving && <span className="text-[11px] text-kumo-link">Saving configuration...</span>}
+        {saveError && <span className="text-[11px] text-kumo-danger">{saveError}</span>}
+      </section>
+    </div>
+  )
+}
+
 type MessageRefCallback = (id: string, node: HTMLElement | null) => void
 
 const MessageBubble = memo(function MessageBubble({
   message,
-  verbose = false,
+  verbosity = 'none',
   registerRef
 }: {
   message: Message
-  verbose?: boolean
+  verbosity?: OutputVerbosity
   registerRef?: MessageRefCallback
 }) {
   const rootRef = useCallback((node: HTMLElement | null) => {
@@ -1773,7 +1944,7 @@ const MessageBubble = memo(function MessageBubble({
   }, [message.id, registerRef])
 
   if (message.role === 'tool-group') {
-    return <ToolGroupBubble message={message} verbose={verbose} rootRef={rootRef} />
+    return <ToolGroupBubble message={message} verbosity={verbosity} rootRef={rootRef} />
   }
 
   if (message.role === 'compaction') {
@@ -1887,7 +2058,7 @@ const MessageBubble = memo(function MessageBubble({
   prev.message.content === next.message.content &&
   prev.message.role === next.message.role &&
   prev.message.toolCalls === next.message.toolCalls &&
-  prev.verbose === next.verbose &&
+  prev.verbosity === next.verbosity &&
   prev.registerRef === next.registerRef
 )
 
@@ -1962,21 +2133,36 @@ function summarizeToolInput(name: string, input: string | undefined): string | u
 
 export const ToolGroupBubble = memo(function ToolGroupBubble({
   message,
-  verbose = false,
+  verbosity = 'none',
   rootRef
 }: {
   message: Message
-  verbose?: boolean
+  verbosity?: OutputVerbosity
   rootRef?: (node: HTMLElement | null) => void
 }) {
   const toolCalls = message.toolCalls ?? []
 
+  // Auto-expand the bubble when any tool in the group is still running so
+  // the user can see progress without having to click. Otherwise the bubble
+  // looks frozen ("tool completed" only appears at the very end) and the user
+  // has no feedback until the tool finishes — which for CI-watching tasks
+  // can be many minutes.
   const hasRunningTool = toolCalls.some((tool) => tool.state === 'running')
-  const [expanded, setExpanded] = useState(verbose || hasRunningTool)
+  const [expanded, setExpanded] = useState(verbosity !== 'none' || hasRunningTool)
+  const previousVerbosityRef = useRef(verbosity)
 
   useEffect(() => {
-    if (verbose || hasRunningTool) setExpanded(true)
-  }, [verbose, hasRunningTool])
+    if (previousVerbosityRef.current === verbosity) return
+    setExpanded(verbosity !== 'none' || hasRunningTool)
+    previousVerbosityRef.current = verbosity
+  }, [verbosity, hasRunningTool])
+
+  // Once a tool starts running inside this group, force the bubble open.
+  // We don't collapse it again when the tool finishes — the user may want to
+  // scroll back through the progress.
+  useEffect(() => {
+    if (hasRunningTool) setExpanded(true)
+  }, [hasRunningTool])
 
   return (
     <div ref={rootRef} className="max-w-[95%] self-start">
@@ -2012,11 +2198,12 @@ export const ToolGroupBubble = memo(function ToolGroupBubble({
                   watch what the sub-agent is doing. Rendered above the final
                   output so the transcript reads top-to-bottom. */}
               {tool.name === 'task' && (tool.state === 'running' || tool.childTranscript?.length) && (
-                <SubagentProgress
-                  entries={tool.childTranscript ?? []}
-                  state={tool.state}
-                  childSessionId={tool.childSessionId}
-                />
+                <div className="mt-2">
+                  <CollapsibleSubagentProgress
+                    tool={tool}
+                    verbosity={verbosity}
+                  />
+                </div>
               )}
               {tool.output && (
                 <pre className="mt-2 whitespace-pre-wrap break-all font-mono text-[10px] text-kumo-subtle bg-kumo-overlay rounded-md px-2 py-1.5 overflow-x-auto">
@@ -2033,7 +2220,7 @@ export const ToolGroupBubble = memo(function ToolGroupBubble({
   prev.message.id === next.message.id &&
   prev.message.content === next.message.content &&
   prev.message.toolCalls === next.message.toolCalls &&
-  prev.verbose === next.verbose
+  prev.verbosity === next.verbosity
 )
 
 /**

--- a/src/renderer/src/components/EventLog.tsx
+++ b/src/renderer/src/components/EventLog.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect, useRef, memo } from 'react'
 import { ListBullets, CaretDown, CaretRight, Funnel } from '@phosphor-icons/react'
 import { PortaledMenu } from './PortaledMenu'
+import type { OutputVerbosity } from '../data/settings'
 
 export interface EventEntry {
   id: string
@@ -12,7 +13,7 @@ export interface EventEntry {
 
 interface EventLogProps {
   events: EventEntry[]
-  verbose?: boolean
+  verbosity?: OutputVerbosity
 }
 
 const typeColorMap: Record<string, string> = {
@@ -43,29 +44,37 @@ function formatJson(data: unknown): string {
   }
 }
 
-export const EventLog = memo(function EventLog({ events, verbose = false }: EventLogProps) {
+export const EventLog = memo(function EventLog({ events, verbosity = 'none' }: EventLogProps) {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(() =>
-    verbose ? new Set(events.map((e) => e.id)) : new Set()
+    verbosity === 'none' ? new Set() : new Set(events.map((e) => e.id))
   )
   const [typeFilter, setTypeFilter] = useState<string>('all')
   const [showFilterMenu, setShowFilterMenu] = useState(false)
   const filterButtonRef = useRef<HTMLButtonElement>(null)
-  // Track items the user explicitly collapsed so we don't re-expand them
   const manuallyCollapsedRef = useRef<Set<string>>(new Set())
+  const previousVerbosityRef = useRef(verbosity)
 
-  // When verbose is on, auto-expand only *new* items (not manually-collapsed ones)
+  // Some and All both expand events because events never contain subagents.
   useEffect(() => {
-    if (!verbose) return
-    setExpandedIds((prev) => {
-      const next = new Set(prev)
-      for (const event of events) {
-        if (!manuallyCollapsedRef.current.has(event.id)) {
-          next.add(event.id)
+    const verbosityChanged = previousVerbosityRef.current !== verbosity
+    if (verbosityChanged && verbosity === 'none') {
+      setExpandedIds(new Set())
+      previousVerbosityRef.current = verbosity
+      return
+    }
+    if (verbosity !== 'none') {
+      setExpandedIds((prev) => {
+        const next = new Set(prev)
+        for (const event of events) {
+          if (!manuallyCollapsedRef.current.has(event.id)) {
+            next.add(event.id)
+          }
         }
-      }
-      return next
-    })
-  }, [verbose, events])
+        return next
+      })
+    }
+    previousVerbosityRef.current = verbosity
+  }, [verbosity, events])
 
   const eventTypes = useMemo(() => {
     const types = new Set<string>()
@@ -85,7 +94,7 @@ export const EventLog = memo(function EventLog({ events, verbose = false }: Even
       const next = new Set(prev)
       if (next.has(eventId)) {
         next.delete(eventId)
-        if (verbose) manuallyCollapsedRef.current.add(eventId)
+        if (verbosity !== 'none') manuallyCollapsedRef.current.add(eventId)
       } else {
         next.add(eventId)
         manuallyCollapsedRef.current.delete(eventId)

--- a/src/renderer/src/components/SelectField.tsx
+++ b/src/renderer/src/components/SelectField.tsx
@@ -11,6 +11,7 @@ interface SelectFieldProps {
   value: string
   options: readonly SelectOption[]
   onChange: (value: string) => void
+  disabled?: boolean
   searchable?: boolean
   searchPlaceholder?: string
   buttonClassName?: string
@@ -26,6 +27,7 @@ export function SelectField({
   value,
   options,
   onChange,
+  disabled = false,
   searchable = false,
   searchPlaceholder = 'Search…',
   buttonClassName,
@@ -64,6 +66,7 @@ export function SelectField({
         type="button"
         aria-haspopup="listbox"
         aria-expanded={isOpen}
+        disabled={disabled}
         onClick={() => setIsOpen((previous) => !previous)}
         className={buttonClassName}
       >
@@ -72,7 +75,7 @@ export function SelectField({
       </button>
 
       <PortaledMenu
-        open={isOpen}
+        open={isOpen && !disabled}
         triggerRef={buttonRef}
         placement="bottom-left"
         matchTriggerWidth

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -22,6 +22,7 @@ import { PortaledMenu } from './PortaledMenu'
 import {
   DEFAULT_CREATE_PR_PROMPT,
   MAX_QUICK_ACTIONS,
+  OUTPUT_VERBOSITY_OPTIONS,
   isQuickActionValid,
   loadSettings,
   saveSettings,
@@ -314,24 +315,20 @@ export function SettingsModal({ onClose, initialTab = 'general', commands = [] }
                 </label>
               </div>
 
-              {/* Verbose Mode */}
+              {/* Output visibility */}
               <div className="flex flex-col gap-2">
                 <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
                   Output Visibility
                 </label>
-                <label className="flex items-center gap-2.5 cursor-pointer group pl-1">
-                  <input
-                    type="checkbox"
-                    checked={settings.verboseMode}
-                    onChange={(event) => updateSettings({ verboseMode: event.target.checked })}
-                    className="w-3.5 h-3.5 rounded border-kumo-line bg-kumo-control accent-kumo-brand"
-                  />
-                  <span className="text-sm text-kumo-default group-hover:text-kumo-strong transition-colors">
-                    Verbose Mode
-                  </span>
-                </label>
+                <SelectField
+                  value={settings.outputVerbosity}
+                  onChange={(value) => updateSettings({ outputVerbosity: value as AppSettings['outputVerbosity'] })}
+                  options={OUTPUT_VERBOSITY_OPTIONS}
+                  buttonClassName={selectButtonClasses}
+                  menuClassName={selectMenuClasses}
+                />
                 <p className="text-[11px] text-kumo-subtle">
-                  Auto-expand all tool calls, tool output, and events in agent detail views. Can be toggled per-agent in the drawer header.
+                  None keeps details collapsed. Some expands parent tools and events. All also expands subagent transcripts. Each agent can override this in its drawer.
                 </p>
               </div>
 

--- a/src/renderer/src/components/ToolsUsage.tsx
+++ b/src/renderer/src/components/ToolsUsage.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useEffect, useRef, memo } from 'react'
 import { Wrench, CaretDown, CaretRight, MagnifyingGlass } from '@phosphor-icons/react'
 import { SubagentProgress } from './SubagentProgress'
 import type { ChildTranscriptEntry } from '../lib/subagent-progress'
+import type { OutputVerbosity } from '../data/settings'
 
 export interface ToolCall {
   id: string
@@ -22,7 +23,7 @@ export interface ToolCall {
 
 interface ToolsUsageProps {
   tools: ToolCall[]
-  verbose?: boolean
+  verbosity?: OutputVerbosity
 }
 
 const stateStyles: Record<ToolCall['state'], string> = {
@@ -48,30 +49,82 @@ function formatRelativeTime(timestamp: number): string {
   return `${days}d ago`
 }
 
-export function shouldAutoExpandTool(tool: ToolCall, verbose: boolean, manuallyCollapsed: boolean): boolean {
-  return !manuallyCollapsed && (verbose || tool.state === 'running')
+export function shouldAutoExpandTool(tool: ToolCall, verbosity: OutputVerbosity, manuallyCollapsed: boolean): boolean {
+  return !manuallyCollapsed && (
+    (verbosity !== 'none' && tool.name !== 'task')
+    || verbosity === 'all'
+    || tool.state === 'running'
+  )
 }
 
-export const ToolsUsage = memo(function ToolsUsage({ tools, verbose = false }: ToolsUsageProps) {
+export function CollapsibleSubagentProgress({
+  tool,
+  verbosity
+}: {
+  tool: ToolCall
+  verbosity: OutputVerbosity
+}) {
+  const [expanded, setExpanded] = useState(
+    verbosity === 'all' || (verbosity === 'none' && tool.state === 'running')
+  )
+  const previousVerbosityRef = useRef(verbosity)
+
+  useEffect(() => {
+    if (previousVerbosityRef.current !== verbosity) {
+      setExpanded(verbosity === 'all')
+      previousVerbosityRef.current = verbosity
+    } else if (verbosity === 'none' && tool.state === 'running') {
+      setExpanded(true)
+    }
+  }, [tool.state, verbosity])
+
+  return (
+    <div className="rounded-md border border-kumo-line bg-kumo-overlay">
+      <button
+        type="button"
+        onClick={() => setExpanded((previous) => !previous)}
+        className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-[10px] text-kumo-subtle hover:text-kumo-default"
+      >
+        {expanded ? <CaretDown size={10} /> : <CaretRight size={10} />}
+        <span className="font-medium">Subagent output</span>
+        <span className="ml-auto">{tool.state === 'running' ? 'Running' : 'Completed'}</span>
+      </button>
+      {expanded && (
+        <div className="border-t border-kumo-line p-2">
+          <SubagentProgress
+            entries={tool.childTranscript ?? []}
+            state={tool.state}
+            childSessionId={tool.childSessionId}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export const ToolsUsage = memo(function ToolsUsage({ tools, verbosity = 'none' }: ToolsUsageProps) {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set(
-    tools.filter((tool) => shouldAutoExpandTool(tool, verbose, false)).map((tool) => tool.id)
+    tools.filter((tool) => shouldAutoExpandTool(tool, verbosity, false)).map((tool) => tool.id)
   ))
   const [filterQuery, setFilterQuery] = useState('')
-  // Track items the user explicitly collapsed so we don't re-expand them
   const manuallyCollapsedRef = useRef<Set<string>>(new Set())
+  const previousVerbosityRef = useRef(verbosity)
 
-  // Expand verbose entries and running tools unless the user collapsed them.
+  // Expand verbose entries and running tools unless the user collapsed them;
+  // reset manual collapses when verbosity changes.
   useEffect(() => {
+    const verbosityChanged = previousVerbosityRef.current !== verbosity
     setExpandedIds((prev) => {
-      const next = new Set(prev)
+      const next = verbosityChanged ? new Set<string>() : new Set(prev)
       for (const tool of tools) {
-        if (shouldAutoExpandTool(tool, verbose, manuallyCollapsedRef.current.has(tool.id))) {
+        if (shouldAutoExpandTool(tool, verbosity, manuallyCollapsedRef.current.has(tool.id))) {
           next.add(tool.id)
         }
       }
       return next
     })
-  }, [verbose, tools])
+    previousVerbosityRef.current = verbosity
+  }, [verbosity, tools])
 
   const toolNameCounts = useMemo(() => {
     const counts: Record<string, number> = {}
@@ -195,11 +248,7 @@ export const ToolsUsage = memo(function ToolsUsage({ tools, verbose = false }: T
                     </div>
                   )}
                   {tool.name === 'task' && (tool.state === 'running' || tool.childTranscript?.length) && (
-                    <SubagentProgress
-                      entries={tool.childTranscript ?? []}
-                      state={tool.state}
-                      childSessionId={tool.childSessionId}
-                    />
+                    <CollapsibleSubagentProgress tool={tool} verbosity={verbosity} />
                   )}
                   {tool.output && (
                     <div>

--- a/src/renderer/src/data/agentSettings.ts
+++ b/src/renderer/src/data/agentSettings.ts
@@ -1,0 +1,38 @@
+import { isOutputVerbosity, type OutputVerbosity } from './settings'
+
+export const AGENT_SETTINGS_STORAGE_KEY = 'oc-orchestrator:agent-settings'
+
+interface StoredAgentSettings {
+  outputVerbosity?: OutputVerbosity
+}
+
+function loadAllAgentSettings(): Record<string, StoredAgentSettings> {
+  try {
+    const stored = localStorage.getItem(AGENT_SETTINGS_STORAGE_KEY)
+    if (!stored) return {}
+    const parsed = JSON.parse(stored) as Record<string, { outputVerbosity?: unknown }>
+    const result: Record<string, StoredAgentSettings> = {}
+    for (const [agentId, settings] of Object.entries(parsed)) {
+      if (isOutputVerbosity(settings?.outputVerbosity)) {
+        result[agentId] = { outputVerbosity: settings.outputVerbosity }
+      }
+    }
+    return result
+  } catch {
+    return {}
+  }
+}
+
+export function loadAgentOutputVerbosity(agentId: string): OutputVerbosity | undefined {
+  return loadAllAgentSettings()[agentId]?.outputVerbosity
+}
+
+export function saveAgentOutputVerbosity(agentId: string, outputVerbosity: OutputVerbosity): void {
+  try {
+    const settings = loadAllAgentSettings()
+    settings[agentId] = { ...settings[agentId], outputVerbosity }
+    localStorage.setItem(AGENT_SETTINGS_STORAGE_KEY, JSON.stringify(settings))
+  } catch {
+    // The drawer still updates when storage is unavailable.
+  }
+}

--- a/src/renderer/src/data/settings.ts
+++ b/src/renderer/src/data/settings.ts
@@ -27,6 +27,14 @@ export const MAX_QUICK_ACTIONS = 7
 
 export type QuickActionSlots = (QuickAction | null)[]
 
+export type OutputVerbosity = 'none' | 'some' | 'all'
+
+export const OUTPUT_VERBOSITY_OPTIONS: ReadonlyArray<{ value: OutputVerbosity; label: string }> = [
+  { value: 'none', label: 'None' },
+  { value: 'some', label: 'Some' },
+  { value: 'all', label: 'All' },
+]
+
 export interface AppSettings {
   model: string
   modelVariant: string
@@ -36,7 +44,7 @@ export interface AppSettings {
   createPrPrompt: string
   quickActions: QuickActionSlots
   notifications: NotificationPrefs
-  verboseMode: boolean
+  outputVerbosity: OutputVerbosity
   soundEnabled: boolean
 }
 
@@ -80,7 +88,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
     completed: false,
     external_attached: true,
   },
-  verboseMode: false,
+  outputVerbosity: 'none',
   soundEnabled: true,
 }
 
@@ -89,7 +97,14 @@ export function loadSettings(): AppSettings {
     const stored = localStorage.getItem(SETTINGS_STORAGE_KEY)
     if (!stored) return DEFAULT_SETTINGS
 
-    const parsed = JSON.parse(stored) as Partial<AppSettings>
+    const parsed = JSON.parse(stored) as Partial<AppSettings> & { verboseMode?: boolean }
+    const currentSettings = { ...parsed }
+    delete currentSettings.verboseMode
+    const outputVerbosity = isOutputVerbosity(parsed.outputVerbosity)
+      ? parsed.outputVerbosity
+      : parsed.verboseMode === true
+        ? 'all'
+        : DEFAULT_SETTINGS.outputVerbosity
 
     // Quick actions: fixed-length slots array. Migrate old dense arrays and
     // pad/trim to exactly MAX_QUICK_ACTIONS slots.
@@ -103,17 +118,22 @@ export function loadSettings(): AppSettings {
 
     return {
       ...DEFAULT_SETTINGS,
-      ...parsed,
+      ...currentSettings,
       notifications: {
         ...DEFAULT_SETTINGS.notifications,
         ...(parsed.notifications ?? {}),
       },
       createPrPrompt: parsed.createPrPrompt?.trim() ? parsed.createPrPrompt : DEFAULT_CREATE_PR_PROMPT,
       quickActions,
+      outputVerbosity,
     }
   } catch {
     return DEFAULT_SETTINGS
   }
+}
+
+export function isOutputVerbosity(value: unknown): value is OutputVerbosity {
+  return value === 'none' || value === 'some' || value === 'all'
 }
 
 export function isQuickActionValid(qa: QuickAction): boolean {

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -136,6 +136,8 @@ export interface LiveAgent {
    *  Used to restore the displayed model after an invoked agent
    *  (which may use a different model) finishes. */
   configuredModel?: string
+  /** Full provider/model value used by model selectors and prompt overrides. */
+  configuredModelPath?: string
   /** The currently selected model variant (thinking level). */
   variant?: string
   lastActivityAt: number
@@ -1045,6 +1047,9 @@ function hydrateHistoricalMessages(entries: unknown): void {
         if (!agent.configuredModel) {
           agent.configuredModel = formatted
         }
+        if (!agent.configuredModelPath) {
+          agent.configuredModelPath = entry.info.modelID
+        }
       }
 
       // PR URLs are only extracted during the live "Create PR" flow and
@@ -1505,7 +1510,8 @@ function processEvent(payload: OpenCodeEventPayload): void {
           if (modelId && depth === 0) {
             const formatted = formatModelName(modelId)
             agent.model = formatted
-            agent.configuredModel = formatted
+            if (!agent.configuredModel) agent.configuredModel = formatted
+            if (!agent.configuredModelPath) agent.configuredModelPath = modelId
             agent.rawModelId = modelId
             const limit = lookupContextLimit(modelId)
             if (limit !== undefined) agent.contextLimit = limit
@@ -2357,13 +2363,21 @@ function handleAgentLaunched(payload: AgentLaunchedPayload): void {
       const config = result.data as { model?: string }
       if (!config.model) return
       const agent = state.agents.get(payload.id)
-      if (!agent || agent.configuredModel) return
-      const formatted = formatModelName(config.model)
-      agent.configuredModel = formatted
-      if (agent.model === UNRESOLVED_MODEL_LABEL) {
-        agent.model = formatted
-        emit({ agents: true })
+      if (!agent) return
+      let agentChanged = false
+      if (!agent.configuredModelPath) {
+        agent.configuredModelPath = config.model
+        agentChanged = true
       }
+      if (!agent.configuredModel) {
+        agent.configuredModel = formatModelName(config.model)
+        agentChanged = true
+      }
+      if (agent.model === UNRESOLVED_MODEL_LABEL) {
+        agent.model = agent.configuredModel
+        agentChanged = true
+      }
+      if (agentChanged) emit({ agents: true })
     })
   }
 }
@@ -2472,6 +2486,15 @@ function upsertAgent(payload: AgentLaunchedPayload, initialStatus?: AgentStatus)
     ? existingAgent.autoNamed
     : isAutoTitle
 
+  const configuredModelPath = payload.modelOverride
+    ? payload.modelOverride.providerID
+      ? `${payload.modelOverride.providerID}/${payload.modelOverride.modelID}`
+      : payload.modelOverride.modelID
+    : existingAgent?.configuredModelPath
+  const configuredModel = configuredModelPath
+    ? formatModelName(configuredModelPath)
+    : existingAgent?.configuredModel
+
   const agent: LiveAgent = {
     id: payload.id,
     runtimeId: payload.runtimeId,
@@ -2485,8 +2508,10 @@ function upsertAgent(payload: AgentLaunchedPayload, initialStatus?: AgentStatus)
     taskSummary: payload.taskSummary || existingAgent?.taskSummary || (hasPrompt ? payload.prompt.slice(0, 120) : 'Waiting for prompt...'),
     status: initialStatus ?? existingAgent?.status ?? (hasPrompt ? 'running' : 'idle'),
     labelIds: existingAgent?.labelIds ?? [],
-    model: existingAgent?.model ?? UNRESOLVED_MODEL_LABEL,
-    configuredModel: existingAgent?.configuredModel,
+    model: existingAgent?.model ?? configuredModel ?? UNRESOLVED_MODEL_LABEL,
+    configuredModel,
+    configuredModelPath,
+    variant: payload.variantOverride ?? existingAgent?.variant,
     prUrl: existingAgent?.prUrl ?? payload.prUrl ?? null,
     lastActivityAt: existingAgent?.lastActivityAt ?? Date.now(),
     cost: existingAgent?.cost ?? 0,
@@ -3937,6 +3962,7 @@ export function useAgentStore() {
     const formatted = formatModelName(modelPath)
     agent.model = formatted
     agent.configuredModel = formatted
+    agent.configuredModelPath = modelPath
     agent.variant = variant
     emit({ agents: true })
   }, [])

--- a/src/renderer/src/hooks/useModelOptions.ts
+++ b/src/renderer/src/hooks/useModelOptions.ts
@@ -279,7 +279,7 @@ export async function ensureProvidersLoaded(): Promise<ProviderFetchResult> {
   return { providerData, configModel }
 }
 
-export function useModelOptions(): { options: ModelOption[]; loading: boolean; providerData: ProviderData | null; configModel: string | undefined } {
+export function useModelOptions(agentId?: string): { options: ModelOption[]; loading: boolean; providerData: ProviderData | null; configModel: string | undefined } {
   const [options, setOptions] = useState<ModelOption[]>(STATIC_MODEL_OPTIONS)
   const [providerData, setProviderData] = useState<ProviderData | null>(null)
   const [configModel, setConfigModel] = useState<string | undefined>(undefined)
@@ -291,11 +291,23 @@ export function useModelOptions(): { options: ModelOption[]; loading: boolean; p
 
     const load = (): void => {
       const seq = ++requestSeq
-      void ensureProvidersLoaded().then(({ providerData, configModel }) => {
+      const fetchResult = agentId
+        ? Promise.all([window.api.getProviders(agentId), window.api.getConfig(agentId)]).then(([providersResult, configResult]) => ({
+            providerData: providersResult.ok && providersResult.data
+              ? providersResult.data as ProviderData
+              : null,
+            configModel: configResult.ok && configResult.data
+              ? (configResult.data as { model?: string }).model
+              : undefined
+          }))
+        : ensureProvidersLoaded()
+
+      void fetchResult.then(({ providerData, configModel }) => {
         if (cancelled || seq !== requestSeq) return
 
         let opts: ModelOption[]
         if (providerData) {
+          recordContextLimitsFromProviders(providerData)
           const dynamicOptions = buildOptionsFromProviders(providerData)
           opts = dynamicOptions.length > 1 ? dynamicOptions : [...STATIC_MODEL_OPTIONS]
         } else {
@@ -311,15 +323,13 @@ export function useModelOptions(): { options: ModelOption[]; loading: boolean; p
     }
 
     load()
-    // Re-fetch when the cache is invalidated (e.g. a runtime restarts after a
-    // config change) so the System Default label reflects the current config.
-    const unsubscribe = subscribeToConfigChanges(load)
+    const unsubscribe = agentId ? () => {} : subscribeToConfigChanges(load)
 
     return () => {
       cancelled = true
       unsubscribe()
     }
-  }, [])
+  }, [agentId])
 
   return { options, loading, providerData, configModel }
 }

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -254,6 +254,8 @@ export interface AgentLaunchedPayload {
   /** @deprecated Use labelIds. Kept for reading legacy persisted data. */
   labelId?: string
   prUrl?: string
+  modelOverride?: { providerID: string; modelID: string }
+  variantOverride?: string
   /** Correlation id from the renderer's launch request. Present only for
    *  launches this renderer started; used to retire the placeholder row. */
   launchId?: string

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -69,6 +69,7 @@ export interface Project {
 
 export interface AgentRuntime {
   id: string
+  sessionId?: string
   name: string
   projectId: string
   projectName: string
@@ -79,6 +80,7 @@ export interface AgentRuntime {
   status: AgentStatus
   labelIds: string[]
   model: string
+  configuredModelPath?: string
   variant?: string
   prUrl: string | null
   lastActivityAt: string


### PR DESCRIPTION
Agents now expose output detail, model, and effort controls in the detail drawer. Output detail supports None, Some, and All. Some expands parent tool and event output while keeping subagent transcripts collapsed.

The global output default uses the same selector, and old `verboseMode` values migrate without changing restored sessions. Model selections remain isolated per agent and survive restarts.

Tested with `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`.