### PR TITLE
NO-JIRA Open the transcript from the Last Message cell

### DIFF
--- a/src/__tests__/fleet-last-message.test.ts
+++ b/src/__tests__/fleet-last-message.test.ts
@@ -1,0 +1,101 @@
+import { createElement, type MouseEvent as ReactMouseEvent, type ReactElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import { FleetTable, LastMessageCell } from '../renderer/src/components/FleetTable'
+import { extractLastAssistantMessage, findLastTranscriptMessageId } from '../renderer/src/lib/last-message'
+import type { AgentRuntime, Message } from '../renderer/src/types'
+
+const messages: Message[] = [
+  { id: 'user-1', role: 'user', content: 'Start', timestamp: 'now' },
+  { id: 'assistant-1', role: 'assistant', content: 'First answer', timestamp: 'now' },
+  { id: 'tools', role: 'tool-group', content: '1 tool call', timestamp: 'now' },
+  { id: 'assistant-2', role: 'assistant', content: 'Latest answer', timestamp: 'now' }
+]
+
+describe('Fleet Last Message navigation', () => {
+  const agent: AgentRuntime = {
+    id: 'agent-1',
+    sessionId: 'session-1',
+    name: 'Agent 1',
+    projectId: '/project',
+    projectName: 'Project',
+    branchName: 'feature',
+    isWorktree: true,
+    workspaceName: 'Workspace',
+    taskSummary: 'Task',
+    status: 'running',
+    labelIds: [],
+    model: 'model',
+    prUrl: null,
+    lastActivityAt: 'now',
+    lastActivityAtMs: 1,
+    lastMessage: 'Latest answer'
+  }
+
+  it('renders the last message as a keyboard-accessible button', () => {
+    const markup = renderToStaticMarkup(LastMessageCell({
+      agentId: agent.id,
+      message: 'Latest answer',
+      onSelect: () => {}
+    }))
+
+    expect(markup).toContain('<button')
+    expect(markup).toContain('type="button"')
+    expect(markup).toContain('Latest answer')
+    expect(markup).toContain('Click to jump to this message')
+  })
+
+  it('jumps without triggering the row click', () => {
+    const onSelect = vi.fn()
+    const stopPropagation = vi.fn()
+    const cell = LastMessageCell({ agentId: agent.id, message: 'Latest answer', onSelect })
+    const button = cell.props.children as ReactElement<{
+      onClick: (event: ReactMouseEvent<HTMLButtonElement>) => void
+    }>
+
+    button.props.onClick({ stopPropagation } as unknown as ReactMouseEvent<HTMLButtonElement>)
+
+    expect(stopPropagation).toHaveBeenCalledOnce()
+    expect(onSelect).toHaveBeenCalledWith(agent.id, 'last-assistant-message')
+  })
+
+  it('keeps an empty Last Message cell non-interactive', () => {
+    const markup = renderToStaticMarkup(LastMessageCell({ agentId: agent.id, onSelect: () => {} }))
+
+    expect(markup).not.toContain('<button')
+    expect(markup).toContain('--')
+  })
+
+  it('uses the interactive Last Message cell in the Fleet table', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {}
+    })
+    const markup = renderToStaticMarkup(createElement(FleetTable, {
+      agents: [agent],
+      selectedId: null,
+      onSelect: () => {},
+      visibleColumns: new Set(['lastMessage']),
+      columnWidths: {}
+    }))
+
+    expect(markup).toContain('<button type="button"')
+    expect(markup).toContain('Click to jump to this message')
+  })
+
+  it('resolves the latest rendered assistant text message', () => {
+    expect(findLastTranscriptMessageId(messages, 'last-assistant-message')).toBe('assistant-2')
+    expect(findLastTranscriptMessageId([
+      ...messages,
+      { id: 'assistant-empty', role: 'assistant', content: '', timestamp: 'now' }
+    ], 'last-assistant-message')).toBe('assistant-2')
+  })
+
+  it('does not display assistant text that the transcript hides', () => {
+    expect(extractLastAssistantMessage([
+      { role: 'assistant', parts: [{ type: 'text', text: 'Visible answer' }] },
+      { role: 'assistant', parts: [{ type: 'text', text: 'Synthetic context', synthetic: true }] },
+      { role: 'assistant', parts: [{ type: 'text', text: '   ' }] }
+    ])).toBe('Visible answer')
+  })
+})

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -26,6 +26,7 @@ import {
   mapToolState,
   orderTranscriptByActivity
 } from './lib/subagent-progress'
