### PR TITLE
NO-JIRA Keep pending prompts visible

### DIFF
--- a/src/__tests__/detail-drawer-interrupt.test.ts
+++ b/src/__tests__/detail-drawer-interrupt.test.ts
@@ -1,0 +1,114 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DetailDrawer } from '../renderer/src/components/DetailDrawer'
+import type { LivePermission, LiveQuestion } from '../renderer/src/hooks/useAgentStore'
+import type { AgentRuntime } from '../renderer/src/types'
+
+function getElementContents(markup: string, attribute: string): string {
+  const attributeIndex = markup.indexOf(attribute)
+  const openingTagStart = markup.lastIndexOf('<div', attributeIndex)
+  const openingTagEnd = markup.indexOf('>', attributeIndex) + 1
+  let depth = 1
+  const tagPattern = /<\/?div\b[^>]*>/g
+  tagPattern.lastIndex = openingTagEnd
+
+  for (let match = tagPattern.exec(markup); match; match = tagPattern.exec(markup)) {
+    depth += match[0].startsWith('</') ? -1 : 1
+    if (depth === 0) return markup.slice(openingTagStart, match.index + match[0].length)
+  }
+
+  throw new Error(`Could not find closing div for ${attribute}`)
+}
+
+describe('DetailDrawer pending interrupts', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it.each<{
+    name: string
+    status: AgentRuntime['status']
+    permission?: LivePermission
+    question?: LiveQuestion
+    expected: string
+  }>([
+    {
+      name: 'structured question',
+      status: 'needs_input',
+      expected: 'Which findings should I fix?',
+      question: {
+        id: 'question-1',
+        agentId: 'agent-1',
+        sessionId: 'session-1',
+        createdAt: 1,
+        questions: [{
+          header: 'Fix selection',
+          question: 'Which findings should I fix?',
+          options: [{ label: 'First', description: 'Fix the first finding.' }]
+        }]
+      }
+    },
+    {
+      name: 'permission request',
+      status: 'needs_approval',
+      expected: 'Permission Request',
+      permission: {
+        id: 'permission-1',
+        agentId: 'agent-1',
+        sessionId: 'session-1',
+        type: 'bash',
+        title: 'Run tests',
+        createdAt: 1
+      }
+    },
+    {
+      name: 'question fallback',
+      status: 'needs_input',
+      expected: 'Waiting for your response'
+    }
+  ])('keeps $name outside the resizable transcript', ({ status, permission, question, expected }) => {
+    vi.stubGlobal('window', { innerHeight: 1000 })
+    vi.stubGlobal('localStorage', { getItem: () => null })
+
+    const agent: AgentRuntime = {
+      id: 'agent-1',
+      sessionId: 'session-1',
+      name: 'Agent 1',
+      projectId: 'project-1',
+      projectName: 'Project',
+      branchName: 'branch',
+      isWorktree: true,
+      workspaceName: 'workspace',
+      taskSummary: 'Task',
+      status,
+      labelIds: [],
+      model: 'model',
+      prUrl: null,
+      lastActivityAt: 'now',
+      lastActivityAtMs: 1
+    }
+    const markup = renderToStaticMarkup(createElement(DetailDrawer, {
+      agent,
+      messages: [{
+        id: 'task-1',
+        role: 'tool-group',
+        content: '1 tool call',
+        timestamp: 'now',
+        toolCalls: [{
+          id: 'tool-1',
+          name: 'task',
+          state: 'running',
+          timestamp: 1,
+          childTranscript: [{ id: 'child-1', kind: 'text', label: 'Working' }]
+        }]
+      }],
+      permission,
+      question,
+      onClose: () => {}
+    }))
+
+    const transcript = getElementContents(markup, 'data-transcript-scroll')
+    const interrupt = getElementContents(markup, 'data-pending-interrupt')
+    expect(transcript).not.toContain(expected)
+    expect(interrupt).toContain(expected)
+  })
+})

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -511,6 +511,7 @@ export const DetailDrawer = memo(function DetailDrawer({
       }
     })
     ro.observe(content)
+    ro.observe(container)
 
     requestAnimationFrame(() => scrollToBottom(container))
     return () => ro.disconnect()
