### PR TITLE
NO-JIRA Keep agent progress accurate after queued messages

### DIFF
--- a/src/__tests__/detail-drawer-interrupt.test.ts
+++ b/src/__tests__/detail-drawer-interrupt.test.ts
@@ -21,6 +21,26 @@ function getElementContents(markup: string, attribute: string): string {
   throw new Error(`Could not find closing div for ${attribute}`)
 }
 
+function createAgent(status: AgentRuntime['status']): AgentRuntime {
+  return {
+    id: 'agent-1',
+    sessionId: 'session-1',
+    name: 'Agent 1',
+    projectId: 'project-1',
+    projectName: 'Project',
+    branchName: 'branch',
+    isWorktree: true,
+    workspaceName: 'workspace',
+    taskSummary: 'Task',
+    status,
+    labelIds: [],
+    model: 'model',
+    prUrl: null,
+    lastActivityAt: 'now',
+    lastActivityAtMs: 1
+  }
+}
+
 describe('DetailDrawer pending interrupts', () => {
   afterEach(() => vi.unstubAllGlobals())
 
@@ -69,23 +89,7 @@ describe('DetailDrawer pending interrupts', () => {
     vi.stubGlobal('window', { innerHeight: 1000 })
     vi.stubGlobal('localStorage', { getItem: () => null })
 
-    const agent: AgentRuntime = {
-      id: 'agent-1',
-      sessionId: 'session-1',
-      name: 'Agent 1',
-      projectId: 'project-1',
-      projectName: 'Project',
-      branchName: 'branch',
-      isWorktree: true,
-      workspaceName: 'workspace',
-      taskSummary: 'Task',
-      status,
-      labelIds: [],
-      model: 'model',
-      prUrl: null,
-      lastActivityAt: 'now',
-      lastActivityAtMs: 1
-    }
+    const agent = createAgent(status)
     const markup = renderToStaticMarkup(createElement(DetailDrawer, {
       agent,
       messages: [{
@@ -110,5 +114,40 @@ describe('DetailDrawer pending interrupts', () => {
     const interrupt = getElementContents(markup, 'data-pending-interrupt')
     expect(transcript).not.toContain(expected)
     expect(interrupt).toContain(expected)
+  })
+
+  it('does not claim a stalled response asked a question', () => {
+    vi.stubGlobal('window', { innerHeight: 1000 })
+    vi.stubGlobal('localStorage', { getItem: () => null })
+
+    const agent: AgentRuntime = {
+      ...createAgent('needs_input'),
+      lastActivityAt: '5m ago',
+      inputReason: 'error',
+      lastError: {
+        name: 'StalledResponse',
+        message: 'No update from provider for 5 minutes.',
+        sessionId: 'session-1',
+        occurredAt: 1
+      }
+    }
+
+    const markup = renderToStaticMarkup(createElement(DetailDrawer, {
+      agent,
+      messages: [],
+      onClose: () => {}
+    }))
+
+    expect(markup).toContain('StalledResponse')
+    expect(markup).not.toContain('Waiting for your response')
+    expect(markup).not.toContain('data-pending-interrupt')
+
+    const dismissedMarkup = renderToStaticMarkup(createElement(DetailDrawer, {
+      agent: { ...agent, lastError: undefined },
+      messages: [],
+      onClose: () => {}
+    }))
+    expect(dismissedMarkup).not.toContain('Waiting for your response')
+    expect(dismissedMarkup).not.toContain('data-pending-interrupt')
   })
 })

--- a/src/__tests__/status-derivation.test.ts
+++ b/src/__tests__/status-derivation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   applyReconciledStatus,
+  getReconnectedInputReason,
   isStalledResponse,
   type LiveMessage
 } from '../renderer/src/hooks/useAgentStore'
@@ -694,15 +695,33 @@ describe('reconcileStatuses: optimistic guard', () => {
   })
 })
 
+describe('agent reconnection', () => {
+  it('preserves error provenance only while needs_input remains preserved', () => {
+    const existing = {
+      status: 'needs_input' as const,
+      inputReason: 'error' as const
+    }
+
+    expect(getReconnectedInputReason(existing, 'needs_input')).toBe('error')
+    expect(getReconnectedInputReason(existing, 'running')).toBeUndefined()
+    expect(getReconnectedInputReason({ ...existing, status: 'running' }, 'needs_input')).toBeUndefined()
+  })
+})
+
 describe('stalled response watchdog', () => {
   const now = 1_000_000
 
-  function toolMessage(toolName: string, toolState: string, id = 'assistant'): LiveMessage {
+  function toolMessage(
+    toolName: string,
+    toolState: string,
+    id = 'assistant',
+    createdAt = now - 8 * 60_000
+  ): LiveMessage {
     return {
       id,
       role: 'assistant',
       sessionId: 'session',
-      createdAt: now - 8 * 60_000,
+      createdAt,
       parts: [{ id: 'tool', type: 'tool', toolName, toolState }]
     }
   }
@@ -721,11 +740,31 @@ describe('stalled response watchdog', () => {
     expect(isStalledResponse(agent, [toolMessage('task', 'running')], now)).toBe(false)
   })
 
+  it('keeps the active Task running when the user queues a follow-up', () => {
+    const agent = { status: 'running' as const, lastActivityAt: now - 7 * 60_000 }
+    const followUp: LiveMessage = {
+      id: 'follow-up',
+      role: 'user',
+      sessionId: 'session',
+      createdAt: now - 6 * 60_000,
+      parts: [{ id: 'text', type: 'text', text: 'Please also check the tests' }]
+    }
+
+    expect(isStalledResponse(agent, [toolMessage('task', 'pending'), followUp], now)).toBe(false)
+  })
+
+  it('flags a stale pending Task on a completed response', () => {
+    const agent = { status: 'running' as const, lastActivityAt: now - 7 * 60_000 }
+    const completedTask = { ...toolMessage('task', 'pending'), completedAt: now - 6 * 60_000 }
+
+    expect(isStalledResponse(agent, [completedTask], now)).toBe(true)
+  })
+
   it('ignores an abandoned Task when a later skill call completed', () => {
     const agent = { status: 'running' as const, lastActivityAt: now - 7 * 60_000 }
     const messages = [
       toolMessage('task', 'pending', 'abandoned-task'),
-      toolMessage('skill', 'completed', 'latest-response')
+      { ...toolMessage('skill', 'completed', 'latest-response', now - 6 * 60_000), completedAt: now - 6 * 60_000 }
     ]
 
     expect(isStalledResponse(agent, messages, now)).toBe(true)

--- a/src/__tests__/subagent-progress.test.ts
+++ b/src/__tests__/subagent-progress.test.ts
@@ -13,6 +13,7 @@ import {
   appendVisibleTextDelta,
   associateChildSessions,
   buildChildTranscript,
+  getActiveAssistantMessage,
   getLatestChildActivityAt,
   getChildSessionId,
   getToolMetadataOutput,
@@ -30,7 +31,7 @@ function assistantMessage(sessionId: string, parts: LiveMessage['parts'], update
     id: `message-${sessionId}`,
     role: 'assistant',
     sessionId,
-    createdAt: 1,
+    createdAt: updatedAt,
     updatedAt,
     parts
   }
@@ -58,7 +59,7 @@ describe('subagent progress', () => {
         }]),
         assistantMessage('child', [{
           id: 'retry', type: 'tool', toolName: 'task', toolState: 'pending', childSessionId: 'retry-child'
-        }])
+        }], 2)
       ]],
       ['abandoned-child', [assistantMessage('abandoned-child', [
         { id: 'old-command', type: 'tool', toolName: 'bash', toolState: 'pending' }
@@ -89,6 +90,64 @@ describe('subagent progress', () => {
     const transcript = buildChildTranscript('child', () => messages)
 
     expect(transcript[0]).toMatchObject({ label: 'bash', toolState: 'running' })
+  })
+
+  it('keeps a Task running when the user queues a follow-up', () => {
+    const task = assistantMessage('child', [{
+      id: 'task', type: 'tool', toolName: 'task', toolState: 'pending', childSessionId: 'task-child'
+    }])
+    const followUp: LiveMessage = {
+      id: 'follow-up',
+      role: 'user',
+      sessionId: 'child',
+      createdAt: 2,
+      parts: [{ id: 'text', type: 'text', text: 'Please also check the tests' }]
+    }
+
+    const transcript = buildChildTranscript('child', () => [task, followUp])
+
+    expect(transcript[0]).toMatchObject({ label: 'task', toolState: 'running' })
+  })
+
+  it('selects the newest unfinished assistant by timestamp', () => {
+    const older = { ...assistantMessage('child', []), id: 'older', createdAt: 10 }
+    const newer = { ...assistantMessage('child', []), id: 'newer', createdAt: 20 }
+    const followUp: LiveMessage = {
+      id: 'follow-up',
+      role: 'user',
+      sessionId: 'child',
+      createdAt: 30,
+      parts: []
+    }
+
+    expect(getActiveAssistantMessage([newer, followUp, older])).toBe(newer)
+  })
+
+  it('does not reactivate a terminal assistant response', () => {
+    const completed = { ...assistantMessage('child', []), completedAt: 2 }
+    const errored = { ...assistantMessage('child', []), errored: true }
+
+    expect(getActiveAssistantMessage([completed])).toBeUndefined()
+    expect(getActiveAssistantMessage([errored])).toBeUndefined()
+    expect(getActiveAssistantMessage([assistantMessage('child', [])], false)).toBeUndefined()
+  })
+
+  it('does not revive a completed Task when a new user message is optimistic', () => {
+    const task = {
+      ...assistantMessage('child', [{ id: 'task', type: 'tool', toolName: 'task', toolState: 'pending' }]),
+      completedAt: 2
+    }
+    const followUp: LiveMessage = {
+      id: 'follow-up',
+      role: 'user',
+      sessionId: 'child',
+      createdAt: 3,
+      parts: [{ id: 'text', type: 'text', text: 'Continue' }]
+    }
+
+    const transcript = buildChildTranscript('child', () => [task, followUp])
+
+    expect(transcript[0]).toMatchObject({ label: 'task', toolState: 'failed' })
   })
 
   it('only infers failure for an inactive Task activity', () => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -22,6 +22,7 @@ import type { EventEntry } from './components/EventLog'
 import { loadSettings, parseSlashCommand, type QuickAction } from './data/settings'
 import {
   buildChildTranscript,
+  getActiveAssistantMessage,
   getLatestChildActivityAt,
   mapToolState,
   orderTranscriptByActivity
@@ -373,6 +374,7 @@ export function App() {
           message: agent.lastError.message,
           occurredAt: agent.lastError.occurredAt
         } : undefined,
+        inputReason: agent.inputReason,
         compacting: agent.compacting,
         contextTokens: agent.contextTokens,
         contextLimit: agent.contextLimit,
@@ -420,7 +422,9 @@ export function App() {
         agentName: agent.name,
         projectName: agent.projectName,
         kind: 'needs_input',
-        reason: 'Agent is waiting for your response',
+        reason: agent.inputReason === 'error'
+          ? agent.lastError?.message ?? 'Agent needs attention'
+          : 'Agent is waiting for your response',
         createdAt: formatTimeAgo(agent.blockedSince ?? agent.lastActivityAt)
       }))
 
@@ -540,31 +544,35 @@ export function App() {
     if (!liveAgent) return []
 
     const liveMessages = getMessagesForSession(liveAgent.sessionId)
-    const latestLiveMessage = liveMessages[liveMessages.length - 1]
     const sessionActive = liveAgent.status !== 'idle'
       && liveAgent.status !== 'completed'
       && liveAgent.status !== 'errored'
       && liveAgent.status !== 'disconnected'
+    const activeAssistantMessage = getActiveAssistantMessage(liveMessages, sessionActive)
     const transcriptItems: Message[] = []
     let pendingToolCalls: ToolCall[] = []
+    let pendingToolAnchorId = ''
+    let pendingToolTimestamp = 0
 
-    const flushPendingToolCalls = (anchorId: string, timestamp: number) => {
+    const flushPendingToolCalls = () => {
       if (pendingToolCalls.length === 0) return
 
       transcriptItems.push({
-        id: `${anchorId}-tools`,
+        id: `${pendingToolAnchorId}-tools`,
         role: 'tool-group',
         content: `${pendingToolCalls.length} tool call${pendingToolCalls.length === 1 ? '' : 's'}`,
-        timestamp: formatTimeAgo(timestamp),
-        activityAt: timestamp,
+        timestamp: formatTimeAgo(pendingToolTimestamp),
+        activityAt: pendingToolTimestamp,
         toolCalls: pendingToolCalls
       })
 
       pendingToolCalls = []
+      pendingToolAnchorId = ''
+      pendingToolTimestamp = 0
     }
 
     for (const msg of liveMessages) {
-      const messageActive = sessionActive && msg === latestLiveMessage
+      const messageActive = msg === activeAssistantMessage
       const textParts: string[] = []
       const toolCalls: ToolCall[] = []
       const images: Array<{ mime: string; url: string; filename?: string }> = []
@@ -624,7 +632,7 @@ export function App() {
       }
 
       if (compactionPart) {
-        flushPendingToolCalls(msg.id, msg.createdAt)
+        flushPendingToolCalls()
         // A compaction part is still "active" while the session flag is set.
         const liveAgentForCompaction = store.agents.find((a) => a.sessionId === msg.sessionId)
         transcriptItems.push({
@@ -643,7 +651,7 @@ export function App() {
       const textContent = textParts.join('\n')
 
       if (textContent.trim() || images.length > 0) {
-        flushPendingToolCalls(msg.id, msg.createdAt)
+        flushPendingToolCalls()
 
         transcriptItems.push({
           id: msg.id,
@@ -657,16 +665,17 @@ export function App() {
 
       if (toolCalls.length > 0) {
         pendingToolCalls.push(...toolCalls)
+        pendingToolAnchorId = msg.id
+        pendingToolTimestamp = msg.createdAt
       }
 
       if (!textContent.trim() && pendingToolCalls.length > 0 && msg === liveMessages[liveMessages.length - 1]) {
-        flushPendingToolCalls(msg.id, msg.createdAt)
+        flushPendingToolCalls()
       }
     }
 
     if (liveMessages.length > 0) {
-      const lastMessage = liveMessages[liveMessages.length - 1]
-      flushPendingToolCalls(lastMessage.id, lastMessage.createdAt)
+      flushPendingToolCalls()
     }
 
     return orderTranscriptByActivity(transcriptItems)

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -295,6 +295,10 @@ export const DetailDrawer = memo(function DetailDrawer({
   const [cursorPos, setCursorPos] = useState(0)
   const [visibleMessageCount, setVisibleMessageCount] = useState(VISIBLE_MESSAGE_WINDOW)
   const [showPrLinkModal, setShowPrLinkModal] = useState(false)
+  const showQuestionFallback = !permission
+    && (!question || question.questions.length === 0)
+    && agent.status === 'needs_input'
+    && agent.inputReason !== 'error'
 
   // Input history cycling: -1 = not browsing, 0+ = offset from most recent
   const historyIndexRef = useRef(-1)
@@ -1010,7 +1014,7 @@ export const DetailDrawer = memo(function DetailDrawer({
           )}
         </div>
 
-        {activeTab === 'transcript' && (permission || question || agent.status === 'needs_input') && (
+        {activeTab === 'transcript' && (permission || question || showQuestionFallback) && (
           <div
             data-pending-interrupt
             className="min-h-0 shrink max-h-[45%] overflow-y-auto border-t border-kumo-line px-4 py-3"
@@ -1063,9 +1067,7 @@ export const DetailDrawer = memo(function DetailDrawer({
               />
             )}
 
-            {!permission
-              && (!question || question.questions.length === 0)
-              && agent.status === 'needs_input' && (
+            {showQuestionFallback && (
               <div className="bg-status-input-bg/30 border border-status-input/20 rounded-lg p-3 flex flex-col gap-2">
                 <div className="text-xs font-semibold text-status-input flex items-center gap-1.5">
                   <ChatCircleDots size={14} weight="fill" /> Waiting for your response

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -26,6 +26,7 @@ import {
   associateChildSessions,
   collectSessionSubtreeIds,
   getChildSessionId,
+  getActiveAssistantMessage,
   getToolMetadataOutput,
   mergeLiveMessagePart,
   type ChildSessionDescriptor
@@ -166,6 +167,7 @@ export interface LiveAgent {
    *  Presence drives an error banner in the detail drawer; cleared by user dismiss
    *  or by a new successful assistant turn. */
   lastError?: LiveAgentError
+  inputReason?: 'question' | 'error'
   /** True while a compactSession RPC is in flight or the server has acknowledged
    *  compaction but session.compacted hasn't arrived yet. Drives the spinner and
    *  disabled states on the Compact buttons so the user can see progress. */
@@ -228,6 +230,8 @@ export interface LiveMessage {
   sessionId: string
   createdAt: number
   updatedAt?: number
+  completedAt?: number
+  errored?: boolean
   parts: LiveMessagePart[]
 }
 
@@ -837,6 +841,7 @@ function adoptOptimisticUserMessage(sessionId: string, serverMessageId: string, 
   target.id = serverMessageId
   target.createdAt = createdAt
   target.updatedAt = Date.now()
+  messages.sort((left, right) => left.createdAt - right.createdAt)
   return true
 }
 
@@ -851,6 +856,11 @@ function upsertMessage(message: LiveMessage): LiveMessage {
       existingMessage.updatedAt ?? existingMessage.createdAt,
       message.updatedAt ?? message.createdAt
     )
+    if (message.completedAt !== undefined) {
+      existingMessage.completedAt = Math.max(existingMessage.completedAt ?? 0, message.completedAt)
+    }
+    existingMessage.errored = existingMessage.errored || message.errored || undefined
+    messages.sort((left, right) => left.createdAt - right.createdAt)
     return existingMessage
   }
 
@@ -989,6 +999,8 @@ function hydrateHistoricalMessages(entries: unknown): void {
       sessionId: entry.info.sessionID,
       createdAt,
       updatedAt: entry.info.time?.completed ?? createdAt,
+      completedAt: entry.info.time?.completed,
+      errored: !!entry.info.error?.name,
       parts: []
     })
 
@@ -1254,9 +1266,11 @@ function processEvent(payload: OpenCodeEventPayload): void {
           agent.lastActivityAt = Date.now()
           if (newStatus === 'needs_input' || newStatus === 'needs_approval') {
             agent.blockedSince = agent.blockedSince ?? Date.now()
+            agent.inputReason = newStatus === 'needs_input' ? 'question' : undefined
           } else {
             agent.blockedSince = undefined
             agent.respondedAt = undefined
+            agent.inputReason = undefined
           }
           if (newStatus === 'completed') {
             persistAgentMeta(agent.id, { persistedStatus: 'completed' })
@@ -1400,6 +1414,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
           target.status = 'needs_input'
           target.blockedSince = target.blockedSince ?? Date.now()
         }
+        target.inputReason = 'error'
         target.lastActivityAt = Date.now()
         // Compactor errors (e.g. "prompt is too long") arrive here. Stop the
         // spinner so the banner flips from "Compacting…" to the error state.
@@ -1477,6 +1492,9 @@ function processEvent(payload: OpenCodeEventPayload): void {
       const messageId = info.id as string
       const role = info.role as 'user' | 'assistant'
       const createdAt = getMessageCreatedAt(info)
+      const time = info.time as { completed?: number } | undefined
+      const completedAt = typeof time?.completed === 'number' ? time.completed : undefined
+      const msgError = info.error as { name?: string; message?: string; data?: unknown } | undefined
 
       let agentChanged = false
       const agent = findAgentBySession(sessionId)
@@ -1522,7 +1540,6 @@ function processEvent(payload: OpenCodeEventPayload): void {
           // the `error` field. Capture that here — it's the canonical place for
           // ContextOverflowError and similar — since the separate session.error
           // event doesn't always fire reliably.
-          const msgError = info.error as { name?: string; message?: string; data?: unknown } | undefined
           if (msgError?.name) {
             console.error('[message.updated] assistant message carries error', {
               agentId: agent.id,
@@ -1547,8 +1564,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
           // placeholder shell before the provider responds, which is when the
           // overflow error lands — clearing on every update would erase the
           // banner before the user sees it.
-          const time = info.time as { completed?: number } | undefined
-          const messageComplete = typeof time?.completed === 'number' && !msgError
+          const messageComplete = completedAt !== undefined && !msgError
           if (messageComplete && agent.lastError) {
             agent.lastError = undefined
             agentChanged = true
@@ -1570,24 +1586,17 @@ function processEvent(payload: OpenCodeEventPayload): void {
         adopted = adoptOptimisticUserMessage(sessionId, messageId, createdAt)
       }
 
-      // Store message
-      const messages = state.messages.get(sessionId) ?? []
-      const existing = messages.find((msg) => msg.id === messageId)
-      if (!existing && !adopted) {
-        const now = Date.now()
-        messages.push({
+      if (!adopted) {
+        upsertMessage({
           id: messageId,
           role,
           sessionId,
           createdAt,
-          updatedAt: now,
+          updatedAt: Date.now(),
+          completedAt,
+          errored: !!msgError?.name,
           parts: []
         })
-        state.messages.set(sessionId, messages)
-      } else if (existing) {
-        existing.createdAt = createdAt
-        existing.updatedAt = Date.now()
-        existing.role = role
       }
 
       emit({ messages: true, agents: agentChanged })
@@ -1892,6 +1901,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
         agent.status = 'needs_input'
         agent.blockedSince = agent.blockedSince ?? Date.now()
         agent.respondedAt = undefined
+        agent.inputReason = 'question'
         // Malformed payload: agent went into needs_input but we don't have the
         // structured question content. Schedule a fast reconciliation so the
         // user isn't stuck looking at a bare placeholder. The next periodic
@@ -2468,6 +2478,15 @@ function removeAgentState(agentId: string): void {
   }
 }
 
+export function getReconnectedInputReason(
+  existingAgent: Pick<LiveAgent, 'status' | 'inputReason'> | undefined,
+  nextStatus: AgentStatus
+): LiveAgent['inputReason'] {
+  return nextStatus === 'needs_input' && existingAgent?.status === 'needs_input'
+    ? existingAgent.inputReason
+    : undefined
+}
+
 function upsertAgent(payload: AgentLaunchedPayload, initialStatus?: AgentStatus): void {
   const hasPrompt = payload.prompt && payload.prompt.trim().length > 0
   const existingAgent = state.agents.get(payload.id)
@@ -2494,6 +2513,7 @@ function upsertAgent(payload: AgentLaunchedPayload, initialStatus?: AgentStatus)
   const configuredModel = configuredModelPath
     ? formatModelName(configuredModelPath)
     : existingAgent?.configuredModel
+  const status = initialStatus ?? existingAgent?.status ?? (hasPrompt ? 'running' : 'idle')
 
   const agent: LiveAgent = {
     id: payload.id,
@@ -2506,7 +2526,8 @@ function upsertAgent(payload: AgentLaunchedPayload, initialStatus?: AgentStatus)
     isWorktree: payload.isWorktree ?? existingAgent?.isWorktree ?? false,
     workspaceName: payload.workspaceName ?? existingAgent?.workspaceName ?? payload.directory.split('/').pop() ?? payload.directory,
     taskSummary: payload.taskSummary || existingAgent?.taskSummary || (hasPrompt ? payload.prompt.slice(0, 120) : 'Waiting for prompt...'),
-    status: initialStatus ?? existingAgent?.status ?? (hasPrompt ? 'running' : 'idle'),
+    status,
+    inputReason: getReconnectedInputReason(existingAgent, status),
     labelIds: existingAgent?.labelIds ?? [],
     model: existingAgent?.model ?? configuredModel ?? UNRESOLVED_MODEL_LABEL,
     configuredModel,
@@ -2544,23 +2565,27 @@ function applyStatuses(statuses: AgentStatusesPayload): void {
     if (nextStatus === 'needs_input' || nextStatus === 'needs_approval') {
 
       agent.blockedSince = agent.blockedSince ?? Date.now()
+      agent.inputReason = nextStatus === 'needs_input' ? 'question' : undefined
     } else {
       agent.blockedSince = undefined
+      agent.inputReason = undefined
 
     }
   }
 }
 
 export function applyReconciledStatus(
-  agent: Pick<LiveAgent, 'status' | 'blockedSince' | 'respondedAt'>,
+  agent: Pick<LiveAgent, 'status' | 'blockedSince' | 'respondedAt' | 'inputReason'>,
   serverStatus: AgentStatus
 ): void {
   agent.status = serverStatus
   if (serverStatus === 'needs_input' || serverStatus === 'needs_approval') {
     agent.blockedSince = agent.blockedSince ?? Date.now()
+    agent.inputReason = serverStatus === 'needs_input' ? 'question' : undefined
   } else {
     agent.blockedSince = undefined
     agent.respondedAt = undefined
+    agent.inputReason = undefined
   }
 }
 
@@ -2870,7 +2895,7 @@ function setChildSessionActivity(sessionId: string, updatedAt: number): void {
  *  When a tool is in flight the model isn't hanging — it's blocked on the tool —
  *  so the "provider overloaded" watchdog does not apply. */
 function hasInFlightToolCall(messages: readonly LiveMessage[] | undefined): boolean {
-  const latestMessage = messages?.[messages.length - 1]
+  const latestMessage = getActiveAssistantMessage(messages)
   if (!messages || !latestMessage) return false
   for (const message of messages) {
     for (const part of message.parts) {
@@ -2958,12 +2983,14 @@ function updateAgentAfterInterruptChange(
     agent.status = pendingStatus
     agent.blockedSince = agent.blockedSince ?? Date.now()
     agent.respondedAt = undefined
+    agent.inputReason = pendingStatus === 'needs_input' ? 'question' : undefined
     return
   }
   if (!markResponded && agent.status !== 'needs_input' && agent.status !== 'needs_approval') return
   agent.status = 'running'
   agent.blockedSince = undefined
   agent.respondedAt = markResponded ? Date.now() : undefined
+  agent.inputReason = undefined
 }
 
 function removeChildSessionTree(sessionId: string): void {
@@ -3021,6 +3048,7 @@ function applyOptimisticSendState(agentId: string, agent: LiveAgent, text: strin
   agent.lastActivityAt = Date.now()
   agent.blockedSince = undefined
   agent.respondedAt = Date.now()
+  agent.inputReason = undefined
 
   injectOptimisticUserMessage(agent.sessionId, text)
   persistAgentMeta(agentId, { taskSummary: agent.taskSummary, persistedStatus: 'running' })
@@ -3448,6 +3476,7 @@ export function useAgentStore() {
           notifyIfNeeded(agent, 'needs_input')
           agent.status = 'needs_input'
           agent.blockedSince = agent.blockedSince ?? now
+          agent.inputReason = 'error'
           changed = true
           console.warn('[watchdog] stalled agent marked needs_input', { agentId: agent.id })
         }

--- a/src/renderer/src/lib/subagent-progress.ts
+++ b/src/renderer/src/lib/subagent-progress.ts
@@ -36,6 +36,19 @@ export function mapToolState(
   return toolName === 'task' && !active ? 'failed' : 'running'
 }
 
+export function getActiveAssistantMessage(
+  messages: readonly LiveMessage[] | undefined,
+  sessionActive = true
+): LiveMessage | undefined {
+  if (!messages || !sessionActive) return undefined
+  let latest: LiveMessage | undefined
+  for (const message of messages) {
+    if (message.role !== 'assistant') continue
+    if (!latest || message.createdAt > latest.createdAt) latest = message
+  }
+  return latest?.completedAt === undefined && !latest?.errored ? latest : undefined
+}
+
 export function getChildSessionId(partState: Record<string, unknown> | undefined): string | undefined {
   const metadata = partState?.metadata as Record<string, unknown> | undefined
   const sessionId = metadata?.sessionId
@@ -151,11 +164,11 @@ export function buildChildTranscript(
   nextAncestors.add(sessionId)
   const entries: ChildTranscriptEntry[] = []
   const messages = getMessagesForSession(sessionId)
-  const latestMessage = messages[messages.length - 1]
+  const latestMessage = getActiveAssistantMessage(messages, active)
 
   for (const message of messages) {
     if (message.role !== 'assistant') continue
-    const messageActive = active && message === latestMessage
+    const messageActive = message === latestMessage
 
     for (const part of message.parts) {
       if (part.type === 'text' && part.text) {

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -90,6 +90,8 @@ export interface AgentRuntime {
   lastMessage?: string
   /** Most recent session-level error from the server (e.g. ContextOverflowError). */
   lastError?: AgentRuntimeError
+  /** Why a needs_input agent needs attention when no structured question exists. */
+  inputReason?: 'question' | 'error'
   /** True while a compaction RPC is running (shows spinner, disables compact buttons). */
   compacting?: boolean
   /** Approximate tokens currently sitting in the model's context window. */


### PR DESCRIPTION
Queued user messages could make OCO treat the running assistant response as abandoned. Active Task progress disappeared even though child events kept the activity timestamp fresh.

OCO now tracks assistant completion and error state before deciding which response is active. Error sourced `needs_input` states also keep their reason, so the UI no longer claims a stalled response asked a question.

Verified with `npm test`, `npm run typecheck`, `npm run lint`, and `npm run build`.