+import { extractLastAssistantMessage } from './lib/last-message'
 
 const NEW_AGENT_COMMAND = '/new'
 const AGENT_MENTION_REGEX = /@(\w+)/
@@ -40,18 +41,6 @@ function sanitizeSlugSegment(value: string, fallback: string): string {
     .slice(0, 50)
 
   return sanitized || fallback
-}
-
-function extractLastAssistantMessage(messages: { role: string; parts: { type: string; text?: string }[] }[]): string | undefined {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i].role !== 'assistant') continue
-    const text = messages[i].parts
-      .filter((p) => p.type === 'text' && p.text)
-      .map((p) => p.text!)
-      .join(' ')
-    if (text) return text.slice(0, 200)
-  }
-  return undefined
 }
 
 export function App() {
@@ -72,13 +61,15 @@ export function App() {
   }, [])
 
   const [selectedAgentId, setSelectedAgentIdRaw] = useState<string | null>(null)
+  const drawerScrollSeqRef = useRef(0)
   // Scroll request signal for DetailDrawer. `seq` bumps on every request so
   // clicking the same cell twice in a row still retriggers the scroll.
   const [drawerScrollRequest, setDrawerScrollRequest] = useState<{ target: DrawerScrollTarget; seq: number } | null>(null)
   const setSelectedAgentId = useCallback((id: string | null, scrollTarget?: DrawerScrollTarget) => {
     setSelectedAgentIdRaw(id)
     if (id && scrollTarget) {
-      setDrawerScrollRequest((prev) => ({ target: scrollTarget, seq: (prev?.seq ?? 0) + 1 }))
+      drawerScrollSeqRef.current += 1
+      setDrawerScrollRequest({ target: scrollTarget, seq: drawerScrollSeqRef.current })
     } else {
       // Clear any stale scroll request so plain row clicks (or drawer close)
       // don't trigger a jump when the drawer remounts for a new agent.

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -55,6 +55,7 @@ import { FilesChanged } from './FilesChanged'
 import { CollapsibleSubagentProgress, ToolsUsage } from './ToolsUsage'
 import { EventLog } from './EventLog'
 import { SelectField } from './SelectField'
+import { findLastTranscriptMessageId } from '../lib/last-message'
 
 import type { FileChange } from './FilesChanged'
 import type { ToolCall } from './ToolsUsage'
@@ -199,7 +200,7 @@ interface DetailDrawerProps {
    * each request so repeated clicks retrigger the scroll even when the target
    * is unchanged.
    */
-  scrollRequest?: { target: 'last-user-message' | 'bottom'; seq: number } | null
+  scrollRequest?: { target: 'last-user-message' | 'last-assistant-message' | 'bottom'; seq: number } | null
   onClose: () => void
   onSendMessage?: (text: string, attachments?: Array<{ mime: string; dataUrl: string; filename?: string }>) => void
   onApprove?: () => void
@@ -581,17 +582,10 @@ export const DetailDrawer = memo(function DetailDrawer({
       return
     }
 
-    if (scrollRequest.target !== 'last-user-message') return
-
-    let targetIndex = -1
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].role === 'user') {
-        targetIndex = i
-        break
-      }
-    }
+    const targetId = findLastTranscriptMessageId(messages, scrollRequest.target)
+    if (!targetId) return
+    const targetIndex = messages.findIndex((message) => message.id === targetId)
     if (targetIndex < 0) return
-    const targetId = messages[targetIndex].id
 
     // Expand the visible window if the target is outside it so the node renders.
     const neededCount = messages.length - targetIndex

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -72,11 +72,13 @@ const quickActionIconMap: Record<QuickActionIcon, typeof Lightning> = {
  * Where to land in the transcript when opening the drawer.
  *  - 'last-user-message': scroll the last user message to the top of the
  *    viewport. Used when jumping back from a notification or quick-action.
+ *  - 'last-assistant-message': scroll the message shown in the Last Message
+ *    column to the top of the viewport.
  *  - 'bottom': scroll all the way to the bottom and re-engage follow-mode
  *    so the next streaming reply auto-scrolls into view. Used after sending
  *    from the workspace's highlight-to-ask popover.
  */
-export type DrawerScrollTarget = 'last-user-message' | 'bottom'
+export type DrawerScrollTarget = 'last-user-message' | 'last-assistant-message' | 'bottom'
 
 interface FleetTableProps {
   agents: AgentRuntime[]
@@ -217,6 +219,38 @@ interface RenameState {
 interface PrLinkState {
   agentId: string
   currentUrl: string
+}
+
+export function LastMessageCell({
+  agentId,
+  message,
+  onSelect
+}: {
+  agentId: string
+  message?: string
+  onSelect?: FleetTableProps['onSelect']
+}) {
+  return (
+    <td className="px-3 py-2 truncate text-kumo-subtle text-[11px]">
+      {message && onSelect ? (
+        <button
+          type="button"
+          className="max-w-full truncate text-left cursor-pointer hover:text-kumo-strong"
+          title={`${message}\n\nClick to jump to this message`}
+          onClick={(event) => {
+            event.stopPropagation()
+            onSelect(agentId, 'last-assistant-message')
+          }}
+        >
+          {message}
+        </button>
+      ) : message ? (
+        <span title={message}>{message}</span>
+      ) : (
+        <span className="text-kumo-muted italic">--</span>
+      )}
+    </td>
+  )
 }
 
 export function FleetTable({
@@ -775,6 +809,7 @@ export function FleetTable({
         suppressNextClickRef={suppressNextClick}
         onSelect={pending ? noop : () => onSelect(agent.id)}
         onJumpToLastUserMessage={pending ? noop : () => onSelect(agent.id, 'last-user-message')}
+        onSelectLastMessage={pending ? undefined : onSelect}
         onContextMenu={pending ? noop : (event) => handleContextMenu(event, agent.id)}
         onApprove={onApprove && !pending ? () => onApprove(agent.id) : undefined}
         onReply={onReply && !pending ? () => onReply(agent.id) : undefined}
@@ -1252,6 +1287,7 @@ function AgentRow({
   suppressNextClickRef,
   onSelect,
   onJumpToLastUserMessage,
+  onSelectLastMessage,
   onContextMenu,
   onApprove,
   onReply,
@@ -1292,6 +1328,7 @@ function AgentRow({
   suppressNextClickRef?: React.MutableRefObject<boolean>
   onSelect: () => void
   onJumpToLastUserMessage: () => void
+  onSelectLastMessage?: FleetTableProps['onSelect']
   onContextMenu: (event: React.MouseEvent) => void
   onApprove?: () => void
   onReply?: () => void
@@ -1503,9 +1540,7 @@ function AgentRow({
         </td>
       )}
       {show('lastMessage') && (
-        <td className="px-3 py-2 truncate text-kumo-subtle text-[11px]" title={agent.lastMessage || undefined}>
-          {agent.lastMessage || <span className="text-kumo-muted italic">--</span>}
-        </td>
+        <LastMessageCell agentId={agent.id} message={agent.lastMessage} onSelect={onSelectLastMessage} />
       )}
       {show('branch') && (
         <td className="px-3 py-2 font-mono text-[11px] text-kumo-subtle truncate" title={formatBranchLabel(agent)}>

--- a/src/renderer/src/lib/last-message.ts
+++ b/src/renderer/src/lib/last-message.ts
@@ -1,0 +1,28 @@
+import type { Message } from '../types'
+
+export function extractLastAssistantMessage(
+  messages: { role: string; parts: { type: string; text?: string; synthetic?: boolean }[] }[]
+): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role !== 'assistant') continue
+    const text = messages[i].parts
+      .filter((part) => part.type === 'text' && part.text?.trim() && !part.synthetic)
+      .map((part) => part.text!)
+      .join(' ')
+    if (text) return text.slice(0, 200)
+  }
+  return undefined
+}
+
+export function findLastTranscriptMessageId(
+  messages: Message[],
+  target: 'last-user-message' | 'last-assistant-message'
+): string | undefined {
+  const role = target === 'last-user-message' ? 'user' : 'assistant'
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role !== role) continue
+    if (role === 'assistant' && !messages[i].content.trim()) continue
+    return messages[i].id
+  }
+  return undefined
+}


### PR DESCRIPTION
The Task cell already opens an agent's transcript and scrolls to a message. Last Message showed plain text with no equivalent affordance, even though it's the exact reply you want to jump to when something catches your eye in the fleet view.

This gives Last Message the same click and keyboard behavior as Task. It opens the drawer and scrolls to the latest assistant reply shown in the cell. The drawer resolves that target with the same visibility rules the transcript already uses, skipping synthetic and empty text, so what you see in the cell is what you land on.

Also moved the drawer's scroll request counter into a ref instead of deriving it from state. Deriving it from state meant the counter reset to null whenever a request cleared, such as after a plain row click, so a jump right after that reused seq 1, and a drawer that was already mounted would treat it as stale and ignore it.
