### PR TITLE
NO-JIRA Let the question panel scroll with the transcript

### DIFF
--- a/src/__tests__/detail-drawer-interrupt.test.ts
+++ b/src/__tests__/detail-drawer-interrupt.test.ts
@@ -85,7 +85,7 @@ describe('DetailDrawer pending interrupts', () => {
       status: 'needs_input',
       expected: 'Waiting for your response'
     }
-  ])('keeps $name outside the resizable transcript', ({ status, permission, question, expected }) => {
+  ])('keeps $name in the transcript scroll flow', ({ status, permission, question, expected }) => {
     vi.stubGlobal('window', { innerHeight: 1000 })
     vi.stubGlobal('localStorage', { getItem: () => null })
 
@@ -112,8 +112,15 @@ describe('DetailDrawer pending interrupts', () => {
 
     const transcript = getElementContents(markup, 'data-transcript-scroll')
     const interrupt = getElementContents(markup, 'data-pending-interrupt')
-    expect(transcript).not.toContain(expected)
+    expect(transcript).toContain(expected)
+    expect(transcript).toContain(interrupt)
     expect(interrupt).toContain(expected)
+    expect(interrupt).not.toContain('max-h-[45%]')
+    expect(interrupt).not.toContain('overflow-y-auto')
+
+    if (question) {
+      expect(markup).toContain('placeholder="Type your answer to the question above..."')
+    }
   })
 
   it('does not claim a stalled response asked a question', () => {

--- a/src/renderer/src/components/DetailDrawer.tsx
+++ b/src/renderer/src/components/DetailDrawer.tsx
@@ -944,6 +944,72 @@ export const DetailDrawer = memo(function DetailDrawer({
                   </div>
                 )}
 
+                {(permission || question || showQuestionFallback) && (
+                  <div
+                    data-pending-interrupt
+                    className="mt-1 border-t border-kumo-line pt-3"
+                  >
+                    {permission && (
+                      <div className="bg-kumo-brand/[0.06] border border-kumo-brand/20 rounded-lg p-3 flex flex-col gap-2">
+                        <div className="text-xs font-semibold text-kumo-brand flex items-center gap-1.5">
+                          &#128274; Permission Request
+                        </div>
+                        <div className="text-xs text-kumo-default">{permission.title}</div>
+                        {permission.pattern && (
+                          <div className="font-mono text-[11px] px-2 py-1 bg-kumo-overlay rounded text-kumo-subtle">
+                            {Array.isArray(permission.pattern) ? permission.pattern.join(', ') : permission.pattern}
+                          </div>
+                        )}
+                        <div className="flex gap-1.5">
+                          {onApprove && (
+                            <button
+                              onClick={onApprove}
+                              className="flex-1 flex items-center justify-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md bg-kumo-success/12 border border-kumo-success/25 text-kumo-success hover:bg-kumo-success/20 transition-colors"
+                            >
+                              <Check size={12} weight="bold" /> Approve Once
+                            </button>
+                          )}
+                          {onApproveAlways && (
+                            <button
+                              onClick={onApproveAlways}
+                              className="flex-1 flex items-center justify-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md bg-kumo-success/12 border border-kumo-success/25 text-kumo-success hover:bg-kumo-success/20 transition-colors"
+                            >
+                              <CheckCircle size={12} weight="fill" /> Approve Always
+                            </button>
+                          )}
+                          {onDeny && (
+                            <button
+                              onClick={onDeny}
+                              className="flex-1 flex items-center justify-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md bg-kumo-danger/10 border border-kumo-danger/20 text-kumo-danger hover:bg-kumo-danger/20 transition-colors"
+                            >
+                              <XCircle size={12} /> Deny
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    )}
+
+                    {!permission && question && question.questions.length > 0 && (
+                      <QuestionCard
+                        question={question}
+                        onReply={onReplyQuestion}
+                        onReject={onRejectQuestion}
+                      />
+                    )}
+
+                    {showQuestionFallback && (
+                      <div className="bg-status-input-bg/30 border border-status-input/20 rounded-lg p-3 flex flex-col gap-2">
+                        <div className="text-xs font-semibold text-status-input flex items-center gap-1.5">
+                          <ChatCircleDots size={14} weight="fill" /> Waiting for your response
+                        </div>
+                        <div className="text-xs text-kumo-default">
+                          This agent has asked a question and is waiting for your reply. Use the input below to respond.
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+
               </div>
             )}
 
@@ -985,72 +1051,6 @@ export const DetailDrawer = memo(function DetailDrawer({
             </div>
           )}
         </div>
-
-        {activeTab === 'transcript' && (permission || question || showQuestionFallback) && (
-          <div
-            data-pending-interrupt
-            className="min-h-0 shrink max-h-[45%] overflow-y-auto border-t border-kumo-line px-4 py-3"
-          >
-            {permission && (
-              <div className="bg-kumo-brand/[0.06] border border-kumo-brand/20 rounded-lg p-3 flex flex-col gap-2">
-                <div className="text-xs font-semibold text-kumo-brand flex items-center gap-1.5">
-                  &#128274; Permission Request
-                </div>
-                <div className="text-xs text-kumo-default">{permission.title}</div>
-                {permission.pattern && (
-                  <div className="font-mono text-[11px] px-2 py-1 bg-kumo-overlay rounded text-kumo-subtle">
-                    {Array.isArray(permission.pattern) ? permission.pattern.join(', ') : permission.pattern}
-                  </div>
-                )}
-                <div className="flex gap-1.5">
-                  {onApprove && (
-                    <button
-                      onClick={onApprove}
-                      className="flex-1 flex items-center justify-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md bg-kumo-success/12 border border-kumo-success/25 text-kumo-success hover:bg-kumo-success/20 transition-colors"
-                    >
-                      <Check size={12} weight="bold" /> Approve Once
-                    </button>
-                  )}
-                  {onApproveAlways && (
-                    <button
-                      onClick={onApproveAlways}
-                      className="flex-1 flex items-center justify-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md bg-kumo-success/12 border border-kumo-success/25 text-kumo-success hover:bg-kumo-success/20 transition-colors"
-                    >
-                      <CheckCircle size={12} weight="fill" /> Approve Always
-                    </button>
-                  )}
-                  {onDeny && (
-                    <button
-                      onClick={onDeny}
-                      className="flex-1 flex items-center justify-center gap-1 px-2.5 py-1.5 text-[11px] font-medium rounded-md bg-kumo-danger/10 border border-kumo-danger/20 text-kumo-danger hover:bg-kumo-danger/20 transition-colors"
-                    >
-                      <XCircle size={12} /> Deny
-                    </button>
-                  )}
-                </div>
-              </div>
-            )}
-
-            {!permission && question && question.questions.length > 0 && (
-              <QuestionCard
-                question={question}
-                onReply={onReplyQuestion}
-                onReject={onRejectQuestion}
-              />
-            )}
-
-            {showQuestionFallback && (
-              <div className="bg-status-input-bg/30 border border-status-input/20 rounded-lg p-3 flex flex-col gap-2">
-                <div className="text-xs font-semibold text-status-input flex items-center gap-1.5">
-                  <ChatCircleDots size={14} weight="fill" /> Waiting for your response
-                </div>
-                <div className="text-xs text-kumo-default">
-                  This agent has asked a question and is waiting for your reply. Use the input below to respond.
-                </div>
-              </div>
-            )}
-          </div>
-        )}
 
         {/* Vertical resize handle */}
         {/* Resize handle + bottom pane (chat input + action rail) only show


### PR DESCRIPTION
The question and permission panel rendered in its own scroll box below the transcript, capped at 45% height. That let it scroll independently, so a user couldn't scroll the transcript up past it or back down past it in one continuous gesture.

This moves the panel into the transcript's own scroll container so it scrolls like any other transcript item. Existing styling, colors, and reply buttons are unchanged, and the chat input still supports replying to a question directly.
