### PR TITLE
NO-JIRA Stop showing abandoned subagent tasks as running

### DIFF
--- a/src/__tests__/agent-controller-commands.test.ts
+++ b/src/__tests__/agent-controller-commands.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   sessionCreate: vi.fn(),
   sessionCommand: vi.fn(),
+  sessionStatus: vi.fn(),
   configUpdate: vi.fn(),
   touchRuntimeActivity: vi.fn(),
 }))
@@ -41,6 +42,7 @@ const runtime = {
     session: {
       create: mocks.sessionCreate,
       command: mocks.sessionCommand,
+      status: mocks.sessionStatus,
     },
     config: {
       update: mocks.configUpdate,
@@ -107,6 +109,8 @@ describe('AgentController.executeCommand', () => {
     mocks.sessionCommand.mockResolvedValue({ data: undefined })
     mocks.sessionCreate.mockReset()
     mocks.sessionCreate.mockResolvedValue({ data: { id: 'new-session' } })
+    mocks.sessionStatus.mockReset()
+    mocks.sessionStatus.mockResolvedValue({ data: {} })
     mocks.configUpdate.mockReset()
     mocks.configUpdate.mockResolvedValue({ data: undefined })
   })
@@ -183,5 +187,21 @@ describe('AgentController.executeCommand', () => {
       model: 'openai/gpt-5.6-sol',
       variant: 'high',
     }))
+  })
+
+  it('reports sessions omitted from a successful status snapshot as idle', async () => {
+    mocks.sessionStatus.mockResolvedValue({
+      data: {
+        'existing-session': { type: 'busy' },
+      },
+    })
+
+    const statuses = await agentController.getSessionStatuses()
+
+    expect(statuses).toMatchObject({
+      'existing-session': { agentId: 'agent-1', status: { type: 'busy' } },
+      'bare-model-session': { agentId: 'agent-2', status: { type: 'idle' } },
+      'default-model-session': { agentId: 'agent-3', status: { type: 'idle' } },
+    })
   })
 })

--- a/src/__tests__/status-derivation.test.ts
+++ b/src/__tests__/status-derivation.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { applyReconciledStatus } from '../renderer/src/hooks/useAgentStore'
 
 // ── Extracted logic from src/renderer/src/hooks/useAgentStore.ts ──
 
@@ -168,14 +169,7 @@ function applyReconciliation(agent: MinimalAgent, serverStatusType: string): voi
   if ((serverStatus === 'needs_input' || serverStatus === 'needs_approval') && isWithinOptimisticGuard(agent)) {
     return
   }
-  agent.status = serverStatus
-  agent.lastActivityAt = Date.now()
-  if (serverStatus === 'needs_input' || serverStatus === 'needs_approval') {
-    agent.blockedSince = agent.blockedSince ?? Date.now()
-  } else {
-    agent.blockedSince = undefined
-    agent.respondedAt = undefined
-  }
+  applyReconciledStatus(agent, serverStatus)
 }
 
 // ── Tests ──
