### PR TITLE
NO-JIRA Keep pending Bash activities running

### DIFF
--- a/src/__tests__/subagent-progress.test.ts
+++ b/src/__tests__/subagent-progress.test.ts
@@ -16,6 +16,7 @@ import {
   getLatestChildActivityAt,
   getChildSessionId,
   getToolMetadataOutput,
+  mapToolState,
   collectSessionSubtreeIds,
   mergeLiveMessagePart,
   orderTranscriptByActivity,
@@ -72,9 +73,27 @@ describe('subagent progress', () => {
     }
 
     expect(getToolStates(true))
-      .toEqual([['failed', 'failed'], ['running', 'running']])
+      .toEqual([['failed', 'running'], ['running', 'running']])
     expect(getToolStates(false))
-      .toEqual([['failed', 'failed'], ['failed', 'failed']])
+      .toEqual([['failed', 'running'], ['failed', 'running']])
+  })
+
+  it('keeps a pending Bash activity running when a later message arrives', () => {
+    const messages = [
+      assistantMessage('child', [{
+        id: 'command', type: 'tool', toolName: 'bash', toolState: 'pending'
+      }]),
+      assistantMessage('child', [{ id: 'progress', type: 'text', text: 'Still working' }])
+    ]
+
+    const transcript = buildChildTranscript('child', () => messages)
+
+    expect(transcript[0]).toMatchObject({ label: 'bash', toolState: 'running' })
+  })
+
+  it('only infers failure for an inactive Task activity', () => {
+    expect(mapToolState('bash', 'pending', false)).toBe('running')
+    expect(mapToolState('task', 'pending', false)).toBe('failed')
   })
 
   it('explains when a task failed before creating its child session', () => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -591,7 +591,7 @@ export function App() {
             }
             break
           case 'tool': {
-            const toolState = mapToolState(part.toolState, messageActive)
+            const toolState = mapToolState(part.toolName, part.toolState, messageActive)
             toolCalls.push({
               id: part.id,
               name: part.toolName ?? 'unknown',

--- a/src/renderer/src/lib/subagent-progress.ts
+++ b/src/renderer/src/lib/subagent-progress.ts
@@ -26,10 +26,14 @@ export interface TaskPartDescriptor {
   childSessionId?: string
 }
 
-export function mapToolState(toolState?: string, active = true): DisplayToolState {
+export function mapToolState(
+  toolName: string | undefined,
+  toolState?: string,
+  active = true
+): DisplayToolState {
   if (toolState === 'completed') return 'completed'
   if (toolState === 'error' || toolState === 'failed') return 'failed'
-  return active ? 'running' : 'failed'
+  return toolName === 'task' && !active ? 'failed' : 'running'
 }
 
 export function getChildSessionId(partState: Record<string, unknown> | undefined): string | undefined {
@@ -157,7 +161,7 @@ export function buildChildTranscript(
       if (part.type === 'text' && part.text) {
         entries.push({ id: part.id, kind: 'text', label: part.text })
       } else if (part.type === 'tool' && part.toolName) {
-        const toolState = mapToolState(part.toolState, messageActive)
+        const toolState = mapToolState(part.toolName, part.toolState, messageActive)
         entries.push({
           id: part.id,
           kind: 'tool',


### PR DESCRIPTION
Pending Bash activities were shown as failed when a later assistant message arrived, even though OpenCode still reported the tool part as pending. The inactive message fallback was added for abandoned Task calls but applied to every tool.

Keep that fallback for Task calls and use OpenCode's explicit terminal state for ordinary tools. The regression coverage keeps abandoned tasks failed while pending Bash calls remain running.