### PR TITLE
NO-JIRA Recover stalled agent responses

### DIFF
--- a/src/__tests__/agent-controller-commands.test.ts
+++ b/src/__tests__/agent-controller-commands.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   sessionCreate: vi.fn(),
@@ -6,9 +6,11 @@ const mocks = vi.hoisted(() => ({
   sessionPromptAsync: vi.fn(),
   sessionStatus: vi.fn(),
   sessionTodo: vi.fn(),
+  sessionAbort: vi.fn(),
   configUpdate: vi.fn(),
   touchRuntimeActivity: vi.fn(),
   sendToRenderer: vi.fn(),
+  bridgeEvent: undefined as ((event: { type: string; properties: unknown }) => void) | undefined,
 }))
 
 const persistedAgents = [
@@ -48,6 +50,7 @@ const runtime = {
       promptAsync: mocks.sessionPromptAsync,
       status: mocks.sessionStatus,
       todo: mocks.sessionTodo,
+      abort: mocks.sessionAbort,
     },
     config: {
       update: mocks.configUpdate,
@@ -74,6 +77,14 @@ vi.mock('../main/services/runtime-manager', () => ({
 
 vi.mock('../main/services/event-bridge', () => ({
   EventBridge: class {
+    constructor(
+      _runtimeId: string,
+      _directory: string,
+      _client: unknown,
+      onEvent?: (event: { type: string; properties: unknown }) => void
+    ) {
+      mocks.bridgeEvent = onEvent
+    }
     async start(): Promise<void> {}
     async ensureStreaming(): Promise<void> {}
   },
@@ -123,9 +134,15 @@ describe('AgentController.executeCommand', () => {
     mocks.sessionStatus.mockResolvedValue({ data: {} })
     mocks.sessionTodo.mockReset()
     mocks.sessionTodo.mockResolvedValue({ data: [] })
+    mocks.sessionAbort.mockReset()
+    mocks.sessionAbort.mockResolvedValue({ data: undefined })
     mocks.configUpdate.mockReset()
     mocks.configUpdate.mockResolvedValue({ data: undefined })
     mocks.sendToRenderer.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('uses the selected model for an existing session with an unavailable previous model', async () => {
@@ -246,5 +263,161 @@ describe('AgentController.executeCommand', () => {
       sessionID: 'existing-session',
       directory: '/tmp/project',
     })
+  })
+
+  it('aborts a running stalled request before sending the recovery prompt', async () => {
+    mocks.sessionStatus
+      .mockResolvedValueOnce({ data: { 'existing-session': { type: 'busy' } } })
+      .mockResolvedValueOnce({ data: {} })
+
+    const result = await agentController.recoverStalledAgent(
+      'agent-1',
+      'Continue from the stalled request.',
+      Date.now()
+    )
+
+    expect(result).toBe('recovered')
+    expect(mocks.sessionAbort).toHaveBeenCalledWith({
+      sessionID: 'existing-session',
+      directory: '/tmp/project',
+    })
+    expect(mocks.sessionPromptAsync).toHaveBeenCalledWith(expect.objectContaining({
+      sessionID: 'existing-session',
+      parts: [{ type: 'text', text: 'Continue from the stalled request.' }],
+    }))
+    expect(mocks.sessionAbort.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.sessionPromptAsync.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('lets a real prompt supersede recovery without aborting that prompt', async () => {
+    let releaseAbort: (() => void) | undefined
+    mocks.sessionAbort.mockImplementationOnce(() => new Promise<void>((resolve) => {
+      releaseAbort = resolve
+    }))
+
+    mocks.sessionStatus.mockResolvedValueOnce({
+      data: { 'existing-session': { type: 'busy' } }
+    })
+    const recovery = agentController.recoverStalledAgent(
+      'agent-1',
+      'Synthetic recovery prompt',
+      Date.now()
+    )
+    await vi.waitFor(() => expect(mocks.sessionAbort).toHaveBeenCalledOnce())
+
+    const realPrompt = agentController.sendMessage('agent-1', 'Real user prompt')
+    expect(mocks.sessionPromptAsync).not.toHaveBeenCalled()
+    releaseAbort?.()
+
+    await expect(recovery).resolves.toBe('superseded')
+    await realPrompt
+    expect(mocks.sessionPromptAsync).toHaveBeenCalledOnce()
+    expect(mocks.sessionPromptAsync).toHaveBeenCalledWith(expect.objectContaining({
+      parts: [{ type: 'text', text: 'Real user prompt' }],
+    }))
+  })
+
+  it('cancels recovery while checking session status', async () => {
+    let releaseStatus: (() => void) | undefined
+    mocks.sessionStatus.mockImplementationOnce(() => new Promise((resolve) => {
+      releaseStatus = () => resolve({ data: { 'existing-session': { type: 'busy' } } })
+    }))
+
+    const recovery = agentController.recoverStalledAgent('agent-1', 'Synthetic recovery prompt', Date.now())
+    await vi.waitFor(() => expect(mocks.sessionStatus).toHaveBeenCalledOnce())
+
+    const realPrompt = agentController.sendMessage('agent-1', 'Real user prompt')
+    expect(mocks.sessionPromptAsync).not.toHaveBeenCalled()
+    releaseStatus?.()
+
+    await expect(recovery).resolves.toBe('superseded')
+    await realPrompt
+    expect(mocks.sessionAbort).not.toHaveBeenCalled()
+    expect(mocks.sessionPromptAsync).toHaveBeenCalledOnce()
+  })
+
+  it('does not abort when provider activity arrives during the recovery check', async () => {
+    let releaseStatus: (() => void) | undefined
+    mocks.sessionStatus.mockImplementationOnce(() => new Promise((resolve) => {
+      releaseStatus = () => resolve({ data: { 'existing-session': { type: 'busy' } } })
+    }))
+
+    const recovery = agentController.recoverStalledAgent('agent-1', 'Synthetic recovery prompt', Date.now())
+    await vi.waitFor(() => expect(mocks.sessionStatus).toHaveBeenCalledOnce())
+    mocks.bridgeEvent?.({
+      type: 'message.part.delta',
+      properties: { part: { sessionID: 'existing-session' } }
+    })
+    releaseStatus?.()
+
+    await expect(recovery).resolves.toBe('superseded')
+    expect(mocks.sessionAbort).not.toHaveBeenCalled()
+    expect(mocks.sessionPromptAsync).not.toHaveBeenCalled()
+  })
+
+  it('does not abort when a Task child resumes during the recovery check', async () => {
+    mocks.bridgeEvent?.({
+      type: 'session.created',
+      properties: { info: { id: 'child-session', parentID: 'existing-session' } }
+    })
+    let releaseStatus: (() => void) | undefined
+    mocks.sessionStatus.mockImplementationOnce(() => new Promise((resolve) => {
+      releaseStatus = () => resolve({ data: { 'existing-session': { type: 'busy' } } })
+    }))
+
+    const recovery = agentController.recoverStalledAgent('agent-1', 'Synthetic recovery prompt', Date.now())
+    await vi.waitFor(() => expect(mocks.sessionStatus).toHaveBeenCalledOnce())
+    mocks.bridgeEvent?.({
+      type: 'message.part.delta',
+      properties: { part: { sessionID: 'child-session' } }
+    })
+    releaseStatus?.()
+
+    await expect(recovery).resolves.toBe('superseded')
+    expect(mocks.sessionAbort).not.toHaveBeenCalled()
+  })
+
+  it('bounds recovery when the abort request never resolves', async () => {
+    vi.useFakeTimers()
+    mocks.sessionStatus.mockResolvedValueOnce({ data: {
+      'existing-session': { type: 'busy' }
+    } })
+    let releaseAbort: (() => void) | undefined
+    mocks.sessionAbort.mockReturnValueOnce(new Promise<void>((resolve) => {
+      releaseAbort = resolve
+    }))
+
+    const recovery = agentController.recoverStalledAgent('agent-1', 'Synthetic recovery prompt', Date.now())
+    await vi.advanceTimersByTimeAsync(12_001)
+
+    await expect(recovery).resolves.toBe('timeout')
+    await expect(agentController.sendMessage('agent-1', 'Real user prompt')).rejects.toThrow(
+      'Stall recovery is still stopping the previous request'
+    )
+    expect(mocks.sessionPromptAsync).not.toHaveBeenCalled()
+
+    releaseAbort?.()
+    await vi.advanceTimersByTimeAsync(0)
+    await agentController.sendMessage('agent-1', 'Real user prompt')
+    expect(mocks.sessionPromptAsync).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    ['waiting', 'blocked'],
+    ['completed', 'completed']
+  ])('does not abort or resume a %s session', async (sessionStatus, expectedResult) => {
+    mocks.sessionStatus.mockResolvedValueOnce({ data: {
+      'existing-session': { type: sessionStatus }
+    } })
+    const result = await agentController.recoverStalledAgent(
+      'agent-1',
+      'Do not send this',
+      Date.now() + 60_000
+    )
+
+    expect(result).toBe(expectedResult)
+    expect(mocks.sessionAbort).not.toHaveBeenCalled()
+    expect(mocks.sessionPromptAsync).not.toHaveBeenCalled()
   })
 })

--- a/src/__tests__/stalled-recovery-settings.test.ts
+++ b/src/__tests__/stalled-recovery-settings.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  DEFAULT_SETTINGS,
+  SETTINGS_STORAGE_KEY,
+  loadSettings
+} from '../renderer/src/data/settings'
+import {
+  AGENT_SETTINGS_STORAGE_KEY,
+  deleteAgentSettings,
+  loadAgentAutoRecoverSetting,
+  resolveAutoRecoverStalledResponses,
+  saveAgentAutoRecoverSetting
+} from '../renderer/src/data/agentSettings'
+
+class MemoryStorage {
+  private values = new Map<string, string>()
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value)
+  }
+}
+
+describe('stalled response recovery settings', () => {
+  let storage: MemoryStorage
+
+  beforeEach(() => {
+    storage = new MemoryStorage()
+    vi.stubGlobal('localStorage', storage)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('defaults automatic recovery to off for new and existing settings', () => {
+    expect(loadSettings().autoRecoverStalledResponses).toBe(false)
+
+    storage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify({ model: 'openai/gpt-5' }))
+    expect(loadSettings().autoRecoverStalledResponses).toBe(DEFAULT_SETTINGS.autoRecoverStalledResponses)
+  })
+
+  it('ignores malformed persisted recovery settings', () => {
+    storage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify({ autoRecoverStalledResponses: 'yes' }))
+    storage.setItem(AGENT_SETTINGS_STORAGE_KEY, JSON.stringify({
+      malformed: { autoRecoverStalledResponses: 'yes' },
+      primitive: true
+    }))
+
+    expect(loadSettings().autoRecoverStalledResponses).toBe(false)
+    expect(loadAgentAutoRecoverSetting('malformed')).toBe('inherit')
+    expect(loadAgentAutoRecoverSetting('primitive')).toBe('inherit')
+  })
+
+  it('persists independent per-agent overrides', () => {
+    saveAgentAutoRecoverSetting('agent-one', 'on')
+    saveAgentAutoRecoverSetting('agent-two', 'off')
+
+    expect(loadAgentAutoRecoverSetting('agent-one')).toBe('on')
+    expect(loadAgentAutoRecoverSetting('agent-two')).toBe('off')
+    expect(loadAgentAutoRecoverSetting('existing-agent')).toBe('inherit')
+    expect(storage.getItem(AGENT_SETTINGS_STORAGE_KEY)).toContain('agent-one')
+  })
+
+  it('removes an inherited override without deleting other agent settings', () => {
+    storage.setItem(AGENT_SETTINGS_STORAGE_KEY, JSON.stringify({
+      agent: { outputVerbosity: 'some', autoRecoverStalledResponses: true }
+    }))
+
+    saveAgentAutoRecoverSetting('agent', 'inherit')
+
+    expect(loadAgentAutoRecoverSetting('agent')).toBe('inherit')
+    expect(storage.getItem(AGENT_SETTINGS_STORAGE_KEY)).toContain('outputVerbosity')
+  })
+
+  it('uses the per-agent setting before the global default', () => {
+    expect(resolveAutoRecoverStalledResponses(false, 'inherit')).toBe(false)
+    expect(resolveAutoRecoverStalledResponses(true, 'inherit')).toBe(true)
+    expect(resolveAutoRecoverStalledResponses(false, 'on')).toBe(true)
+    expect(resolveAutoRecoverStalledResponses(true, 'off')).toBe(false)
+  })
+
+  it('removes settings with a deleted agent', () => {
+    saveAgentAutoRecoverSetting('deleted-agent', 'on')
+
+    deleteAgentSettings('deleted-agent')
+
+    expect(loadAgentAutoRecoverSetting('deleted-agent')).toBe('inherit')
+    expect(storage.getItem(AGENT_SETTINGS_STORAGE_KEY)).not.toContain('deleted-agent')
+  })
+})

--- a/src/__tests__/status-derivation.test.ts
+++ b/src/__tests__/status-derivation.test.ts
@@ -3,6 +3,8 @@ import {
   applyReconciledStatus,
   getReconnectedInputReason,
   isStalledResponse,
+  shouldAutoRecoverStalledResponse,
+  wasStallRecoveryLastPrompt,
   type LiveMessage
 } from '../renderer/src/hooks/useAgentStore'
 
@@ -763,10 +765,62 @@ describe('stalled response watchdog', () => {
   it('ignores an abandoned Task when a later skill call completed', () => {
     const agent = { status: 'running' as const, lastActivityAt: now - 7 * 60_000 }
     const messages = [
-      toolMessage('task', 'pending', 'abandoned-task'),
+      {
+        ...toolMessage('task', 'pending', 'abandoned-task'),
+        parts: [{ id: 'tool', type: 'tool', toolName: 'task', toolState: 'pending', childSessionId: 'child' }]
+      },
       { ...toolMessage('skill', 'completed', 'latest-response', now - 6 * 60_000), completedAt: now - 6 * 60_000 }
     ]
 
     expect(isStalledResponse(agent, messages, now)).toBe(true)
+  })
+
+  it('flags a Task whose child session also stopped producing updates', () => {
+    const agent = { status: 'running' as const, lastActivityAt: now - 7 * 60_000 }
+    const task = toolMessage('task', 'running')
+    task.parts[0].childSessionId = 'child'
+
+    expect(isStalledResponse(agent, [task], now, () => now - 7 * 60_000)).toBe(true)
+    expect(isStalledResponse(agent, [task], now, () => now - 1_000)).toBe(false)
+  })
+
+  it('flags an apply_patch call after one minute without updates', () => {
+    const messages = [toolMessage('apply_patch', 'running')]
+
+    expect(isStalledResponse({ status: 'running', lastActivityAt: now - 60_000 + 1 }, messages, now)).toBe(false)
+    expect(isStalledResponse({ status: 'running', lastActivityAt: now - 60_000 }, messages, now)).toBe(true)
+  })
+
+  it('ignores an abandoned Bash call on an older response', () => {
+    const agent = { status: 'running' as const, lastActivityAt: now - 7 * 60_000 }
+    const messages = [
+      toolMessage('bash', 'pending', 'abandoned-bash'),
+      { ...toolMessage('skill', 'completed', 'latest-response', now - 6 * 60_000) }
+    ]
+
+    expect(isStalledResponse(agent, messages, now)).toBe(true)
+  })
+
+  it('recovers only when enabled and not already attempted', () => {
+    expect(shouldAutoRecoverStalledResponse(true, false)).toBe(true)
+    expect(shouldAutoRecoverStalledResponse(false, false)).toBe(false)
+    expect(shouldAutoRecoverStalledResponse(true, true)).toBe(false)
+    expect(shouldAutoRecoverStalledResponse(true, false, true)).toBe(false)
+  })
+
+  it('recognizes a recovery prompt after renderer state is restored', () => {
+    const messages: LiveMessage[] = [{
+      id: 'recovery',
+      role: 'user',
+      sessionId: 'session',
+      createdAt: now,
+      parts: [{
+        id: 'text',
+        type: 'text',
+        text: 'Your previous response stalled without producing output. Continue from the exact point where you stopped, preserving the existing work and context.'
+      }]
+    }]
+
+    expect(wasStallRecoveryLastPrompt(messages)).toBe(true)
   })
 })

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -178,6 +178,21 @@ export function registerIpcHandlers(): void {
     }
   })
 
+  ipcMain.handle('agent:recover-stall', async (
+    _event,
+    agentId: string,
+    resumePrompt: string,
+    observedLastActivityAt: number
+  ) => {
+    try {
+      const result = await agentController.recoverStalledAgent(agentId, resumePrompt, observedLastActivityAt)
+      return { ok: true, data: result }
+    } catch (error) {
+      logIpcError('agent:recover-stall', error)
+      return { ok: false, error: String(error) }
+    }
+  })
+
   ipcMain.handle('agent:remove', async (_event, agentId: string) => {
     try {
       await agentController.removeAgent(agentId)

--- a/src/main/services/agent-controller.ts
+++ b/src/main/services/agent-controller.ts
@@ -248,6 +248,20 @@ interface PersistedAgentHandle {
 const ACTIVE_AGENTS_PREFERENCE_KEY = 'active_agents'
 const IDLE_RUNTIME_CHECK_INTERVAL_MS = 60_000
 const DEFAULT_RUNTIME_IDLE_TIMEOUT_MS = 15 * 60_000
+const STALL_RECOVERY_TIMEOUT_MS = 10_000
+const STALL_RECOVERY_TOTAL_TIMEOUT_MS = 12_000
+const USER_ACTION_CLOCK_SKEW_MS = 1_000
+
+export type StallRecoveryResult = 'recovered' | 'superseded' | 'blocked' | 'idle' | 'completed' | 'errored' | 'timeout'
+type SettledSessionStatus = 'idle' | 'blocked' | 'completed' | 'errored' | 'timeout'
+type RecoverySessionStatus = SettledSessionStatus | 'running'
+
+interface StallRecovery {
+  cancelled: boolean
+  settled: boolean
+  operation: Promise<StallRecoveryResult>
+  promise: Promise<StallRecoveryResult>
+}
 
 /**
  * High-level controller for managing individual agent instances.
@@ -257,6 +271,10 @@ class AgentController {
   private agents = new Map<string, AgentHandle>()
   private bridges = new Map<string, EventBridge>()
   private pendingBridge = new Map<string, Promise<RuntimeInfo>>()
+  private stallRecoveries = new Map<string, StallRecovery>()
+  private lastUserActionAt = new Map<string, number>()
+  private sessionActivity = new Map<string, { version: number; at: number }>()
+  private sessionParents = new Map<string, string>()
   private nextId = 1
   private idleRuntimeTimer: ReturnType<typeof setInterval> | null = null
   private stoppingIdleRuntimes = false
@@ -424,6 +442,7 @@ class AgentController {
   async resetSession(agentId: string, prompt?: string): Promise<AgentHandle> {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
+    await this.beginUserAction(agentId)
 
     const runtime = await this.ensureRuntimeForAgent(handle)
     runtimeManager.touchRuntimeActivity(runtime.id)
@@ -514,6 +533,7 @@ class AgentController {
   async sendMessage(agentId: string, text: string, agent?: string, attachments?: Attachment[]): Promise<void> {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
+    await this.beginUserAction(agentId)
 
     const runtime = await this.ensureRuntimeForAgent(handle)
     runtimeManager.touchRuntimeActivity(runtime.id)
@@ -535,6 +555,7 @@ class AgentController {
   async respondToPermission(agentId: string, permissionId: string, response: 'once' | 'always' | 'reject'): Promise<void> {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
+    await this.beginUserAction(agentId)
 
     const runtime = await this.ensureRuntimeForAgent(handle)
     runtimeManager.touchRuntimeActivity(runtime.id)
@@ -552,6 +573,7 @@ class AgentController {
   async replyToQuestion(agentId: string, requestId: string, answers: string[][]): Promise<void> {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
+    await this.beginUserAction(agentId)
 
     const runtime = await this.ensureRuntimeForAgent(handle)
     runtimeManager.touchRuntimeActivity(runtime.id)
@@ -569,6 +591,7 @@ class AgentController {
   async rejectQuestion(agentId: string, requestId: string): Promise<void> {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
+    await this.beginUserAction(agentId)
 
     const runtime = await this.ensureRuntimeForAgent(handle)
     runtimeManager.touchRuntimeActivity(runtime.id)
@@ -602,8 +625,162 @@ class AgentController {
   async abortAgent(agentId: string): Promise<void> {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
+    await this.beginUserAction(agentId)
 
     const runtime = await this.ensureRuntimeForAgent(handle)
+    await this.abortSession(handle, runtime)
+  }
+
+  async recoverStalledAgent(
+    agentId: string,
+    resumePrompt: string,
+    observedLastActivityAt: number
+  ): Promise<StallRecoveryResult> {
+    const handle = this.agents.get(agentId)
+    if (!handle) throw new Error(`Agent ${agentId} not found`)
+    if (this.hasNewerUserAction(agentId, observedLastActivityAt)) return 'superseded'
+    const activity = this.sessionActivity.get(handle.sessionId)
+    if (activity && activity.at > observedLastActivityAt + USER_ACTION_CLOCK_SKEW_MS) return 'superseded'
+
+    const existing = this.stallRecoveries.get(agentId)
+    if (existing) return existing.promise
+
+    const recovery: StallRecovery = {
+      cancelled: false,
+      settled: false,
+      operation: Promise.resolve('timeout'),
+      promise: Promise.resolve('timeout')
+    }
+    const activityVersion = activity?.version ?? 0
+    recovery.operation = this.performStallRecovery(
+      handle,
+      resumePrompt,
+      observedLastActivityAt,
+      activityVersion,
+      recovery
+    ).catch(() => 'timeout' as StallRecoveryResult).finally(() => {
+      recovery.settled = true
+      if (this.stallRecoveries.get(agentId) === recovery) this.stallRecoveries.delete(agentId)
+    })
+    recovery.promise = this.limitStallRecovery(
+      recovery.operation,
+      recovery
+    )
+    this.stallRecoveries.set(agentId, recovery)
+    return recovery.promise
+  }
+
+  private async performStallRecovery(
+    handle: AgentHandle,
+    resumePrompt: string,
+    observedLastActivityAt: number,
+    activityVersion: number,
+    recovery: StallRecovery
+  ): Promise<StallRecoveryResult> {
+    const sessionId = handle.sessionId
+    const runtime = await this.ensureRuntimeForAgent(handle)
+    if (this.isStallRecoverySuperseded(handle, sessionId, observedLastActivityAt, activityVersion, recovery)) return 'superseded'
+
+    const initialStatus = await this.getRecoverySessionStatus(handle, runtime, sessionId)
+    if (initialStatus !== 'running') return initialStatus
+    if (this.isStallRecoverySuperseded(handle, sessionId, observedLastActivityAt, activityVersion, recovery)) return 'superseded'
+
+    await this.abortSession(handle, runtime)
+    if (recovery.cancelled) return 'superseded'
+    const status = await this.waitForSessionToSettle(handle, runtime, sessionId)
+    if (status !== 'idle') return status
+    if (this.isStallRecoverySuperseded(handle, sessionId, observedLastActivityAt, undefined, recovery)) return 'superseded'
+
+    await handle.bridge.ensureStreaming()
+    if (this.isStallRecoverySuperseded(handle, sessionId, observedLastActivityAt, undefined, recovery)) return 'superseded'
+
+    await runtime.client.session.promptAsync({
+      sessionID: sessionId,
+      directory: handle.directory,
+      parts: [{ type: 'text', text: resumePrompt }],
+      ...(handle.modelOverride && { model: handle.modelOverride }),
+      ...(handle.variantOverride && { variant: handle.variantOverride })
+    })
+    return 'recovered'
+  }
+
+  private async waitForSessionToSettle(
+    handle: AgentHandle,
+    runtime: RuntimeInfo,
+    sessionId: string
+  ): Promise<SettledSessionStatus> {
+    const deadline = Date.now() + STALL_RECOVERY_TIMEOUT_MS
+    while (Date.now() < deadline) {
+      const status = await this.getRecoverySessionStatus(handle, runtime, sessionId)
+      if (status !== 'running') return status
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+    return 'timeout'
+  }
+
+  private async getRecoverySessionStatus(
+    handle: AgentHandle,
+    runtime: RuntimeInfo,
+    sessionId: string
+  ): Promise<Exclude<RecoverySessionStatus, 'timeout'>> {
+    if (handle.sessionId !== sessionId) return 'completed'
+    const result = await runtime.client.session.status({ directory: handle.directory })
+    const status = (result.data as Record<string, { type: string }> | undefined)?.[sessionId]?.type ?? 'idle'
+    if (status === 'idle') return 'idle'
+    if (status === 'waiting') return 'blocked'
+    if (status === 'completed') return 'completed'
+    if (status === 'error') return 'errored'
+    return 'running'
+  }
+
+  private isStallRecoverySuperseded(
+    handle: AgentHandle,
+    sessionId: string,
+    observedLastActivityAt: number,
+    activityVersion: number | undefined,
+    recovery: StallRecovery
+  ): boolean {
+    return recovery.cancelled ||
+      this.agents.get(handle.id) !== handle ||
+      handle.sessionId !== sessionId ||
+      (activityVersion !== undefined && (this.sessionActivity.get(sessionId)?.version ?? 0) !== activityVersion) ||
+      this.hasNewerUserAction(handle.id, observedLastActivityAt)
+  }
+
+  private async limitStallRecovery(
+    operation: Promise<StallRecoveryResult>,
+    recovery: StallRecovery
+  ): Promise<StallRecoveryResult> {
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    const timedOut = new Promise<StallRecoveryResult>((resolve) => {
+      timeout = setTimeout(() => {
+        recovery.cancelled = true
+        resolve('timeout')
+      }, STALL_RECOVERY_TOTAL_TIMEOUT_MS)
+    })
+    try {
+      return await Promise.race([operation, timedOut])
+    } finally {
+      if (timeout) clearTimeout(timeout)
+    }
+  }
+
+  private async beginUserAction(agentId: string): Promise<void> {
+    this.lastUserActionAt.set(agentId, Date.now())
+    const recovery = this.stallRecoveries.get(agentId)
+    if (!recovery) return
+    recovery.cancelled = true
+    await recovery.promise.catch(() => undefined)
+    if (!recovery.settled) {
+      throw new Error('Stall recovery is still stopping the previous request. Retry when the agent leaves the stopping state.')
+    }
+  }
+
+  private hasNewerUserAction(agentId: string, observedLastActivityAt: number): boolean {
+    return (this.lastUserActionAt.get(agentId) ?? 0) > observedLastActivityAt + USER_ACTION_CLOCK_SKEW_MS
+  }
+
+  private async abortSession(handle: AgentHandle, runtime: RuntimeInfo): Promise<void> {
     runtimeManager.touchRuntimeActivity(runtime.id)
 
     await runtime.client.session.abort({
@@ -635,6 +812,7 @@ class AgentController {
   async executeCommand(agentId: string, command: string, args: string): Promise<unknown> {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
+    await this.beginUserAction(agentId)
 
     const runtime = await this.ensureRuntimeForAgent(handle)
     runtimeManager.touchRuntimeActivity(runtime.id)
@@ -864,6 +1042,7 @@ class AgentController {
   async compactSession(agentId: string): Promise<unknown> {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
+    await this.beginUserAction(agentId)
 
     const runtime = await this.ensureRuntimeForAgent(handle)
     runtimeManager.touchRuntimeActivity(runtime.id)
@@ -983,6 +1162,7 @@ class AgentController {
   async sendMessageWithModel(agentId: string, text: string, providerID: string, modelID: string, attachments?: Attachment[]): Promise<void> {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
+    await this.beginUserAction(agentId)
 
     handle.modelOverride = { providerID, modelID }
     this.persistAgents()
@@ -1500,6 +1680,10 @@ class AgentController {
     const handle = this.agents.get(agentId)
     if (!handle) throw new Error(`Agent ${agentId} not found`)
 
+    const recovery = this.stallRecoveries.get(agentId)
+    if (recovery) recovery.cancelled = true
+    this.lastUserActionAt.delete(agentId)
+
     const otherAgents = Array.from(this.agents.values()).filter((agent) => agent.id !== agentId)
     const shouldStopRuntime = !otherAgents.some((agent) => agent.runtimeId === handle.runtimeId)
     const shouldRemoveWorktree = handle.isWorktree && !otherAgents.some((agent) => agent.directory === handle.directory)
@@ -1590,12 +1774,50 @@ class AgentController {
     const runtime = await runtimeManager.ensureRuntime(directory)
 
     if (!this.bridges.has(runtime.id)) {
-      const bridge = new EventBridge(runtime.id, directory, runtime.client)
+      const bridge = new EventBridge(
+        runtime.id,
+        directory,
+        runtime.client,
+        (event) => this.recordSessionActivity(event)
+      )
       this.bridges.set(runtime.id, bridge)
       await bridge.start()
     }
 
     return runtime
+  }
+
+  private recordSessionActivity(event: { type: string; properties: unknown }): void {
+    const properties = event.properties as Record<string, unknown>
+    if (event.type === 'session.created') {
+      const info = properties.info as Record<string, unknown> | undefined
+      const childSessionId = info?.id as string | undefined
+      const parentSessionId = info?.parentID as string | undefined
+      if (childSessionId && parentSessionId) this.sessionParents.set(childSessionId, parentSessionId)
+      return
+    }
+    if (!event.type.startsWith('message.') && event.type !== 'question.asked' && event.type !== 'permission.asked') {
+      return
+    }
+    const nested = (properties.part ?? properties.info) as Record<string, unknown> | undefined
+    const sessionId = (properties.sessionID ?? nested?.sessionID) as string | undefined
+    if (!sessionId) return
+    if (event.type === 'message.part.updated') {
+      const state = nested?.state as Record<string, unknown> | undefined
+      const metadata = state?.metadata as Record<string, unknown> | undefined
+      const childSessionId = metadata?.sessionId as string | undefined
+      if (childSessionId) this.sessionParents.set(childSessionId, sessionId)
+    }
+
+    const at = Date.now()
+    const visited = new Set<string>()
+    let currentSessionId: string | undefined = sessionId
+    while (currentSessionId && !visited.has(currentSessionId)) {
+      visited.add(currentSessionId)
+      const current = this.sessionActivity.get(currentSessionId)
+      this.sessionActivity.set(currentSessionId, { version: (current?.version ?? 0) + 1, at })
+      currentSessionId = this.sessionParents.get(currentSessionId)
+    }
   }
 
   private async ensureRuntimeForAgent(handle: AgentHandle): Promise<RuntimeInfo> {

--- a/src/main/services/event-bridge.ts
+++ b/src/main/services/event-bridge.ts
@@ -25,7 +25,8 @@ export class EventBridge {
   constructor(
     private runtimeId: string,
     private directory: string,
-    private client: OpencodeClient
+    private client: OpencodeClient,
+    private onEvent?: (event: { type: string; properties: unknown }) => void
   ) {}
 
   /**
@@ -206,6 +207,7 @@ export class EventBridge {
   }
 
   private forwardEvent(event: { type: string; properties: unknown }): void {
+    this.onEvent?.(event)
     if (event.type !== 'server.heartbeat') {
       runtimeManager.touchRuntimeActivity(this.runtimeId)
     }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -51,6 +51,9 @@ const api = {
   abortAgent: (agentId: string): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:abort', agentId),
 
+  recoverStalledAgent: (agentId: string, resumePrompt: string, observedLastActivityAt: number): Promise<IpcResult> =>
+    ipcRenderer.invoke('agent:recover-stall', agentId, resumePrompt, observedLastActivityAt),
+
   removeAgent: (agentId: string): Promise<IpcResult> =>
     ipcRenderer.invoke('agent:remove', agentId),
 

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -41,7 +41,13 @@ import {
   type QuickAction,
   type QuickActionIcon
 } from '../data/settings'
-import { loadAgentOutputVerbosity, saveAgentOutputVerbosity } from '../data/agentSettings'
+import {
+  loadAgentAutoRecoverSetting,
+  loadAgentOutputVerbosity,
+  saveAgentAutoRecoverSetting,
+  saveAgentOutputVerbosity,
+  type AgentAutoRecoverSetting
+} from '../data/agentSettings'
 import { useImageAttachments } from '../hooks/useImageAttachments'
 import { useEditorLabel } from '../hooks/useEditorLabel'
 import { getVariantOptionsForModel, useModelOptions } from '../hooks/useModelOptions'
@@ -295,12 +301,17 @@ export const DetailDrawer = memo(function DetailDrawer({
   const [outputVerbosity, setOutputVerbosity] = useState<OutputVerbosity>(() =>
     loadAgentOutputVerbosity(agent.sessionId ?? agent.id) ?? loadSettings().outputVerbosity
   )
+  const [autoRecoverSetting, setAutoRecoverSetting] = useState<AgentAutoRecoverSetting>(() =>
+    loadAgentAutoRecoverSetting(agent.id)
+  )
+  const [globalAutoRecover, setGlobalAutoRecover] = useState(() => loadSettings().autoRecoverStalledResponses)
   const [quickActions, setQuickActions] = useState(() => loadSettings().quickActions)
   const editorLabel = useEditorLabel()
   useEffect(() => {
     const onSettingsChanged = () => {
       const s = loadSettings()
       if (!loadAgentOutputVerbosity(agent.sessionId ?? agent.id)) setOutputVerbosity(s.outputVerbosity)
+      setGlobalAutoRecover(s.autoRecoverStalledResponses)
       setQuickActions(s.quickActions)
     }
     window.addEventListener(SETTINGS_CHANGED_EVENT, onSettingsChanged)
@@ -311,6 +322,10 @@ export const DetailDrawer = memo(function DetailDrawer({
     setOutputVerbosity(value)
     saveAgentOutputVerbosity(agent.sessionId ?? agent.id, value)
   }, [agent.id, agent.sessionId])
+  const handleAutoRecoverSettingChange = useCallback((value: AgentAutoRecoverSetting) => {
+    setAutoRecoverSetting(value)
+    saveAgentAutoRecoverSetting(agent.id, value)
+  }, [agent.id])
   const {
     attachments, isDragOver, fileInputRef,
     removeAttachment, clearAttachments,
@@ -947,6 +962,9 @@ export const DetailDrawer = memo(function DetailDrawer({
                 agent={agent}
                 outputVerbosity={outputVerbosity}
                 onOutputVerbosityChange={handleOutputVerbosityChange}
+                autoRecoverSetting={autoRecoverSetting}
+                globalAutoRecover={globalAutoRecover}
+                onAutoRecoverSettingChange={handleAutoRecoverSettingChange}
                 onChangeModel={onChangeModel}
               />
             )}
@@ -1747,11 +1765,17 @@ function AgentConfigPanel({
   agent,
   outputVerbosity,
   onOutputVerbosityChange,
+  autoRecoverSetting,
+  globalAutoRecover,
+  onAutoRecoverSettingChange,
   onChangeModel
 }: {
   agent: AgentRuntime
   outputVerbosity: OutputVerbosity
   onOutputVerbosityChange: (value: OutputVerbosity) => void
+  autoRecoverSetting: AgentAutoRecoverSetting
+  globalAutoRecover: boolean
+  onAutoRecoverSettingChange: (value: AgentAutoRecoverSetting) => void
   onChangeModel?: (modelPath: string, variant?: string) => Promise<boolean>
 }) {
   const { options, loading, providerData, configModel } = useModelOptions(agent.id)
@@ -1838,6 +1862,27 @@ function AgentConfigPanel({
             )
           })}
         </div>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-kumo-subtle">Stall Recovery</h3>
+          <p className="mt-1 text-[11px] text-kumo-subtle">Override automatic recovery for this agent.</p>
+        </div>
+        <SelectField
+          value={autoRecoverSetting}
+          options={[
+            { value: 'inherit', label: `Default (global ${globalAutoRecover ? 'on' : 'off'})` },
+            { value: 'on', label: 'On' },
+            { value: 'off', label: 'Off' }
+          ]}
+          onChange={(value) => onAutoRecoverSettingChange(value as AgentAutoRecoverSetting)}
+          buttonClassName={selectButtonClasses}
+          menuClassName={selectMenuClasses}
+        />
+        <p className="text-[10px] text-kumo-subtle">
+          On resumes one stalled request; Off only shows the stalled alert.
+        </p>
       </section>
 
       <section className="flex flex-col gap-3">

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -264,6 +264,28 @@ export function SettingsModal({ onClose, initialTab = 'general', commands = [] }
                 </div>
               </div>
 
+              <div className="flex flex-col gap-2">
+                <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">
+                  Stalled Agents
+                </label>
+                <label className="flex items-start gap-2.5 cursor-pointer group pl-1">
+                  <input
+                    type="checkbox"
+                    checked={settings.autoRecoverStalledResponses}
+                    onChange={(event) => updateSettings({ autoRecoverStalledResponses: event.target.checked })}
+                    className="mt-0.5 w-3.5 h-3.5 rounded border-kumo-line bg-kumo-control accent-kumo-brand"
+                  />
+                  <span>
+                    <span className="block text-sm text-kumo-default group-hover:text-kumo-strong transition-colors">
+                      Automatically resume stalled agents
+                    </span>
+                    <span className="mt-0.5 block text-[11px] text-kumo-subtle">
+                      When provider or tool activity stalls, abort the request and ask the agent to continue once.
+                    </span>
+                  </span>
+                </label>
+              </div>
+
               {/* Notify When */}
               <div className="flex flex-col gap-2">
                 <label className="text-xs font-medium text-kumo-subtle uppercase tracking-wide">

--- a/src/renderer/src/data/agentSettings.ts
+++ b/src/renderer/src/data/agentSettings.ts
@@ -4,22 +4,42 @@ export const AGENT_SETTINGS_STORAGE_KEY = 'oc-orchestrator:agent-settings'
 
 interface StoredAgentSettings {
   outputVerbosity?: OutputVerbosity
+  autoRecoverStalledResponses?: boolean
 }
+
+export type AgentAutoRecoverSetting = 'inherit' | 'on' | 'off'
 
 function loadAllAgentSettings(): Record<string, StoredAgentSettings> {
   try {
     const stored = localStorage.getItem(AGENT_SETTINGS_STORAGE_KEY)
     if (!stored) return {}
-    const parsed = JSON.parse(stored) as Record<string, { outputVerbosity?: unknown }>
+    const parsed = JSON.parse(stored) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+
     const result: Record<string, StoredAgentSettings> = {}
     for (const [agentId, settings] of Object.entries(parsed)) {
-      if (isOutputVerbosity(settings?.outputVerbosity)) {
-        result[agentId] = { outputVerbosity: settings.outputVerbosity }
-      }
+      if (!settings || typeof settings !== 'object' || Array.isArray(settings)) continue
+      const storedSettings = settings as Record<string, unknown>
+      const outputVerbosity = isOutputVerbosity(storedSettings.outputVerbosity)
+        ? storedSettings.outputVerbosity
+        : undefined
+      const autoRecoverStalledResponses = typeof storedSettings.autoRecoverStalledResponses === 'boolean'
+        ? storedSettings.autoRecoverStalledResponses
+        : undefined
+      if (outputVerbosity === undefined && autoRecoverStalledResponses === undefined) continue
+      result[agentId] = { outputVerbosity, autoRecoverStalledResponses }
     }
     return result
   } catch {
     return {}
+  }
+}
+
+function saveAllAgentSettings(settings: Record<string, StoredAgentSettings>): void {
+  try {
+    localStorage.setItem(AGENT_SETTINGS_STORAGE_KEY, JSON.stringify(settings))
+  } catch {
+    // Settings remain usable for the current render when storage is unavailable.
   }
 }
 
@@ -28,11 +48,43 @@ export function loadAgentOutputVerbosity(agentId: string): OutputVerbosity | und
 }
 
 export function saveAgentOutputVerbosity(agentId: string, outputVerbosity: OutputVerbosity): void {
-  try {
-    const settings = loadAllAgentSettings()
-    settings[agentId] = { ...settings[agentId], outputVerbosity }
-    localStorage.setItem(AGENT_SETTINGS_STORAGE_KEY, JSON.stringify(settings))
-  } catch {
-    // The drawer still updates when storage is unavailable.
+  const settings = loadAllAgentSettings()
+  settings[agentId] = { ...settings[agentId], outputVerbosity }
+  saveAllAgentSettings(settings)
+}
+
+export function loadAgentAutoRecoverSetting(agentId: string): AgentAutoRecoverSetting {
+  const value = loadAllAgentSettings()[agentId]?.autoRecoverStalledResponses
+  if (value === true) return 'on'
+  if (value === false) return 'off'
+  return 'inherit'
+}
+
+export function saveAgentAutoRecoverSetting(agentId: string, value: AgentAutoRecoverSetting): void {
+  const settings = loadAllAgentSettings()
+  const current = settings[agentId] ?? {}
+  if (value === 'inherit') {
+    delete current.autoRecoverStalledResponses
+  } else {
+    current.autoRecoverStalledResponses = value === 'on'
   }
+  if (current.outputVerbosity === undefined && current.autoRecoverStalledResponses === undefined) {
+    delete settings[agentId]
+  } else {
+    settings[agentId] = current
+  }
+  saveAllAgentSettings(settings)
+}
+
+export function deleteAgentSettings(agentId: string): void {
+  const settings = loadAllAgentSettings()
+  delete settings[agentId]
+  saveAllAgentSettings(settings)
+}
+
+export function resolveAutoRecoverStalledResponses(
+  globalDefault: boolean,
+  agentSetting: AgentAutoRecoverSetting
+): boolean {
+  return agentSetting === 'inherit' ? globalDefault : agentSetting === 'on'
 }

--- a/src/renderer/src/data/settings.ts
+++ b/src/renderer/src/data/settings.ts
@@ -45,6 +45,7 @@ export interface AppSettings {
   quickActions: QuickActionSlots
   notifications: NotificationPrefs
   outputVerbosity: OutputVerbosity
+  autoRecoverStalledResponses: boolean
   soundEnabled: boolean
 }
 
@@ -89,6 +90,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
     external_attached: true,
   },
   outputVerbosity: 'none',
+  autoRecoverStalledResponses: false,
   soundEnabled: true,
 }
 
@@ -126,6 +128,9 @@ export function loadSettings(): AppSettings {
       createPrPrompt: parsed.createPrPrompt?.trim() ? parsed.createPrPrompt : DEFAULT_CREATE_PR_PROMPT,
       quickActions,
       outputVerbosity,
+      autoRecoverStalledResponses: typeof parsed.autoRecoverStalledResponses === 'boolean'
+        ? parsed.autoRecoverStalledResponses
+        : DEFAULT_SETTINGS.autoRecoverStalledResponses,
     }
   } catch {
     return DEFAULT_SETTINGS

--- a/src/renderer/src/demoApi.ts
+++ b/src/renderer/src/demoApi.ts
@@ -328,6 +328,7 @@ export function createDemoApi(): OrchestratorApi {
     sendMessageWithModel: noop,
     respondToPermission: noop,
     abortAgent: noop,
+    recoverStalledAgent: async () => ok('recovered'),
     removeAgent: noop,
     resetSession: noop,
     getMessages: (agentId: string) => ok(makeDemoMessages(agentId)),

--- a/src/renderer/src/hooks/useAgentStore.ts
+++ b/src/renderer/src/hooks/useAgentStore.ts
@@ -33,6 +33,8 @@ import {
   type ChildSessionDescriptor
 } from '../lib/subagent-progress'
 import { getPendingInterruptStatus } from '../lib/interrupt-status'
+import { loadSettings } from '../data/settings'
+import { deleteAgentSettings, loadAgentAutoRecoverSetting, resolveAutoRecoverStalledResponses } from '../data/agentSettings'
 
 // Deduplication cache for provider error toasts per runtime to avoid flicker.
 const toastDedup = new Map<string, { sig: string; expiresAt: number }>()
@@ -353,6 +355,7 @@ interface PendingMessage {
   taskSummaryOverride?: string
 }
 const pendingMessages = new Map<string, PendingMessage>()
+const stalledRecoveryStates = new Map<string, 'recovering' | 'attempted'>()
 
 // Safety timers for the `compacting` flag. We set a short "kickoff" watchdog
 // (30s): if the server doesn't produce a compaction part or set
@@ -1321,6 +1324,9 @@ function processEvent(payload: OpenCodeEventPayload): void {
       const agent = findAgentBySession(sessionId)
       if (agent) {
         const newStatus = mapSessionStatus(statusInfo.type)
+        if (newStatus === 'idle' || newStatus === 'completed' || newStatus === 'errored') {
+          clearStalledRecoveryAttempt(agent.id)
+        }
         // While stopping, only allow transitions to terminal states (idle/completed/errored).
         // Ignore 'running' or 'needs_input' events that may arrive after abort was sent.
         if (agent.status === 'stopping' && newStatus !== 'idle' && newStatus !== 'completed' && newStatus !== 'errored') {
@@ -1373,6 +1379,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
       const sessionId = props.sessionID as string
       const agent = findAgentBySession(sessionId)
       if (agent) {
+        clearStalledRecoveryAttempt(agent.id)
         notifyIfNeeded(agent, 'idle')
         agent.status = 'idle'
         agent.lastActivityAt = Date.now()
@@ -1401,6 +1408,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
       console.error('[session.error]', { sessionId, error: errorProp, fullProps: props })
       const agent = findAgentBySession(sessionId)
       if (agent) {
+        clearStalledRecoveryAttempt(agent.id)
         notifyIfNeeded(agent, 'errored')
         agent.status = 'errored'
         agent.lastActivityAt = Date.now()
@@ -1429,6 +1437,7 @@ function processEvent(payload: OpenCodeEventPayload): void {
       const sessionId = props.sessionID as string
       const agent = findAgentBySession(sessionId)
       if (agent) {
+        clearStalledRecoveryAttempt(agent.id)
         notifyIfNeeded(agent, 'completed')
         agent.status = 'completed'
         agent.lastActivityAt = Date.now()
@@ -2498,6 +2507,7 @@ function handleSessionReset(payload: { id: string; sessionId: string; oldSession
   clearChildSessionsForAgent(payload.id)
   pendingMessages.delete(payload.id)
   childHydrationRetryAgents.delete(payload.id)
+  stalledRecoveryStates.delete(payload.id)
   agent.sessionId = payload.sessionId
   agent.branchName = payload.branchName
   agent.prUrl = null
@@ -2534,6 +2544,8 @@ function removeAgentState(agentId: string): void {
   pendingMessages.delete(agentId)
   pendingModelChanges.delete(agentId)
   childHydrationRetryAgents.delete(agentId)
+  stalledRecoveryStates.delete(agentId)
+  deleteAgentSettings(agentId)
   const compactingTimer = compactingTimers.get(agentId)
   if (compactingTimer) {
     clearTimeout(compactingTimer)
@@ -2931,6 +2943,8 @@ function findAgentByRuntime(runtimeId: string): LiveAgent | undefined {
  *  activity. Anything else (including unset) is treated as still running. */
 const TERMINAL_TOOL_STATES = new Set(['completed', 'error', 'failed'])
 const STALLED_RESPONSE_TIMEOUT_MS = 5 * 60_000
+const STALLED_APPLY_PATCH_TIMEOUT_MS = 60_000
+const STALLED_RESPONSE_RESUME_PROMPT = 'Your previous response stalled without producing output. Continue from the exact point where you stopped, preserving the existing work and context.'
 
 /** Find the parent agent for a sub-agent's child sessionId, or undefined if
  *  no mapping is known. */
@@ -2983,29 +2997,141 @@ function setChildSessionActivity(sessionId: string, updatedAt: number): void {
  *
  *  When a tool is in flight the model isn't hanging — it's blocked on the tool —
  *  so the "provider overloaded" watchdog does not apply. */
-function hasInFlightToolCall(messages: readonly LiveMessage[] | undefined): boolean {
+function getStalledResponseTimeout(
+  messages: readonly LiveMessage[] | undefined,
+  now: number,
+  getChildActivityAt?: (sessionId: string) => number | undefined
+): number | undefined {
   const latestMessage = getActiveAssistantMessage(messages)
-  if (!messages || !latestMessage) return false
-  for (const message of messages) {
-    for (const part of message.parts) {
-      if (part.type !== 'tool') continue
-      if (TERMINAL_TOOL_STATES.has(part.toolState ?? '')) continue
-      if (part.toolName === 'task' && message !== latestMessage) continue
-      return true
+  if (!latestMessage) return STALLED_RESPONSE_TIMEOUT_MS
+  let timeout = STALLED_RESPONSE_TIMEOUT_MS
+  for (const part of latestMessage.parts) {
+    if (part.type !== 'tool') continue
+    if (TERMINAL_TOOL_STATES.has(part.toolState ?? '')) continue
+    if (part.toolName === 'apply_patch') {
+      timeout = STALLED_APPLY_PATCH_TIMEOUT_MS
+      continue
     }
+    if (part.toolName === 'task' && part.childSessionId) {
+      const childActivityAt = getChildActivityAt?.(part.childSessionId)
+      if (childActivityAt !== undefined && now - childActivityAt >= STALLED_RESPONSE_TIMEOUT_MS) continue
+    }
+    return undefined
   }
-  return false
+  return timeout
 }
 
 export function isStalledResponse(
   agent: Pick<LiveAgent, 'status' | 'lastActivityAt'>,
   messages: readonly LiveMessage[] | undefined,
-  now: number
+  now: number,
+  getChildActivityAt?: (sessionId: string) => number | undefined
 ): boolean {
+  const timeout = getStalledResponseTimeout(messages, now, getChildActivityAt)
   return agent.status === 'running'
     && agent.lastActivityAt > 0
-    && now - agent.lastActivityAt >= STALLED_RESPONSE_TIMEOUT_MS
-    && !hasInFlightToolCall(messages)
+    && timeout !== undefined
+    && now - agent.lastActivityAt >= timeout
+}
+
+export function shouldAutoRecoverStalledResponse(
+  autoRecoverEnabled: boolean,
+  recoveryStarted: boolean,
+  lastPromptWasRecovery = false
+): boolean {
+  return autoRecoverEnabled && !recoveryStarted && !lastPromptWasRecovery
+}
+
+export function wasStallRecoveryLastPrompt(messages: readonly LiveMessage[] | undefined): boolean {
+  let latestUserMessage: LiveMessage | undefined
+  for (const message of messages ?? []) {
+    if (message.role !== 'user') continue
+    if (!latestUserMessage || message.createdAt > latestUserMessage.createdAt) latestUserMessage = message
+  }
+  return latestUserMessage?.parts.some(
+    (part) => part.type === 'text' && part.text === STALLED_RESPONSE_RESUME_PROMPT
+  ) ?? false
+}
+
+function clearStalledRecoveryAttempt(agentId: string): void {
+  if (stalledRecoveryStates.get(agentId) === 'attempted') stalledRecoveryStates.delete(agentId)
+}
+
+function markStalledResponse(
+  agent: LiveAgent,
+  now: number,
+  recovery: 'disabled' | 'attempted' | 'failed'
+): void {
+  const messages = {
+    disabled: 'The agent stopped producing updates. Automatic recovery is off; try again or switch models.',
+    attempted: 'The agent stopped producing updates after automatic recovery; try again or switch models.',
+    failed: 'Automatic recovery failed after the agent stopped producing updates. Try again or switch models.'
+  }
+  agent.lastError ??= {
+    name: 'StalledResponse',
+    message: messages[recovery],
+    sessionId: agent.sessionId,
+    occurredAt: now
+  }
+  notifyIfNeeded(agent, 'needs_input')
+  agent.status = 'needs_input'
+  agent.blockedSince = agent.blockedSince ?? now
+  agent.inputReason = 'error'
+}
+
+async function autoRecoverStalledAgent(agentId: string): Promise<boolean> {
+  const agent = state.agents.get(agentId)
+  if (!window.api || !agent || agent.status !== 'running') return false
+  const sessionId = agent.sessionId
+  const observedLastActivityAt = agent.lastActivityAt
+
+  agent.status = 'stopping'
+  agent.lastActivityAt = Date.now()
+  emit({ agents: true })
+
+  const result = await window.api.recoverStalledAgent(
+    agentId,
+    STALLED_RESPONSE_RESUME_PROMPT,
+    observedLastActivityAt
+  )
+  const current = state.agents.get(agentId)
+  if (current?.sessionId !== sessionId) return true
+  if (!result.ok || result.data === 'timeout') return false
+
+  if ((result.data === 'recovered' || result.data === 'superseded') && current.status === 'stopping') {
+    current.status = 'running'
+    current.lastActivityAt = Date.now()
+    updateAgentAfterInterruptChange(current, false, false)
+    emit({ agents: true })
+  }
+
+  if (result.data === 'blocked') {
+    current.status = 'running'
+    const [questions, permissions] = await Promise.all([
+      window.api.listQuestions(),
+      window.api.listPermissions()
+    ])
+    if (questions.ok && questions.data) reconcileQuestions(questions.data as PendingQuestionSnapshot[])
+    if (permissions.ok && permissions.data) reconcilePermissions(permissions.data as PendingPermissionSnapshot[])
+    if (current.status === 'running') {
+      current.status = 'needs_input'
+      current.blockedSince = Date.now()
+      current.inputReason = 'question'
+      emit({ agents: true })
+    }
+  }
+
+  if (result.data === 'idle' || result.data === 'completed' || result.data === 'errored') {
+    notifyIfNeeded(current, result.data)
+    current.status = result.data
+    current.lastActivityAt = Date.now()
+    current.blockedSince = undefined
+    current.respondedAt = undefined
+    current.inputReason = undefined
+    emit({ agents: true })
+  }
+
+  return result.data !== undefined
 }
 
 /** Record that `childSessionId` belongs to `parentAgentId` so we can bump the
@@ -3602,25 +3728,47 @@ export function useAgentStore() {
           emit({ messages: true })
         }
 
-        // Watchdog: if an agent has been 'running' with no activity for N minutes,
-        // surface it as needs_input so it shows in the InterruptBanner. This
-        // catches cases where providers hang or keep retrying silently.
+        // Recover one silent provider stall per run, then require user input.
         const now = Date.now()
+        const autoRecoverByDefault = loadSettings().autoRecoverStalledResponses
         let changed = false
         for (const agent of state.agents.values()) {
-          if (!isStalledResponse(agent, state.messages.get(agent.sessionId), now)) continue
-          agent.lastError = agent.lastError ?? {
-            name: 'StalledResponse',
-            message: 'No update from provider for 5 minutes — model may be overloaded or network is unstable. Try again or switch models.',
-            sessionId: agent.sessionId,
-            occurredAt: now
+          if (!isStalledResponse(
+            agent,
+            state.messages.get(agent.sessionId),
+            now,
+            (sessionId) => childSessions.get(sessionId)?.updatedAt
+          )) continue
+
+          const autoRecoverEnabled = resolveAutoRecoverStalledResponses(
+            autoRecoverByDefault,
+            loadAgentAutoRecoverSetting(agent.id)
+          )
+          const shouldRecover = shouldAutoRecoverStalledResponse(
+            autoRecoverEnabled,
+            stalledRecoveryStates.has(agent.id),
+            wasStallRecoveryLastPrompt(state.messages.get(agent.sessionId))
+          )
+          if (shouldRecover) {
+            const sessionId = agent.sessionId
+            stalledRecoveryStates.set(agent.id, 'recovering')
+            console.warn('[watchdog] auto-recovering stalled agent', { agentId: agent.id })
+            void autoRecoverStalledAgent(agent.id).then((recovered) => {
+              const current = state.agents.get(agent.id)
+              if (recovered || current?.sessionId !== sessionId || current.status !== 'stopping') return
+              markStalledResponse(current, Date.now(), 'failed')
+              emit({ agents: true })
+            }).finally(() => {
+              if (stalledRecoveryStates.get(agent.id) === 'recovering') {
+                stalledRecoveryStates.set(agent.id, 'attempted')
+              }
+            })
+            continue
           }
-          notifyIfNeeded(agent, 'needs_input')
-          agent.status = 'needs_input'
-          agent.blockedSince = agent.blockedSince ?? now
-          agent.inputReason = 'error'
+
+          markStalledResponse(agent, now, autoRecoverEnabled ? 'attempted' : 'disabled')
           changed = true
-          console.warn('[watchdog] stalled agent marked needs_input', { agentId: agent.id })
+          console.warn('[watchdog] stalled agent needs user input', { agentId: agent.id })
         }
         if (changed) emit({ agents: true })
       } catch {
@@ -3717,11 +3865,13 @@ export function useAgentStore() {
     if (!window.api) return
     // No session exists to send to yet.
     if (state.agents.get(agentId)?.pending) return
+    const recoveryInProgress = stalledRecoveryStates.get(agentId) === 'recovering'
+    stalledRecoveryStates.delete(agentId)
 
     // Queue the message if the agent is still stopping — it will be dispatched
     // automatically once the abort completes.
     const agent = state.agents.get(agentId)
-    if (agent?.status === 'stopping') {
+    if (agent?.status === 'stopping' && !recoveryInProgress) {
       pendingMessages.set(agentId, { text, agentConfig, attachments, taskSummaryOverride })
       return { ok: true, queued: true }
     }
@@ -3799,6 +3949,7 @@ export function useAgentStore() {
 
     const agent = state.agents.get(agentId)
     if (agent?.status === 'stopping') return
+    stalledRecoveryStates.delete(agentId)
 
     // Show the slash command in the task summary so it's visible in the dashboard
     const previousStatus = agent?.status
@@ -3833,6 +3984,7 @@ export function useAgentStore() {
   const prepareFreshAgent = useCallback((agentId: string, prompt?: string) => {
     const agent = state.agents.get(agentId)
     if (!agent) return
+    stalledRecoveryStates.delete(agentId)
 
     const trimmedPrompt = prompt?.trim() ?? ''
 
@@ -3858,6 +4010,7 @@ export function useAgentStore() {
     if (!window.api) return
 
     const agent = state.agents.get(agentId)
+    stalledRecoveryStates.delete(agentId)
     const previousStatus = agent?.status
     const previousBlockedSince = agent?.blockedSince
     const previousLabelIds = agent?.labelIds ? [...agent.labelIds] : []
@@ -3896,6 +4049,7 @@ export function useAgentStore() {
     if (!window.api) return
 
     const agent = state.agents.get(agentId)
+    stalledRecoveryStates.delete(agentId)
     const previousStatus = agent?.status
     const previousBlockedSince = agent?.blockedSince
     const previousLabelIds = agent?.labelIds ? [...agent.labelIds] : []
@@ -3934,6 +4088,7 @@ export function useAgentStore() {
     if (!window.api) return
 
     const agent = state.agents.get(agentId)
+    stalledRecoveryStates.delete(agentId)
     const previousStatus = agent?.status
     const previousBlockedSince = agent?.blockedSince
     const previousLabelIds = agent?.labelIds ? [...agent.labelIds] : []

--- a/src/renderer/src/types/api.d.ts
+++ b/src/renderer/src/types/api.d.ts
@@ -26,6 +26,7 @@ export interface OrchestratorApi {
   sendMessage: (agentId: string, text: string, agent?: string, attachments?: MessageAttachment[]) => Promise<IpcResult>
   respondToPermission: (agentId: string, permissionId: string, response: 'once' | 'always' | 'reject') => Promise<IpcResult>
   abortAgent: (agentId: string) => Promise<IpcResult>
+  recoverStalledAgent: (agentId: string, resumePrompt: string, observedLastActivityAt: number) => Promise<IpcResult<'recovered' | 'superseded' | 'blocked' | 'idle' | 'completed' | 'errored' | 'timeout'>>
   removeAgent: (agentId: string) => Promise<IpcResult>
   resetSession: (agentId: string, prompt?: string) => Promise<IpcResult>
   getMessages: (agentId: string) => Promise<IpcResult>


### PR DESCRIPTION
Agents can remain busy after a provider, child agent, or short tool stops emitting updates. OCO currently leaves them running until someone interrupts them manually.

This adds optional automatic recovery after five minutes of silence, with a one minute limit for `apply_patch`. The global setting defaults off, and each agent can inherit or override it. Recovery waits for the old request to stop and yields to newer user or provider activity.

Tests cover provider and child activity races, blocked and terminal sessions, late aborts, settings persistence, and active long running tools.