@@ -676,6 +670,14 @@ describe('reconcileStatuses: optimistic guard', () => {
     applyReconciliation(agent, 'idle')
     expect(agent.status).toBe('idle')
     expect(agent.respondedAt).toBeUndefined()
+  })
+
+  it('preserves the last real activity time during reconciliation', () => {
+    const agent: MinimalAgent = { status: 'running', lastActivityAt: 123 }
+
+    applyReconciledStatus(agent, 'idle')
+
+    expect(agent.lastActivityAt).toBe(123)
   })
 
   it('skips reconciliation when statuses already match', () => {

--- a/src/__tests__/subagent-progress.test.ts
+++ b/src/__tests__/subagent-progress.test.ts
@@ -2,6 +2,7 @@ import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import { ToolGroupBubble } from '../renderer/src/components/DetailDrawer'
+import { SubagentProgress } from '../renderer/src/components/SubagentProgress'
 import {
   shouldAutoExpandTool,
   ToolsUsage,
@@ -46,6 +47,45 @@ describe('subagent progress', () => {
 
     expect(getChildSessionId(state)).toBe('child')
     expect(getToolMetadataOutput(state)).toBe('live command output')
+  })
+
+  it('keeps only the latest pending tool running when a session retries', () => {
+    const messages = new Map<string, LiveMessage[]>([
+      ['child', [
+        assistantMessage('child', [{
+          id: 'abandoned', type: 'tool', toolName: 'task', toolState: 'pending', childSessionId: 'abandoned-child'
+        }]),
+        assistantMessage('child', [{
+          id: 'retry', type: 'tool', toolName: 'task', toolState: 'pending', childSessionId: 'retry-child'
+        }])
+      ]],
+      ['abandoned-child', [assistantMessage('abandoned-child', [
+        { id: 'old-command', type: 'tool', toolName: 'bash', toolState: 'pending' }
+      ])]],
+      ['retry-child', [assistantMessage('retry-child', [
+        { id: 'new-command', type: 'tool', toolName: 'bash', toolState: 'pending' }
+      ])]]
+    ])
+    const getToolStates = (active: boolean) => {
+      const transcript = buildChildTranscript('child', (sessionId) => messages.get(sessionId) ?? [], active)
+      return transcript.map((entry) => [entry.toolState, entry.childTranscript?.[0].toolState])
+    }
+
+    expect(getToolStates(true))
+      .toEqual([['failed', 'failed'], ['running', 'running']])
+    expect(getToolStates(false))
+      .toEqual([['failed', 'failed'], ['failed', 'failed']])
+  })
+
+  it('explains when a task failed before creating its child session', () => {
+    const markup = renderToStaticMarkup(createElement(SubagentProgress, {
+      entries: [],
+      state: 'failed'
+    }))
+
+    expect(markup).toContain('sub-agent failed')
+    expect(markup).toContain('Child session was not created.')
+    expect(markup).not.toContain('Creating child session...')
   })
 
   it('streams visible assistant text without exposing reasoning deltas', () => {
@@ -145,7 +185,6 @@ describe('subagent progress', () => {
     ])
 
     const transcript = buildChildTranscript('child', (sessionId) => messages.get(sessionId) ?? [])
-
     expect(transcript[0]).toMatchObject({
       label: 'bash',
       toolState: 'running',
@@ -163,7 +202,7 @@ describe('subagent progress', () => {
     )).toBe(4)
   })
 
-  it('places the most recently updated subagent at the bottom of the transcript', () => {
+  it('moves running subagents by activity without moving completed tasks past later output', () => {
     const userMessage: Message = {
       id: 'user', role: 'user', content: 'continue', timestamp: 'now', activityAt: 15
     }
@@ -171,7 +210,7 @@ describe('subagent progress', () => {
       id: 'tasks', role: 'tool-group', content: '2 tool calls', timestamp: 'now', activityAt: 1,
       toolCalls: [{
         id: 'older', name: 'task', state: 'completed', timestamp: 1,
-        childSessionId: 'older-child', childActivityAt: 10
+        childSessionId: 'older-child', childActivityAt: 30
       }, {
         id: 'newer', name: 'task', state: 'running', timestamp: 2,
         childSessionId: 'newer-child', childActivityAt: 20
@@ -251,6 +290,30 @@ describe('subagent progress', () => {
     expect(shouldAutoExpandTool(ordinaryTool, 'some', false)).toBe(true)
     expect(shouldAutoExpandTool(completedTask, 'some', false)).toBe(false)
     expect(shouldAutoExpandTool(completedTask, 'all', false)).toBe(true)
+  })
+
+  it('shows completed Task results without treating child details as parent output', () => {
+    const transcript = renderToStaticMarkup(createElement(ToolGroupBubble, {
+      message: {
+        id: 'task-result',
+        role: 'tool-group',
+        content: '1 tool call',
+        timestamp: 'now',
+        toolCalls: [{
+          id: 'task',
+          name: 'task',
+          state: 'completed',
+          timestamp: 1,
+          output: '<task_result>Confirm this draft?</task_result>',
+          childSessionId: 'child',
+          childTranscript: [{ id: 'draft', kind: 'text', label: 'full child draft' }]
+        }]
+      },
+      verbosity: 'some'
+    }))
+
+    expect(transcript).toContain('Confirm this draft?')
+    expect(transcript).not.toContain('full child draft')
   })
 
   it('expands running commands after a completed todo update', () => {

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -1053,12 +1053,9 @@ class AgentController {
         if (result.data) {
           const sessionStatuses = result.data as Record<string, { type: string }>
           for (const handle of handles) {
-            const sessionStatus = sessionStatuses[handle.sessionId]
-            if (sessionStatus) {
-              statuses[handle.sessionId] = {
-                agentId: handle.id,
-                status: sessionStatus
-              }
+            statuses[handle.sessionId] = {
+              agentId: handle.id,
+              status: sessionStatuses[handle.sessionId] ?? { type: 'idle' }
             }
           }
         }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -549,6 +549,11 @@ export function App() {
     if (!liveAgent) return []
 
     const liveMessages = getMessagesForSession(liveAgent.sessionId)
+    const latestLiveMessage = liveMessages[liveMessages.length - 1]
+    const sessionActive = liveAgent.status !== 'idle'
+      && liveAgent.status !== 'completed'
+      && liveAgent.status !== 'errored'
+      && liveAgent.status !== 'disconnected'
     const transcriptItems: Message[] = []
     let pendingToolCalls: ToolCall[] = []
 
@@ -568,6 +573,7 @@ export function App() {
     }
 
     for (const msg of liveMessages) {
+      const messageActive = sessionActive && msg === latestLiveMessage
       const textParts: string[] = []
       const toolCalls: ToolCall[] = []
       const images: Array<{ mime: string; url: string; filename?: string }> = []
@@ -584,11 +590,12 @@ export function App() {
               textParts.push(part.text)
             }
             break
-          case 'tool':
+          case 'tool': {
+            const toolState = mapToolState(part.toolState, messageActive)
             toolCalls.push({
               id: part.id,
               name: part.toolName ?? 'unknown',
-              state: mapToolState(part.toolState),
+              state: toolState,
               input: part.toolInput,
               output: part.text ?? undefined,
               timestamp: msg.createdAt,
@@ -601,10 +608,11 @@ export function App() {
                   )
                 : undefined,
               childTranscript: part.childSessionId
-                ? buildChildTranscript(part.childSessionId, getMessagesForSession)
+                ? buildChildTranscript(part.childSessionId, getMessagesForSession, toolState === 'running')
                 : undefined
             })
             break
+          }
           case 'file':
             if (part.fileUrl && part.fileMime?.startsWith('image/')) {
               images.push({

--- a/src/renderer/src/components/SubagentProgress.tsx
+++ b/src/renderer/src/components/SubagentProgress.tsx
@@ -19,6 +19,14 @@ function progressLabel(state: DisplayToolState, childSessionId: string | undefin
   return childSessionId ? 'sub-agent working' : 'sub-agent starting'
 }
 
+function emptyProgressMessage(state: DisplayToolState, childSessionId: string | undefined): string {
+  if (state === 'failed') {
+    return childSessionId ? 'Sub-agent stopped without output.' : 'Child session was not created.'
+  }
+  if (state === 'completed') return 'No sub-agent output was recorded.'
+  return childSessionId ? 'Waiting for live output...' : 'Creating child session...'
+}
+
 export function SubagentProgress({ entries, state, childSessionId }: SubagentProgressProps) {
   const running = state === 'running'
 
@@ -30,7 +38,7 @@ export function SubagentProgress({ entries, state, childSessionId }: SubagentPro
       </div>
       {entries.length === 0 ? (
         <div className="text-[10px] font-mono text-kumo-subtle">
-          {childSessionId ? 'Waiting for live output...' : 'Creating child session...'}
+          {emptyProgressMessage(state, childSessionId)}
         </div>
       ) : (
         <div className="flex flex-col gap-1.5">

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -2551,6 +2551,19 @@ function applyStatuses(statuses: AgentStatusesPayload): void {
   }
 }
 
+export function applyReconciledStatus(
+  agent: Pick<LiveAgent, 'status' | 'blockedSince' | 'respondedAt'>,
+  serverStatus: AgentStatus
+): void {
+  agent.status = serverStatus
+  if (serverStatus === 'needs_input' || serverStatus === 'needs_approval') {
+    agent.blockedSince = agent.blockedSince ?? Date.now()
+  } else {
+    agent.blockedSince = undefined
+    agent.respondedAt = undefined
+  }
+}
+
 /**
  * Periodic reconciliation: compare local agent statuses against the server's
  * actual session statuses and correct any drift. This catches agents stuck
@@ -2597,16 +2610,7 @@ function reconcileStatuses(statuses: AgentStatusesPayload): void {
     console.warn(
       `[AgentStore] Reconciliation: agent ${agent.id} status ${agent.status} → ${serverStatus} (server says ${statusEntry.status.type})`
     )
-    agent.status = serverStatus
-    agent.lastActivityAt = Date.now()
-    if (serverStatus === 'needs_input' || serverStatus === 'needs_approval') {
-
-      agent.blockedSince = agent.blockedSince ?? Date.now()
-    } else {
-      agent.blockedSince = undefined
-      agent.respondedAt = undefined
-
-    }
+    applyReconciledStatus(agent, serverStatus)
     changed = true
   }
 

--- a/src/renderer/src/lib/subagent-progress.ts
+++ b/src/renderer/src/lib/subagent-progress.ts
@@ -26,10 +26,10 @@ export interface TaskPartDescriptor {
   childSessionId?: string
 }
 
-export function mapToolState(toolState?: string): DisplayToolState {
+export function mapToolState(toolState?: string, active = true): DisplayToolState {
   if (toolState === 'completed') return 'completed'
   if (toolState === 'error' || toolState === 'failed') return 'failed'
-  return 'running'
+  return active ? 'running' : 'failed'
 }
 
 export function getChildSessionId(partState: Record<string, unknown> | undefined): string | undefined {
@@ -138,6 +138,7 @@ export function collectSessionSubtreeIds(
 export function buildChildTranscript(
   sessionId: string,
   getMessagesForSession: (sessionId: string) => LiveMessage[],
+  active = true,
   ancestors: ReadonlySet<string> = new Set()
 ): ChildTranscriptEntry[] {
   if (ancestors.has(sessionId)) return []
@@ -145,24 +146,28 @@ export function buildChildTranscript(
   const nextAncestors = new Set(ancestors)
   nextAncestors.add(sessionId)
   const entries: ChildTranscriptEntry[] = []
+  const messages = getMessagesForSession(sessionId)
+  const latestMessage = messages[messages.length - 1]
 
-  for (const message of getMessagesForSession(sessionId)) {
+  for (const message of messages) {
     if (message.role !== 'assistant') continue
+    const messageActive = active && message === latestMessage
 
     for (const part of message.parts) {
       if (part.type === 'text' && part.text) {
         entries.push({ id: part.id, kind: 'text', label: part.text })
       } else if (part.type === 'tool' && part.toolName) {
+        const toolState = mapToolState(part.toolState, messageActive)
         entries.push({
           id: part.id,
           kind: 'tool',
           label: part.toolName,
-          toolState: mapToolState(part.toolState),
+          toolState,
           toolSummary: summarizeChildToolInput(part.toolName, part.toolInput),
           toolOutput: part.text,
           childSessionId: part.childSessionId,
           childTranscript: part.childSessionId
-            ? buildChildTranscript(part.childSessionId, getMessagesForSession, nextAncestors)
+            ? buildChildTranscript(part.childSessionId, getMessagesForSession, toolState === 'running', nextAncestors)
             : undefined
         })
       }
@@ -208,7 +213,7 @@ export function orderTranscriptByActivity(messages: Message[]): Message[] {
       message,
       index,
       activityAt: message.toolCalls
-        ?.filter((tool) => tool.name === 'task')
+        ?.filter((tool) => tool.name === 'task' && tool.state === 'running')
         .reduce((latest, tool) => Math.max(latest, tool.childActivityAt ?? latest), message.activityAt ?? 0)
         ?? message.activityAt
         ?? index


### PR DESCRIPTION
OpenCode omits idle sessions from its status response. OCO dropped those missing entries, so the
parent and its pending Task call could remain Running forever.

Missing entries now resolve to idle. An abandoned pending Task call becomes failed, and a Task that
stops before creating its child session explains what happened. Running Tasks follow child activity,
while completed Tasks keep their original place before later parent output. Completed Task results
remain visible when the child transcript is collapsed.

`needs_input` still requires an OpenCode question or waiting event. OCO doesn't infer it from prose in
a completed Task result.

Verified under Node 24.14.0 with `npm test` (290 passed, 6 skipped), `npm run typecheck`, `npm run lint`
(no new warnings), and `git diff --check`. The transcript ordering test fails against the old code and
passes with this change.

This change was written and tested with AI assistance.