@@ -924,6 +925,7 @@ export const DetailDrawer = memo(function DetailDrawer({
         <div className="flex-1 relative overflow-hidden">
           <div
             ref={transcriptScrollRef}
+            data-transcript-scroll
             className="absolute inset-0 overflow-y-auto px-4 py-3 flex flex-col gap-2"
           >
             {activeTab === 'transcript' && (
@@ -975,72 +977,6 @@ export const DetailDrawer = memo(function DetailDrawer({
                   </div>
                 )}
 
-                {/* Permission request inline card */}
-                {permission && (
-                  <div className="bg-kumo-brand/[0.06] border border-kumo-brand/20 rounded-lg p-3 flex flex-col gap-2">
-                    <div className="text-xs font-semibold text-kumo-brand flex items-center gap-1.5">
-                      &#128274; Permission Request
-                    </div>
-                    <div className="text-xs text-kumo-default">{permission.title}</div>
-                    {permission.pattern && (
-                      <div className="font-mono text-[11px] px-2 py-1 bg-kumo-overlay rounded text-kumo-subtle">
-                        {Array.isArray(permission.pattern) ? permission.pattern.join(', ') : permission.pattern}
-                      </div>
-                    )}
-                    <div className="flex gap-1.5">
-                      {onApprove && (
-                        <button
-                          onClick={onApprove}
-                          className="flex-1 flex items-center justify-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md bg-kumo-success/12 border border-kumo-success/25 text-kumo-success hover:bg-kumo-success/20 transition-colors"
-                        >
-                          <Check size={12} weight="bold" /> Approve Once
-                        </button>
-                      )}
-                      {onApproveAlways && (
-                        <button
-                          onClick={onApproveAlways}
-                          className="flex-1 flex items-center justify-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md bg-kumo-success/12 border border-kumo-success/25 text-kumo-success hover:bg-kumo-success/20 transition-colors"
-                        >
-                          <CheckCircle size={12} weight="fill" /> Approve Always
-                        </button>
-                      )}
-                      {onDeny && (
-                        <button
-                          onClick={onDeny}
-                          className="flex-1 flex items-center justify-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md bg-kumo-danger/10 border border-kumo-danger/20 text-kumo-danger hover:bg-kumo-danger/20 transition-colors"
-                        >
-                          <XCircle size={12} /> Deny
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                )}
-
-                {/* Question card — show only when we actually have structured question
-                    content. If the server delivered a malformed event with an empty
-                    `questions` array, fall through to the "Waiting for your response"
-                    placeholder so the user isn't stuck staring at a bare header. */}
-                {!permission && question && question.questions.length > 0 && (
-                  <QuestionCard
-                    question={question}
-                    onReply={onReplyQuestion}
-                    onReject={onRejectQuestion}
-                  />
-                )}
-
-                {/* Waiting for input (no structured question, or question payload was empty) */}
-                {!permission
-                  && (!question || question.questions.length === 0)
-                  && agent.status === 'needs_input' && (
-                  <div className="bg-status-input-bg/30 border border-status-input/20 rounded-lg p-3 flex flex-col gap-2">
-                    <div className="text-xs font-semibold text-status-input flex items-center gap-1.5">
-                      <ChatCircleDots size={14} weight="fill" /> Waiting for your response
-                    </div>
-                    <div className="text-xs text-kumo-default">
-                      This agent has asked a question and is waiting for your reply. Use the input below to respond.
-                    </div>
-                  </div>
-                )}
               </div>
             )}
 
@@ -1079,6 +1015,74 @@ export const DetailDrawer = memo(function DetailDrawer({
             </div>
           )}
         </div>
+
+        {activeTab === 'transcript' && (permission || question || agent.status === 'needs_input') && (
+          <div
+            data-pending-interrupt
+            className="min-h-0 shrink max-h-[45%] overflow-y-auto border-t border-kumo-line px-4 py-3"
+          >
+            {permission && (
+              <div className="bg-kumo-brand/[0.06] border border-kumo-brand/20 rounded-lg p-3 flex flex-col gap-2">
+                <div className="text-xs font-semibold text-kumo-brand flex items-center gap-1.5">
+                  &#128274; Permission Request
+                </div>
+                <div className="text-xs text-kumo-default">{permission.title}</div>
+                {permission.pattern && (
+                  <div className="font-mono text-[11px] px-2 py-1 bg-kumo-overlay rounded text-kumo-subtle">
+                    {Array.isArray(permission.pattern) ? permission.pattern.join(', ') : permission.pattern}
+                  </div>
+                )}
+                <div className="flex gap-1.5">
+                  {onApprove && (
+                    <button
+                      onClick={onApprove}
+                      className="flex-1 flex items-center justify-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md bg-kumo-success/12 border border-kumo-success/25 text-kumo-success hover:bg-kumo-success/20 transition-colors"
+                    >
+                      <Check size={12} weight="bold" /> Approve Once
+                    </button>
+                  )}
+                  {onApproveAlways && (
+                    <button
+                      onClick={onApproveAlways}
+                      className="flex-1 flex items-center justify-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md bg-kumo-success/12 border border-kumo-success/25 text-kumo-success hover:bg-kumo-success/20 transition-colors"
+                    >
+                      <CheckCircle size={12} weight="fill" /> Approve Always
+                    </button>
+                  )}
+                  {onDeny && (
+                    <button
+                      onClick={onDeny}
+                      className="flex-1 flex items-center justify-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md bg-kumo-danger/10 border border-kumo-danger/20 text-kumo-danger hover:bg-kumo-danger/20 transition-colors"
+                    >
+                      <XCircle size={12} /> Deny
+                    </button>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {!permission && question && question.questions.length > 0 && (
+              <QuestionCard
+                question={question}
+                onReply={onReplyQuestion}
+                onReject={onRejectQuestion}
+              />
+            )}
+
+            {!permission
+              && (!question || question.questions.length === 0)
+              && agent.status === 'needs_input' && (
+              <div className="bg-status-input-bg/30 border border-status-input/20 rounded-lg p-3 flex flex-col gap-2">
+                <div className="text-xs font-semibold text-status-input flex items-center gap-1.5">
+                  <ChatCircleDots size={14} weight="fill" /> Waiting for your response
+                </div>
+                <div className="text-xs text-kumo-default">
+                  This agent has asked a question and is waiting for your reply. Use the input below to respond.
+                </div>
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Vertical resize handle */}
         {/* Resize handle + bottom pane (chat input + action rail) only show


### PR DESCRIPTION
Pending question and permission cards were part of the transcript scroll area. Expanding an
earlier task after leaving follow mode could push the active prompt below the viewport while
the agent remained blocked.

The drawer now keeps pending prompts in a bounded panel above the composer. The transcript
observer also tracks viewport size changes so follow mode stays at the bottom. Regression
coverage checks structured questions, permission requests, and the fallback prompt.