### PR TITLE
NO-JIRA Show completed task progress in the Fleet table

### DIFF
--- a/src/__tests__/fleet-last-message.test.ts
+++ b/src/__tests__/fleet-last-message.test.ts
@@ -30,7 +30,7 @@ describe('Fleet Last Message navigation', () => {
     lastActivityAt: 'now',
     lastActivityAtMs: 1,
     lastMessage: 'Latest answer',
-    currentTask: { current: 2, total: 3, content: 'Add coverage' }
+    currentTask: { status: 'in_progress', current: 2, total: 3, content: 'Add coverage' }
   }
 
   it('renders the last message as a keyboard-accessible button', () => {
@@ -100,6 +100,23 @@ describe('Fleet Last Message navigation', () => {
     expect(markup).toContain('Task 2/3: Add coverage')
     expect(markup).toContain('align-top')
     expect(markup).toContain('line-clamp-2')
+  })
+
+  it('shows completed task tracking with text and the success treatment', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {}
+    })
+    const markup = renderToStaticMarkup(createElement(FleetTable, {
+      agents: [{ ...agent, currentTask: { status: 'completed', total: 1 } }],
+      selectedId: null,
+      onSelect: () => {},
+      visibleColumns: new Set(['task']),
+      columnWidths: {}
+    }))
+
+    expect(markup).toContain('All 1 task complete')
+    expect(markup).toContain('text-kumo-success')
   })
 
   it('resolves the latest rendered assistant text message', () => {

--- a/src/__tests__/todo-progress.test.ts
+++ b/src/__tests__/todo-progress.test.ts
@@ -12,6 +12,7 @@ describe('Todo progress', () => {
       { content: 'Add coverage', status: 'in_progress' },
       { content: 'Run checks', status: 'pending' }
     ])).toEqual({
+      status: 'in_progress',
       current: 2,
       total: 3,
       content: 'Add coverage'
@@ -22,6 +23,22 @@ describe('Todo progress', () => {
     expect(getCurrentTaskProgress([
       { content: 'Trace events', status: 'completed' },
       { content: 'Add coverage', status: 'pending' }
+    ])).toBeUndefined()
+  })
+
+  it('reports when every tracked task is complete', () => {
+    expect(getCurrentTaskProgress([
+      { content: 'Trace events', status: 'completed' },
+      { content: 'Add coverage', status: 'completed' }
+    ])).toEqual({
+      status: 'completed',
+      total: 2
+    })
+
+    expect(getCurrentTaskProgress([])).toBeUndefined()
+    expect(getCurrentTaskProgress([
+      { content: 'Trace events', status: 'completed' },
+      { content: 'Old approach', status: 'cancelled' }
     ])).toBeUndefined()
   })
 
@@ -36,6 +53,7 @@ describe('Todo progress', () => {
       ]
     })
     expect(getCurrentTaskProgress(todos.get('session-1') ?? [])).toEqual({
+      status: 'in_progress',
       current: 1,
       total: 2,
       content: 'Trace events'
@@ -50,6 +68,7 @@ describe('Todo progress', () => {
       ]
     })
     expect(getCurrentTaskProgress(todos.get('session-1') ?? [])).toEqual({
+      status: 'in_progress',
       current: 2,
       total: 3,
       content: 'Refine coverage'

--- a/src/renderer/src/components/FleetTable.tsx
+++ b/src/renderer/src/components/FleetTable.tsx
@@ -1409,6 +1409,9 @@ function AgentRow({
   }
 
   const show = (key: ColumnKey): boolean => visibleColumns.has(key)
+  const completedTaskLabel = agent.currentTask?.status === 'completed'
+    ? `All ${agent.currentTask.total} ${agent.currentTask.total === 1 ? 'task' : 'tasks'} complete`
+    : undefined
 
   // Background/hover styling depends on selection, urgency, and whether a drag
   // is in progress (during drag we suppress hover so non-folder rows don't
@@ -1539,12 +1542,22 @@ function AgentRow({
                 {agent.taskSummary}
               </button>
               {agent.currentTask && (
-                <div
-                  className="truncate text-[11px] text-kumo-subtle"
-                  title={`Task ${agent.currentTask.current}/${agent.currentTask.total}: ${agent.currentTask.content}`}
-                >
-                  Task {agent.currentTask.current}/{agent.currentTask.total}: {agent.currentTask.content}
-                </div>
+                agent.currentTask.status === 'completed' ? (
+                  <div
+                    className="flex items-center gap-1 truncate text-[11px] text-kumo-success"
+                    title={completedTaskLabel}
+                  >
+                    <CheckCircle size={12} weight="fill" className="shrink-0" />
+                    <span className="truncate">{completedTaskLabel}</span>
+                  </div>
+                ) : (
+                  <div
+                    className="truncate text-[11px] text-kumo-subtle"
+                    title={`Task ${agent.currentTask.current}/${agent.currentTask.total}: ${agent.currentTask.content}`}
+                  >
+                    Task {agent.currentTask.current}/{agent.currentTask.total}: {agent.currentTask.content}
+                  </div>
+                )
               )}
             </div>
           )}

--- a/src/renderer/src/lib/task-progress.ts
+++ b/src/renderer/src/lib/task-progress.ts
@@ -3,9 +3,14 @@ import type { AgentTaskProgress } from '../types'
 
 export function getCurrentTaskProgress(todos: AgentTodo[]): AgentTaskProgress | undefined {
   const index = todos.findIndex((todo) => todo.status === 'in_progress')
-  if (index === -1) return undefined
+  if (index === -1) {
+    return todos.length > 0 && todos.every((todo) => todo.status === 'completed')
+      ? { status: 'completed', total: todos.length }
+      : undefined
+  }
 
   return {
+    status: 'in_progress',
     current: index + 1,
     total: todos.length,
     content: todos[index].content

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -106,11 +106,9 @@ export interface AgentRuntime {
   pending?: boolean
 }
 
-export interface AgentTaskProgress {
-  current: number
-  total: number
-  content: string
-}
+export type AgentTaskProgress =
+  | { status: 'in_progress'; current: number; total: number; content: string }
+  | { status: 'completed'; total: number }
 
 /**
  * Spike: client-side folder/directory definition for grouping agents in the


### PR DESCRIPTION
Fleet rows stopped showing task progress after the final tracked task completed because progress only represented an active task.

Keep a completed result for nonempty lists where every task is complete, and render "All N tasks complete" with the existing success style. Other task list states keep their prior behavior.

Tested with `npm run lint`, `npm run typecheck`, and `npm test`.