### PR TITLE
NO-JIRA Show current task progress in the Fleet table

### DIFF
--- a/src/__tests__/fleet-last-message.test.ts
+++ b/src/__tests__/fleet-last-message.test.ts
@@ -29,7 +29,8 @@ describe('Fleet Last Message navigation', () => {
     prUrl: null,
     lastActivityAt: 'now',
     lastActivityAtMs: 1,
-    lastMessage: 'Latest answer'
+    lastMessage: 'Latest answer',
+    currentTask: { current: 2, total: 3, content: 'Add coverage' }
   }
 
   it('renders the last message as a keyboard-accessible button', () => {
@@ -81,6 +82,24 @@ describe('Fleet Last Message navigation', () => {
 
     expect(markup).toContain('<button type="button"')
     expect(markup).toContain('Click to jump to this message')
+  })
+
+  it('aligns two-line task progress with the Last Message cell', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {}
+    })
+    const markup = renderToStaticMarkup(createElement(FleetTable, {
+      agents: [agent],
+      selectedId: null,
+      onSelect: () => {},
+      visibleColumns: new Set(['task', 'lastMessage']),
+      columnWidths: {}
+    }))
+
+    expect(markup).toContain('Task 2/3: Add coverage')
+    expect(markup).toContain('align-top')
+    expect(markup).toContain('line-clamp-2')
   })
 
   it('resolves the latest rendered assistant text message', () => {

--- a/src/__tests__/todo-progress.test.ts
+++ b/src/__tests__/todo-progress.test.ts
@@ -3,8 +3,28 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import { TodoList } from '../renderer/src/components/DetailDrawer'
 import { applyTodoUpdate, isCurrentTodoFetch, type AgentTodo } from '../renderer/src/hooks/useAgentStore'
+import { getCurrentTaskProgress } from '../renderer/src/lib/task-progress'
 
 describe('Todo progress', () => {
+  it('reports the active task position and content', () => {
+    expect(getCurrentTaskProgress([
+      { content: 'Trace events', status: 'completed' },
+      { content: 'Add coverage', status: 'in_progress' },
+      { content: 'Run checks', status: 'pending' }
+    ])).toEqual({
+      current: 2,
+      total: 3,
+      content: 'Add coverage'
+    })
+  })
+
+  it('does not report progress without an active task', () => {
+    expect(getCurrentTaskProgress([
+      { content: 'Trace events', status: 'completed' },
+      { content: 'Add coverage', status: 'pending' }
+    ])).toBeUndefined()
+  })
+
   it('replaces an earlier task snapshot when OpenCode reports new progress', () => {
     const todos = new Map<string, AgentTodo[]>()
 

--- a/src/__tests__/todo-progress.test.ts
+++ b/src/__tests__/todo-progress.test.ts
@@ -25,6 +25,37 @@ describe('Todo progress', () => {
     ])).toBeUndefined()
   })
 
+  it('tracks the current task when the todo list changes over time', () => {
+    const todos = new Map<string, AgentTodo[]>()
+
+    applyTodoUpdate(todos, {
+      sessionID: 'session-1',
+      todos: [
+        { content: 'Trace events', status: 'in_progress' },
+        { content: 'Add coverage', status: 'pending' }
+      ]
+    })
+    expect(getCurrentTaskProgress(todos.get('session-1') ?? [])).toEqual({
+      current: 1,
+      total: 2,
+      content: 'Trace events'
+    })
+
+    applyTodoUpdate(todos, {
+      sessionID: 'session-1',
+      todos: [
+        { content: 'Trace events', status: 'completed' },
+        { content: 'Refine coverage', status: 'in_progress' },
+        { content: 'Run checks', status: 'pending' }
+      ]
+    })
+    expect(getCurrentTaskProgress(todos.get('session-1') ?? [])).toEqual({
+      current: 2,
+      total: 3,
+      content: 'Refine coverage'
+    })
+  })
+
   it('replaces an earlier task snapshot when OpenCode reports new progress', () => {
     const todos = new Map<string, AgentTodo[]>()
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -28,6 +28,7 @@ import {
   orderTranscriptByActivity
 } from './lib/subagent-progress'
 import { extractLastAssistantMessage } from './lib/last-message'
+import { getCurrentTaskProgress } from './lib/task-progress'
 
 const NEW_AGENT_COMMAND = '/new'
 const AGENT_MENTION_REGEX = /@(\w+)/
@@ -147,6 +148,7 @@ export function App() {
     listCommands,
     listAgentConfigs,
     getMessagesForSession,
+    getTodosForSession,
     getChildSessionActivityAt,
     getFileChangesForSession,
     getEventsForSession,
@@ -340,6 +342,7 @@ export function App() {
   const liveAgentsAsRuntimes: AgentRuntime[] = useMemo(() => {
     return store.agents.map((agent): AgentRuntime => {
       const lastMessage = extractLastAssistantMessage(getMessagesForSession(agent.sessionId))
+      const currentTask = getCurrentTaskProgress(getTodosForSession(agent.sessionId))
 
       // 'compacting' is a UI-level status: the agent's underlying server status
       // is whatever it is (often 'idle' once compaction is queued), but the
@@ -369,6 +372,7 @@ export function App() {
         blockedSince: agent.blockedSince ? formatTimeAgo(agent.blockedSince) : undefined,
         blockedSinceMs: agent.blockedSince,
         lastMessage,
+        currentTask,
         lastError: agent.lastError ? {
           name: agent.lastError.name,
           message: agent.lastError.message,
@@ -381,7 +385,7 @@ export function App() {
         pending: agent.pending
       }
     })
-  }, [store.agents, tick, getMessagesForSession])
+  }, [store.agents, tick, getMessagesForSession, getTodosForSession])
 
   // ── Convert live permissions + needs_input agents to Interrupt shape ──
   const liveInterrupts: Interrupt[] = useMemo(() => {

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -231,11 +231,11 @@ export function LastMessageCell({
   onSelect?: FleetTableProps['onSelect']
 }) {
   return (
-    <td className="px-3 py-2 truncate text-kumo-subtle text-[11px]">
+    <td className="px-3 py-2 align-top text-kumo-subtle text-[11px] leading-4">
       {message && onSelect ? (
         <button
           type="button"
-          className="max-w-full truncate text-left cursor-pointer hover:text-kumo-strong"
+          className="line-clamp-2 min-h-8 max-w-full text-left cursor-pointer hover:text-kumo-strong"
           title={`${message}\n\nClick to jump to this message`}
           onClick={(event) => {
             event.stopPropagation()
@@ -245,9 +245,9 @@ export function LastMessageCell({
           {message}
         </button>
       ) : message ? (
-        <span title={message}>{message}</span>
+        <span className="line-clamp-2 min-h-8" title={message}>{message}</span>
       ) : (
-        <span className="text-kumo-muted italic">--</span>
+        <span className="block min-h-8 text-kumo-muted italic">--</span>
       )}
     </td>
   )
@@ -1510,7 +1510,7 @@ function AgentRow({
         </td>
       )}
       {show('task') && (
-        <td className="px-3 py-2 truncate text-kumo-default">
+        <td className="px-3 py-2 align-top overflow-hidden text-kumo-default">
           {isPending ? (
             // A placeholder has no transcript to jump to. Dismiss is offered
             // unconditionally, not just on failure — it's the row's only exit,
@@ -1529,13 +1529,24 @@ function AgentRow({
               )}
             </div>
           ) : agent.taskSummary && (
-            <span
-              className="cursor-pointer hover:text-kumo-strong"
-              title={`${agent.taskSummary}\n\nClick to jump to your last message`}
-              onClick={(event) => { event.stopPropagation(); onJumpToLastUserMessage() }}
-            >
-              {agent.taskSummary}
-            </span>
+            <div className="min-h-8 leading-4">
+              <button
+                type="button"
+                className="block max-w-full truncate text-left cursor-pointer hover:text-kumo-strong"
+                title={`${agent.taskSummary}\n\nClick to jump to your last message`}
+                onClick={(event) => { event.stopPropagation(); onJumpToLastUserMessage() }}
+              >
+                {agent.taskSummary}
+              </button>
+              {agent.currentTask && (
+                <div
+                  className="truncate text-[11px] text-kumo-subtle"
+                  title={`Task ${agent.currentTask.current}/${agent.currentTask.total}: ${agent.currentTask.content}`}
+                >
+                  Task {agent.currentTask.current}/{agent.currentTask.total}: {agent.currentTask.content}
+                </div>
+              )}
+            </div>
           )}
         </td>
       )}

--- a/src/renderer/src/lib/task-progress.ts
+++ b/src/renderer/src/lib/task-progress.ts
@@ -1,0 +1,13 @@
+import type { AgentTodo } from '../hooks/useAgentStore'
+import type { AgentTaskProgress } from '../types'
+
+export function getCurrentTaskProgress(todos: AgentTodo[]): AgentTaskProgress | undefined {
+  const index = todos.findIndex((todo) => todo.status === 'in_progress')
+  if (index === -1) return undefined
+
+  return {
+    current: index + 1,
+    total: todos.length,
+    content: todos[index].content
+  }
+}

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -88,6 +88,7 @@ export interface AgentRuntime {
   blockedSince?: string
   blockedSinceMs?: number
   lastMessage?: string
+  currentTask?: AgentTaskProgress
   /** Most recent session-level error from the server (e.g. ContextOverflowError). */
   lastError?: AgentRuntimeError
   /** Why a needs_input agent needs attention when no structured question exists. */
@@ -103,6 +104,12 @@ export interface AgentRuntime {
   /** Placeholder row for a launch that main hasn't acknowledged yet. It has no
    *  session, so row actions other than dismissal are unavailable. */
   pending?: boolean
+}
+
+export interface AgentTaskProgress {
+  current: number
+  total: number
+  content: string
 }
 
 /**


### PR DESCRIPTION
The Task column only showed the summary from launch, so you had to open the drawer to see which todo an agent was working on. It now shows the active todo and its position under the summary.

When OpenCode changes the todo list, the displayed position and content follow the newest snapshot.

The Task and Last Message cells use matching heights and top alignment. Last Message can wrap across two lines without making the columns look uneven.